### PR TITLE
Styling and no twins fix in hierarchy

### DIFF
--- a/src/Cards/ADTHierarchyCard/Consume/ADTHierarchyCard.tsx
+++ b/src/Cards/ADTHierarchyCard/Consume/ADTHierarchyCard.tsx
@@ -214,7 +214,7 @@ const ADTHierarchyCard: React.FC<ADTHierarchyCardProps> = ({
                 }
             });
         }
-    }, [modelState.adapterResult.getData()]);
+    }, [modelState.adapterResult.result]);
 
     useEffect(() => {
         if (focusedModelIdRef.current && twinState.adapterResult.result) {
@@ -302,7 +302,7 @@ const ADTHierarchyCard: React.FC<ADTHierarchyCardProps> = ({
                 }
             }
         }
-    }, [twinState.adapterResult.getData()]);
+    }, [twinState.adapterResult.result]);
 
     useEffect(() => {
         if (!searchState.adapterResult.hasNoData()) {

--- a/src/Components/Hierarchy/Hierarchy.scss
+++ b/src/Components/Hierarchy/Hierarchy.scss
@@ -45,7 +45,10 @@
     }
 
     .cb-hierarchy-node-name {
+        overflow: hidden;
         padding-right: 8px;
+        text-overflow: ellipsis;
+        white-space: nowrap;
     }
 
     .cb-hierarchy-parent-node {
@@ -86,8 +89,9 @@
     }
 
     .cb-hierarchy-no-results {
+        display: block;
         font-size: 12px;
         font-style: italic;
-        padding: 20px;
+        padding: 0 20px;
     }
 }


### PR DESCRIPTION
- Hierarchy node names style fixes for overflow/nowrap
- When there are no twins under a model spinner stayed there (fixed by reverting a change from a previous PR)
![image](https://user-images.githubusercontent.com/45217314/125121733-30ef0e00-e0a9-11eb-9c57-a656123be006.png)
