### PR TITLE
Fixed build typings

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,5 @@
 {
     "compilerOptions": {
-        "declaration": true,
-        "declarationDir": "dist",
         "experimentalDecorators": true,
         "outDir": "dist",
         "module": "esnext",


### PR DESCRIPTION
### Summary of changes 🔍 
- PR #178 broke build output for direct component imports & typings
- This PR fixes the build by removing the tsconfig options

### Testing 🧪
`npm run build` - view `dist/` build output

### Checklist ✔️
- [x] Linked associated issue (if present)
- [x] Added to Cardboard kanban project
- [x] Added relevant labels
- [ ] Requested reviews
- [x] Verify all code checks are passing