### PR TITLE
Authentication to read 3d files in SceneView component

### DIFF
--- a/src/Components/3DV/SceneView.stories.local.tsx
+++ b/src/Components/3DV/SceneView.stories.local.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import useAuthParams from '../../../.storybook/useAuthParams';
+import MsalAuthService from '../../Models/Services/MsalAuthService';
+import { SceneView } from './SceneView';
+
+export default {
+    title: 'Components/SceneView'
+};
+
+export const BasicObjectWithAuth = () => {
+    const authenticationParameters = useAuthParams();
+    const authService = authenticationParameters
+        ? new MsalAuthService(authenticationParameters.storage.aadParameters)
+        : null;
+    if (authService) {
+        authService.login();
+    }
+
+    return !authenticationParameters ? (
+        <div></div>
+    ) : (
+        <div
+            style={{
+                height: '100%',
+                position: 'relative'
+            }}
+        >
+            <SceneView
+                modelUrl="https://cardboardresources.blob.core.windows.net/3dv-workspace-1/BasicObjects.gltf"
+                getToken={() => authService.getToken('storage')}
+            />
+        </div>
+    );
+};

--- a/src/Models/Classes/SceneView.types.ts
+++ b/src/Models/Classes/SceneView.types.ts
@@ -57,4 +57,5 @@ export interface ISceneViewProp {
     showMeshesOnHover?: boolean;
     meshSelectionColor?: string;
     meshHoverColor?: string;
+    getToken?: () => Promise<string>;
 }


### PR DESCRIPTION
### Summary of changes 🔍 
- Added **`getToken`** prop to **SceneView** component's load method to get 3d asset files in private blob
- Added **local SceneView story** with MSAL **authentication** to pass getToken to SceneView component as an example
- Added necessary **headers** to the Azure Storage blob service account CORS settings in Azure Portal to avoid CORS errors

### Testing 🧪
- Update your secret file with the values I sent on Cardboard dev chat to access Azure storage with AAD
- Test it with SceneView.stories.local.tsx

### Checklist ✔️
- [ ] Linked associated issue (if present)
- [ ] Added to Cardboard kanban project
- [ ] Added relevant labels
- [x] Requested reviews
- [x] Verify all code checks are passing