### PR TITLE
Hotfix for property inspector v2 bug

### DIFF
--- a/src/Components/PropertyInspector/PropertyInspectoryModel.ts
+++ b/src/Components/PropertyInspector/PropertyInspectoryModel.ts
@@ -16,6 +16,7 @@ import {
     getModelContentUnit,
     getModelContentType
 } from '../../Models/Services/Utils';
+import i18n from 'i18next';
 
 /** Utility class for standalone property inspector.  This class is responsible for:
  *  - Merging set and modelled properties and constructing property tree nodes;
@@ -706,11 +707,11 @@ abstract class PropertyInspectorModel {
         const getStringOrNull = (valToTest) =>
             typeof valToTest === 'string' ? valToTest : null;
 
-        const displayName: any = node?.displayName;
-        return displayName;
+        const currentLanguage = i18n?.language;
+
         return (
-            getStringOrNull(displayName?.en) ||
-            getStringOrNull(displayName?.displayName) ||
+            getStringOrNull(node?.displayName) ||
+            getStringOrNull(node?.displayName?.[currentLanguage]) ||
             node.name
         );
     };

--- a/src/Components/PropertyInspector/StandalonePropertyInspector.tsx
+++ b/src/Components/PropertyInspector/StandalonePropertyInspector.tsx
@@ -16,7 +16,6 @@ import { CommandBar } from '@fluentui/react/lib/components/CommandBar/CommandBar
 import { useTranslation } from 'react-i18next';
 import I18nProviderWrapper from '../../Models/Classes/I18NProviderWrapper';
 import { ThemeProvider } from '../../Theming/ThemeProvider';
-import i18n from '../../i18n';
 import StandalonePropertyInspectorReducer, {
     defaultStandalonePropertyInspectorState,
     spiActionType
@@ -31,7 +30,7 @@ import { MessageBarType } from '@fluentui/react/lib/components/MessageBar/Messag
 const StandalonePropertyInspector: React.FC<StandalonePropertyInspectorProps> = (
     props
 ) => {
-    const { t } = useTranslation();
+    const { t, i18n } = useTranslation();
 
     const originalTree = useMemo(() => {
         return isTwin(props.inputData)
@@ -46,7 +45,7 @@ const StandalonePropertyInspector: React.FC<StandalonePropertyInspectorProps> = 
                   props.inputData.relationship,
                   props.inputData.relationshipDefinition
               );
-    }, [props.inputData]);
+    }, [props.inputData, i18n.language]);
 
     const [state, dispatch] = useReducer(StandalonePropertyInspectorReducer, {
         ...defaultStandalonePropertyInspectorState,
@@ -62,7 +61,7 @@ const StandalonePropertyInspector: React.FC<StandalonePropertyInspectorProps> = 
             type: spiActionType.SET_PROPERTY_TREE_NODES,
             nodes: originalTree
         });
-    }, [props.inputData]);
+    }, [props.inputData, i18n.language]);
 
     const undoAllChanges = () => {
         dispatch({


### PR DESCRIPTION
 Hotfix for fatal bug when parsing displayName objects rather than strings, ex: displayName: {en: 'test'}