### PR TITLE
feat: Add colored meshes/zoom prop to ADTViewer

### DIFF
--- a/src/Components/3DV/SceneView.tsx
+++ b/src/Components/3DV/SceneView.tsx
@@ -100,6 +100,8 @@ const SceneView: React.FC<ISceneViewProp> = ({
     onCameraMove,
     showMeshesOnHover,
     renderMode,
+    zoomToMeshIds,
+    hideUnzoomedMeshes,
     onSceneLoaded,
     getToken,
     coloredMeshItems,
@@ -131,6 +133,9 @@ const SceneView: React.FC<ISceneViewProp> = ({
     const originalMaterials = useRef<any>();
     const meshesAreOriginal = useRef(true);
     const [currentRenderMode, setCurrentRenderMode] = useState(RenderModes[0]);
+    const meshMap = useRef<any>(null);
+    const prevZoomToIds = useRef('');
+    const prevHideUnzoomedRef = useRef<boolean>(undefined);
 
     const defaultMeshHover = (
         marker: Marker,
@@ -203,7 +208,6 @@ const SceneView: React.FC<ISceneViewProp> = ({
 
             if (success) {
                 assets.addAllToScene();
-                createCamera();
                 advancedTextureRef.current = GUI.AdvancedDynamicTexture.CreateFullscreenUI(
                     'UI'
                 );
@@ -213,65 +217,6 @@ const SceneView: React.FC<ISceneViewProp> = ({
                     onSceneLoaded(sc);
                 }
             }
-        }
-
-        function createCamera() {
-            for (const mesh of sceneRef.current.meshes) {
-                mesh.computeWorldMatrix(true);
-            }
-
-            if (sceneRef.current.meshes) {
-                const someMeshFromTheArrayOfMeshes = sceneRef.current.meshes[0];
-                someMeshFromTheArrayOfMeshes.setBoundingInfo(
-                    totalBoundingInfo(sceneRef.current.meshes)
-                );
-                someMeshFromTheArrayOfMeshes.showBoundingBox = false;
-
-                const es = someMeshFromTheArrayOfMeshes.getBoundingInfo()
-                    .boundingBox.extendSize;
-                const es_scaled = es.scale(3);
-                const width = es_scaled.x;
-                const height = es_scaled.y;
-                const depth = es_scaled.z;
-
-                const center = someMeshFromTheArrayOfMeshes.getBoundingInfo()
-                    .boundingBox.centerWorld;
-
-                const canvas = document.getElementById(
-                    canvasId
-                ) as HTMLCanvasElement;
-
-                const camera = new BABYLON.ArcRotateCamera(
-                    'camera',
-                    0,
-                    Math.PI / 2.5,
-                    Math.max(width, height, depth),
-                    center,
-                    sceneRef.current
-                );
-
-                camera.attachControl(canvas, false);
-                cameraRef.current = camera;
-            }
-        }
-
-        function totalBoundingInfo(meshes: BABYLON.AbstractMesh[]) {
-            let boundingInfo = meshes[0].getBoundingInfo();
-            let min = boundingInfo.boundingBox.minimumWorld;
-            let max = boundingInfo.boundingBox.maximumWorld;
-
-            for (const mesh of meshes) {
-                boundingInfo = mesh.getBoundingInfo();
-                min = BABYLON.Vector3.Minimize(
-                    min,
-                    boundingInfo.boundingBox.minimumWorld
-                );
-                max = BABYLON.Vector3.Maximize(
-                    max,
-                    boundingInfo.boundingBox.maximumWorld
-                );
-            }
-            return new BABYLON.BoundingInfo(min, max);
         }
 
         function onProgress(e: BABYLON.ISceneLoaderProgressEvent) {
@@ -331,6 +276,114 @@ const SceneView: React.FC<ISceneViewProp> = ({
 
         return sceneRef.current;
     }, [canvasId, modelUrl]);
+
+    // Handle mesh zooming
+    useEffect(() => {
+        function createOrZoomCamera() {
+            const zoomTo = (zoomToMeshIds || []).join(',');
+            if (
+                !isLoading &&
+                sceneRef.current?.meshes?.length &&
+                (!cameraRef.current ||
+                    prevZoomToIds.current !== zoomTo ||
+                    prevHideUnzoomedRef.current !== hideUnzoomedMeshes)
+            ) {
+                prevHideUnzoomedRef.current = hideUnzoomedMeshes;
+                meshMap.current = {};
+                for (const mesh of sceneRef.current.meshes) {
+                    if (mesh.id) {
+                        meshMap.current[mesh.id] = mesh;
+                    }
+
+                    mesh.computeWorldMatrix(true);
+                    mesh.visibility =
+                        hideUnzoomedMeshes &&
+                        zoomToMeshIds?.length &&
+                        !zoomToMeshIds.includes(mesh.id)
+                            ? 0
+                            : 1;
+                }
+
+                // Only zoom if the Ids actually changed, not just a re-render
+                if (!cameraRef.current || prevZoomToIds.current !== zoomTo) {
+                    prevZoomToIds.current = zoomTo;
+                    const someMeshFromTheArrayOfMeshes =
+                        sceneRef.current.meshes[0];
+                    let meshes = sceneRef.current.meshes;
+                    if (zoomToMeshIds?.length) {
+                        const meshList: BABYLON.AbstractMesh[] = [];
+                        for (const id of zoomToMeshIds) {
+                            const m = meshMap.current[id];
+                            if (m) {
+                                meshList.push(m);
+                            }
+                        }
+
+                        meshes = meshList;
+                    }
+
+                    someMeshFromTheArrayOfMeshes.setBoundingInfo(
+                        totalBoundingInfo(meshes)
+                    );
+
+                    someMeshFromTheArrayOfMeshes.showBoundingBox = false;
+
+                    const es = someMeshFromTheArrayOfMeshes.getBoundingInfo()
+                        .boundingBox.extendSize;
+                    const es_scaled = es.scale(zoomToMeshIds?.length ? 5 : 3);
+                    const width = es_scaled.x;
+                    const height = es_scaled.y;
+                    const depth = es_scaled.z;
+                    const radius = Math.max(width, height, depth);
+
+                    const center = someMeshFromTheArrayOfMeshes.getBoundingInfo()
+                        .boundingBox.centerWorld;
+
+                    const canvas = document.getElementById(
+                        canvasId
+                    ) as HTMLCanvasElement;
+
+                    if (!cameraRef.current) {
+                        const camera = new BABYLON.ArcRotateCamera(
+                            'camera',
+                            0,
+                            Math.PI / 2.5,
+                            radius,
+                            center,
+                            sceneRef.current
+                        );
+
+                        camera.attachControl(canvas, false);
+                        cameraRef.current = camera;
+                    }
+
+                    cameraRef.current.zoomOn(meshes, true);
+                    cameraRef.current.radius = radius;
+                }
+            }
+        }
+
+        function totalBoundingInfo(meshes: BABYLON.AbstractMesh[]) {
+            let boundingInfo = meshes[0].getBoundingInfo();
+            let min = boundingInfo.boundingBox.minimumWorld;
+            let max = boundingInfo.boundingBox.maximumWorld;
+
+            for (const mesh of meshes) {
+                boundingInfo = mesh.getBoundingInfo();
+                min = BABYLON.Vector3.Minimize(
+                    min,
+                    boundingInfo.boundingBox.minimumWorld
+                );
+                max = BABYLON.Vector3.Maximize(
+                    max,
+                    boundingInfo.boundingBox.maximumWorld
+                );
+            }
+            return new BABYLON.BoundingInfo(min, max);
+        }
+
+        createOrZoomCamera();
+    }, [isLoading, zoomToMeshIds, hideUnzoomedMeshes]);
 
     if (!originalMaterials.current && sceneRef.current?.meshes?.length) {
         originalMaterials.current = {};

--- a/src/Components/ADT3DViewer/ADT3DViewer.tsx
+++ b/src/Components/ADT3DViewer/ADT3DViewer.tsx
@@ -37,7 +37,9 @@ const ADT3DViewer: React.FC<IADT3DViewerProps> = ({
     showMeshesOnHover,
     enableMeshSelection,
     showHoverOnSelected,
-    coloredMeshItems: coloredMeshItemsProp
+    coloredMeshItems: coloredMeshItemsProp,
+    zoomToMeshIds,
+    hideUnzoomedMeshes
 }) => {
     const { t } = useTranslation();
     const [modelUrl, setModelUrl] = useState('');
@@ -295,6 +297,8 @@ const ADT3DViewer: React.FC<IADT3DViewerProps> = ({
                         renderMode: renderMode,
                         showHoverOnSelected: showHoverOnSelected,
                         showMeshesOnHover: showMeshesOnHover,
+                        zoomToMeshIds: zoomToMeshIds,
+                        hideUnzoomedMeshes: hideUnzoomedMeshes,
                         onMeshClick: (marker, mesh, scene) =>
                             meshClick(marker, mesh, scene),
                         onMeshHover: (marker, mesh) => meshHover(marker, mesh),

--- a/src/Models/Classes/SceneView.types.ts
+++ b/src/Models/Classes/SceneView.types.ts
@@ -68,6 +68,8 @@ export interface ISceneViewProp {
     showMeshesOnHover?: boolean;
     getToken?: () => Promise<string>;
     coloredMeshItems?: ColoredMeshItem[];
+    zoomToMeshIds?: string[];
+    hideUnzoomedMeshes?: boolean;
     showHoverOnSelected?: boolean;
     renderMode?: IADT3DViewerRenderMode;
 }

--- a/src/Models/Constants/Interfaces.ts
+++ b/src/Models/Constants/Interfaces.ts
@@ -657,6 +657,8 @@ export interface IADT3DViewerProps {
     showMeshesOnHover?: boolean;
     showHoverOnSelected?: boolean;
     coloredMeshItems?: ColoredMeshItem[];
+    zoomToMeshIds?: string[];
+    hideUnzoomedMeshes?: boolean;
 }
 
 export interface IADT3DViewerRenderMode {


### PR DESCRIPTION
### Summary of changes 🔍 
> [ Summarize what your PR is about.  Include images / screenshots if relevant. ]


### Testing 🧪
 > Add colored meshes list as a prop to ADTViewer so that apps can color their own meshes
> Add zoomToMeshIds as a prop to ADTViewer and SceneView to allow caller to zoom into a mesh

### Checklist ✔️
- [ ] Linked associated issue (if present)
- [ ] Added relevant labels
- [ ] Requested developer reviews
- [ ] Request UI review from design / PM
- [ ] Verify all code checks are passing