### PR TITLE
fix: Regressions when re-loading SceneView

### DIFF
--- a/src/Components/3DV/SceneView.styles.ts
+++ b/src/Components/3DV/SceneView.styles.ts
@@ -39,7 +39,7 @@ export const getSceneViewStyles = memoizeFunction((theme: Theme) =>
             classNames.canvasVisible,
             {
                 opacity: 1,
-                transition: '2s'
+                transition: '6s'
             } as IStyle
         ],
         errorMessage: [


### PR DESCRIPTION
### Summary of changes 🔍 
> Fix various regressions when re-loading SceneView caused by deferred camera creation (for zooming) and caching materials for performance


### Testing 🧪
 > [ Add any special instructions needed to test or view your changes such as environment URLs or other config details. ]

### Checklist ✔️
- [ ] Linked associated issue (if present)
- [ ] Added relevant labels
- [ ] Requested developer reviews
- [ ] Request UI review from design / PM
- [ ] Verify all code checks are passing