### PR TITLE
Proxy server retry

### DIFF
--- a/.storybook/middleware.js
+++ b/.storybook/middleware.js
@@ -139,7 +139,7 @@ module.exports = function (app) {
                         'Proxy server retry request attempt number: ' +
                             req.currentRetryAttempt
                     );
-                    proxy.call(proxy, req, res); // resend the original request to proxy middleware again
+                    blobProxy.call(blobProxy, req, res); // resend the original request to proxy middleware again
                 } else {
                     console.log(
                         'All proxy server retry attempts failed, returning error...'


### PR DESCRIPTION
### Summary of changes 🔍 
Retry request again if proxy server fails with specific code (which was causing 504 error):
`[HPM] Error occurred while trying to proxy request /proxy/blob/3dv-workspace-2/vconfigDecFinal.json from explorer.digitaltwins.azure.net to / (ECONNRESET) (https://nodejs.org/api/errors.html#errors_common_system_errors)`
![image](https://user-images.githubusercontent.com/45217314/150843363-e4a41c08-3707-431a-9b11-0b20f8e82c46.png)


### Testing 🧪
You can test it on ADT3DScenePage component by switching back and forth between Home/scenes/viewer/builder and see if you hit any 504 error in Network tab and card error (due to not loading config data)

### Checklist ✔️
- [ ] Linked associated issue (if present)
- [ ] Added to Cardboard kanban project
- [x] Added relevant labels
- [x] Requested reviews
- [x] Verify all code checks are passing