### PR TITLE
Only call hover function when pointer is not active

### DIFF
--- a/src/Components/3DV/SceneView.tsx
+++ b/src/Components/3DV/SceneView.tsx
@@ -701,6 +701,7 @@ const SceneView: React.FC<ISceneViewProp> = ({
         debugLog('hover effect' + (scene ? ' with scene' : ' no scene'));
         let pt: BABYLON.Observer<BABYLON.PointerInfo>;
         if (scene) {
+            // setting flag based on mouse down (i.e camera is being moved) to stop hover events firing at the same time
             pt = scene.onPointerObservable.add((eventData) => {
                 if (eventData.type === BABYLON.PointerEventTypes.POINTERDOWN) {
                     pointerActive.current = true;


### PR DESCRIPTION
### Summary of changes 🔍 
> Added flag that tracks when pointer is active and restricts when pointer hover is called


### Testing 🧪
 > [ Add any special instructions needed to test or view your changes such as environment URLs or other config details. ]

### Checklist ✔️
- [ ] Linked associated issue (if present)
- [ ] Added relevant labels
- [ ] Requested developer reviews
- [ ] Request UI review from design / PM
- [ ] Verify all code checks are passing