### PR TITLE
Fix rollup SVGs 🖼️

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -9,6 +9,7 @@ import eslint from '@rollup/plugin-eslint';
 import dts from 'rollup-plugin-dts';
 import url from '@rollup/plugin-url';
 import svgr from '@svgr/rollup';
+import image from '@rollup/plugin-image';
 const parseExportListFromIndex = require('./tools/index-parser');
 
 // Build map of library entry points -- this allows for splitting library into chunks & tree shaking
@@ -58,7 +59,10 @@ const commonPlugins = [
             })
         ]
     }),
-    url(),
+    url({
+        exclude: ['**/*.svg']
+    }),
+    image(),
     svgr()
 ];
 

--- a/src/Components/TestStories/SvgTest.stories.tsx
+++ b/src/Components/TestStories/SvgTest.stories.tsx
@@ -4,9 +4,13 @@ import { ReactComponent as AccessRestrictedComponent } from '../../Resources/Sta
 import Error from '../../Resources/Static/error.svg';
 import { Image } from '@fluentui/react';
 import { useTranslation } from 'react-i18next';
+import { getDefaultStoryDecorator } from '../../Models/Services/StoryUtilities';
+
+const wrapperStyle = { width: '100%' };
 
 export default {
-    title: 'Test stories/SvgTest'
+    title: 'Test stories/SvgTest',
+    decorators: [getDefaultStoryDecorator(wrapperStyle)]
 };
 
 const SvgTest = () => {


### PR DESCRIPTION
### Summary of changes 🔍 
Included @rollup/plugin-image  to fix broken SVGs in public component distro


### Testing 🧪
- `npm run build` (iot-cardboard-js)
- Copy path to artifact created in `./build_artifacts`
- `npm install <path_copied> into `Azure-IoT-DigitalTwins-Explorer/app`
- `npm run start` the `Azure-IoT-DigitalTwins-Explorer/app` project and verify SVGs are working as expected

(Filed issue #282 - which I noticed while testing this.  I believe this is unrelated to this fix as I was noticing the same behavior on the current `main` branch).

### Pictures showing SVGs working in `Azure-IoT-DigitalTwins-Explorer/app`
![image](https://user-images.githubusercontent.com/18181049/160338583-e5931239-0377-4a98-b01b-4dc9259706f3.png)
![image](https://user-images.githubusercontent.com/18181049/160338615-fc6d6081-711b-4873-a706-061d61c52ac0.png)
![image](https://user-images.githubusercontent.com/18181049/160338749-750febea-2493-4908-a364-06196cdee698.png)
![image](https://user-images.githubusercontent.com/18181049/160338788-7c74f1be-7f9b-4f3e-8774-60186035a12e.png)
(spacing here filed in issue #282)

### Checklist ✔️
- [x] Linked associated issue (if present)
- [x] Added relevant labels
- [ ] Requested developer reviews
- [ ] Request UI review from design / PM
- [ ] Verify all code checks are passing