### PR TITLE
Fix for not triggering reverse lookup when lookupTwinId prop changes when initially undefined

### DIFF
--- a/src/Cards/ADTHierarchyCard/Consume/ADTHierarchyCard.tsx
+++ b/src/Cards/ADTHierarchyCard/Consume/ADTHierarchyCard.tsx
@@ -434,10 +434,10 @@ const ADTHierarchyCard: React.FC<ADTHierarchyCardProps> = ({
     }, [hierarchyNodes, lookupTwinAndModelRef.current]);
 
     /** Initiate lookup process as long as twinLookupStatus is idle and either:
-     * (1) when hierarchy nodes (models) are first rendered or
-     * (2) twinLookupStatus resets from 'Finished' to 'Idle' with lookupTwinId changes
+     * (1) when hierarchy nodes (models) are first rendered (when the lookup status is 'Idle') or
+     * (2) twinLookupStatus resets from either 'Finished' or 'Idle' to 'Ready' with lookupTwinId changes
      *
-     * After model expansion (if not already expanded), with the lookup status change from 'Idle' to 'InProgress'
+     * After model expansion (if not already expanded), with the lookup status change from either 'Idle' or 'Ready' to 'InProgress'
      * and the updated hierarchy nodes rendered with twins (if not already exist), locate the looked up twin
      * under that parent model node */
     useEffect(() => {
@@ -445,7 +445,8 @@ const ADTHierarchyCard: React.FC<ADTHierarchyCardProps> = ({
             lookupTwinId &&
             modelState.adapterResult.getData() &&
             !modelState.isLoading &&
-            twinLookupStatus === TwinLookupStatus.Idle &&
+            (twinLookupStatus === TwinLookupStatus.Idle ||
+                twinLookupStatus === TwinLookupStatus.Ready) &&
             !searchTerm
         ) {
             lookupTwinAndExpandModel();
@@ -459,12 +460,12 @@ const ADTHierarchyCard: React.FC<ADTHierarchyCardProps> = ({
         }
     }, [hierarchyNodes, twinLookupStatus]);
 
-    // to trigger lookup process when lookupTwinId prop changes by resetting the twinLookupStatus from 'Finished' back to 'Idle' again
+    // to trigger lookup process when lookupTwinId prop changes by setting the twinLookupStatus from either 'Finished' or 'Idle' to 'Ready'
     useEffect(() => {
         if (lookupTwinId) {
             dispatch({
                 type: SET_TWIN_LOOKUP_STATUS,
-                payload: TwinLookupStatus.Idle
+                payload: TwinLookupStatus.Ready
             });
         }
     }, [lookupTwinId]);

--- a/src/Cards/CompositeCards/ADTHierarchyWithBoard/Consume/ADTHierarchyWithBoard.scss
+++ b/src/Cards/CompositeCards/ADTHierarchyWithBoard/Consume/ADTHierarchyWithBoard.scss
@@ -1,6 +1,7 @@
 .cb-hbcard-container {
     display: flex;
     flex-direction: row;
+    height: 100%;
     min-height: 600px;
     width: 1280px;
 

--- a/src/Components/Hierarchy/Hierarchy.tsx
+++ b/src/Components/Hierarchy/Hierarchy.tsx
@@ -26,7 +26,7 @@ const Hierarchy: React.FC<IHierarchyProps> = ({
         if (shouldScrollToSelectedNode && selectedNodeRef.current) {
             (selectedNodeRef.current as HTMLUListElement).scrollIntoView({
                 behavior: 'smooth',
-                block: 'center',
+                block: 'nearest',
                 inline: 'start'
             });
         }

--- a/src/Models/Constants/Enums.ts
+++ b/src/Models/Constants/Enums.ts
@@ -42,6 +42,7 @@ export enum CardTypes {
 
 export enum TwinLookupStatus {
     Idle,
+    Ready,
     Started,
     ReadyToLocate,
     Finished


### PR DESCRIPTION
- Bug fix: **After a hierarchy component is initially rendered with no lookupTwinId prop (undefined), changes in lookupTwinId prop was not triggering the reverse lookup process** (because the twinLookupStatus enum value was not changing which is in the dependency list to kick off the lookup process with lookupTwinAndExpandModel). To differentiate "Idle" from this condition, added additional twinLookupStatus enum value "Ready" which starts the lookup process when lookupTwinId prop changes from undefined to some valid value.
- Changed the height of the board to 100% to keep the hierarchy sub component fit into the view so that whenever we scrollintoview with reverse lookup the scroll will be restricted within the visible height and changed the vertical alignment (block) of scrollintoview to "nearest" to align the scroll view to the nearest visible area in the scrollable ancestor. These changes fixes the **double scroll issue when reverse lookup**