### PR TITLE
Logic change for pulling ADT instances in environment picker

### DIFF
--- a/src/Components/EnvironmentPicker/EnvironmentPicker.tsx
+++ b/src/Components/EnvironmentPicker/EnvironmentPicker.tsx
@@ -57,6 +57,7 @@ const EnvironmentPicker = (props: EnvironmentPickerProps) => {
     const [containerUrlToEdit, setContainerUrlToEdit] = useState('');
     const [isDialogHidden, { toggle: toggleIsDialogHidden }] = useBoolean(true);
     const dialogResettingValuesTimeoutRef = useRef(null);
+    const hasPulledEnvironmentsFromSubscription = useRef(false);
 
     const dialogContentProps = {
         type: DialogType.normal,
@@ -97,7 +98,7 @@ const EnvironmentPicker = (props: EnvironmentPickerProps) => {
     const environmentsState = useAdapter({
         adapterMethod: () => props.adapter.getADTInstances(),
         refetchDependencies: [],
-        isAdapterCalledOnMount: props.shouldPullFromSubscription
+        isAdapterCalledOnMount: false
     });
 
     // set initial values based on props and local storage
@@ -218,6 +219,7 @@ const EnvironmentPicker = (props: EnvironmentPickerProps) => {
                     )
                 )
             );
+            hasPulledEnvironmentsFromSubscription.current = true;
         }
     }, [environmentsState.adapterResult.result]);
 
@@ -356,6 +358,17 @@ const EnvironmentPicker = (props: EnvironmentPickerProps) => {
             </div>
         );
     };
+
+    const handleOnEditClick = useCallback(() => {
+        if (
+            props.shouldPullFromSubscription &&
+            !hasPulledEnvironmentsFromSubscription.current &&
+            !environmentsState.isLoading
+        ) {
+            environmentsState.callAdapter();
+        }
+        toggleIsDialogHidden();
+    }, []);
 
     const handleOnEnvironmentUrlChange = useCallback(
         (option, value) => {
@@ -533,7 +546,7 @@ const EnvironmentPicker = (props: EnvironmentPickerProps) => {
                     iconProps={{ iconName: 'Edit' }}
                     title={t('edit')}
                     ariaLabel={t('edit')}
-                    onClick={toggleIsDialogHidden}
+                    onClick={handleOnEditClick}
                     className={'cb-environment-picker-edit-button'}
                 />
             </div>


### PR DESCRIPTION
### Summary of changes 🔍 
Now instead of onmount, we are pulling environments from subscription (if enabled) on edit icon click and doing it only once. So, if user makes any changes in environments(adding/removing) in Azure portal, need to hard refresh to get the changes in this component.

### Testing 🧪
`EnvironmentPicker `standalone component or `ADT3DScenePage`

### Checklist ✔️
- [ ] Linked associated issue (if present)
- [x] Added relevant labels
- [x] Requested developer reviews
- [ ] Request UI review from design / PM
- [x] Verify all code checks are passing