### PR TITLE
Auth header for public files and not loading globe fix

### DIFF
--- a/src/Components/3DV/SceneView.tsx
+++ b/src/Components/3DV/SceneView.tsx
@@ -129,6 +129,10 @@ export const SceneView: React.FC<ISceneViewProp> = ({
                 Tools.CustomRequestHeaders.Authorization = 'Bearer ' + token;
                 Tools.CustomRequestHeaders['x-ms-version'] = '2017-11-09';
                 Tools.UseCustomRequestHeaders = true;
+            } else {
+                delete Tools.CustomRequestHeaders.Authorization;
+                delete Tools.CustomRequestHeaders['x-ms-version'];
+                Tools.UseCustomRequestHeaders = false;
             }
 
             const assets = await loadPromise(


### PR DESCRIPTION
### Summary of changes 🔍 
> There was an issue while switching between stories/SceneView components. It was because I was sending auth headers unnecessarily which was hitting CORS error for public files. So unncessary headers removed and set global useCustomHeaders flag back to false if getToken not present (i.e. for publicly accessible files)

### Testing 🧪
 > You can test any component which consumes SceneView component. 3dpage or other ADT3DBuilder/Viewer/Globe stories and try switch between Globe one and others

### Checklist ✔️
- [ ] Linked associated issue (if present)
- [ ] Added to Cardboard kanban project
- [x] Added relevant labels
- [x] Requested reviews
- [x] Verify all code checks are passing