### PR TITLE
fix: ADT3DViewer fixes

### DIFF
--- a/src/Components/ADT3DSceneBuilder/Internal/Behaviors/Widgets/WidgetForm.tsx
+++ b/src/Components/ADT3DSceneBuilder/Internal/Behaviors/Widgets/WidgetForm.tsx
@@ -24,7 +24,7 @@ import GaugeWidgetBuilder from './WidgetBuilders/GaugeWidgetBuilder';
 import { IValueRangeBuilderHandle } from '../../../../ValueRangeBuilder/ValueRangeBuilder.types';
 import LinkWidgetBuilder from './WidgetBuilders/LinkWidgetBuilder';
 import { linkedTwinName } from '../../../../../Models/Constants';
-import { createGUID, deepCopy } from '../../../../../Models/Services/Utils';
+import { deepCopy } from '../../../../../Models/Services/Utils';
 
 // Note, this widget form does not currently support panels
 const WidgetForm: React.FC = () => {

--- a/src/Components/ADT3DViewer/ADT3DViewer.stories.local.tsx
+++ b/src/Components/ADT3DViewer/ADT3DViewer.stories.local.tsx
@@ -7,16 +7,19 @@ import MockAdapter from '../../Adapters/MockAdapter';
 import mockVConfig from '../../Adapters/__mockData__/3DScenesConfiguration.json';
 import { ADT3DAddInEventData, IADT3DAddInProps } from '../../Models/Constants';
 import { I3DScenesConfig } from '../../Models/Types/Generated/3DScenesConfiguration-v1.0.0';
+import { CustomMeshItem } from '../../Models/Classes/SceneView.types';
+import { Checkbox } from '@fluentui/react';
 
 export default {
     title: '3DV/ADT3DViewer',
     component: ADT3DViewer
 };
 
+const mockScene = 'f7053e7537048e03be4d1e6f8f93aa8a';
+
 export const Engine = (_args, { globals: { theme, locale } }) => {
     const authenticationParameters = useAuthParams();
     const scenesConfig = mockVConfig as I3DScenesConfig;
-
     return !authenticationParameters ? (
         <div></div>
     ) : (
@@ -35,7 +38,7 @@ export const Engine = (_args, { globals: { theme, locale } }) => {
                 }
                 scenesConfig={scenesConfig}
                 pollingInterval={10000}
-                sceneId="58e02362287440d9a5bf3f8d6d6bfcf9"
+                sceneId={mockScene}
                 connectionLineColor="#000"
             />
         </div>
@@ -65,21 +68,120 @@ export const EngineWithHover = (_args, { globals: { theme, locale } }) => {
                 scenesConfig={scenesConfig}
                 showMeshesOnHover={true}
                 pollingInterval={10000}
-                sceneId="58e02362287440d9a5bf3f8d6d6bfcf9"
+                sceneId={mockScene}
                 connectionLineColor="#000"
             />
         </div>
     );
 };
 
-export const EngineWithShaders = (_args, { globals: { theme, locale } }) => {
+export const ZoomAndColor = (_args, { globals: { theme, locale } }) => {
     const authenticationParameters = useAuthParams();
+    const [hoveredIndex, setHoveredIndex] = useState(-1);
+    const [clickedIndex, setClickedIndex] = useState(-1);
+    const [coloredMeshes, setColoredMeshes] = useState<CustomMeshItem[]>();
+    const [zoomedMeshes, setZoomedMeshes] = useState<string[]>();
+    const [hideElementsPanel, setHideElementsPanel] = useState(true);
+
     const scenesConfig = mockVConfig as I3DScenesConfig;
+    const scene = scenesConfig.configuration.scenes.find(
+        (s) => s.id === mockScene
+    );
+    if (!scene) {
+        throw new Error('Bad scene definition ' + mockScene);
+    }
+
+    const makeMeshItems = (meshIds: string[]) => {
+        const meshItems: CustomMeshItem[] = [];
+        for (const id of meshIds) {
+            meshItems.push({ meshId: id, color: '#ffff00' });
+        }
+
+        return meshItems;
+    };
+
+    const onHover = (e, index: number) => {
+        e.stopPropagation();
+        if (index !== hoveredIndex) {
+            setHoveredIndex(index);
+            const element = scene.elements[index];
+            if (element?.objectIDs) {
+                setColoredMeshes(makeMeshItems(element.objectIDs as any));
+            } else {
+                setColoredMeshes([]);
+            }
+        }
+    };
+
+    const onClick = (e, index: number) => {
+        e.stopPropagation();
+        if (clickedIndex !== index) {
+            setClickedIndex(index);
+            const element = scene.elements[index];
+            if (element?.objectIDs) {
+                setZoomedMeshes(element.objectIDs as any);
+            } else {
+                setZoomedMeshes([]);
+                setColoredMeshes(null);
+            }
+        } else {
+            setZoomedMeshes([]);
+            setColoredMeshes(null);
+        }
+    };
 
     return !authenticationParameters ? (
         <div></div>
     ) : (
-        <div style={{ width: '100%', height: '100%', background: '#2A3A44' }}>
+        <div style={{ width: '100%', height: '600px', display: 'flex' }}>
+            <div
+                style={{
+                    width: '250px',
+                    height: '100%',
+                    background: 'white',
+                    fontFamily: 'sans-serif',
+                    padding: '10px',
+                    cursor: 'default',
+                    display: 'flex',
+                    flexDirection: 'column'
+                }}
+            >
+                <div style={{ margin: '20px' }}>
+                    <Checkbox
+                        label="Show elements panel"
+                        onChange={() =>
+                            setHideElementsPanel(!hideElementsPanel)
+                        }
+                    />
+                </div>
+                <div
+                    style={{
+                        width: '100%',
+                        height: '100%',
+                        cursor: 'default',
+                        display: 'flex',
+                        flexDirection: 'column'
+                    }}
+                    onMouseMove={(e) => onHover(e, -1)}
+                    onClick={(e) => onClick(e, -1)}
+                >
+                    {scene.elements.map((element, index) => (
+                        <div
+                            key={index}
+                            style={{
+                                padding: '10px',
+                                cursor: 'default',
+                                backgroundColor:
+                                    hoveredIndex === index ? '#ccc' : ''
+                            }}
+                            onMouseMove={(e) => onHover(e, index)}
+                            onClick={(e) => onClick(e, index)}
+                        >
+                            {element.displayName}
+                        </div>
+                    ))}
+                </div>
+            </div>
             <ADT3DViewer
                 title="3D Viewer"
                 theme={theme}
@@ -94,8 +196,11 @@ export const EngineWithShaders = (_args, { globals: { theme, locale } }) => {
                 }
                 scenesConfig={scenesConfig}
                 pollingInterval={10000}
-                sceneId="58e02362287440d9a5bf3f8d6d6bfcf9"
+                sceneId={mockScene}
                 connectionLineColor="#000"
+                coloredMeshItems={coloredMeshes}
+                zoomToMeshIds={zoomedMeshes}
+                hideElementsPanel={hideElementsPanel}
             />
         </div>
     );
@@ -181,7 +286,7 @@ export const AddIn = (_args, { globals: { theme, locale } }) => {
                 }
                 scenesConfig={scenesConfig}
                 pollingInterval={10000}
-                sceneId="58e02362287440d9a5bf3f8d6d6bfcf9"
+                sceneId={mockScene}
                 connectionLineColor="#000"
                 addInProps={addInProps}
             />
@@ -212,7 +317,7 @@ export const Mock = (_args, { globals: { theme, locale } }) => {
                 adapter={new MockAdapter()}
                 scenesConfig={scenesConfig}
                 pollingInterval={10000}
-                sceneId={'58e02362287440d9a5bf3f8d6d6bfcf9'}
+                sceneId={mockScene}
                 connectionLineColor="#000"
             />
         </div>
@@ -231,7 +336,7 @@ export const MockWithHover = (_args, { globals: { theme, locale } }) => {
                 adapter={new MockAdapter()}
                 scenesConfig={scenesConfig}
                 pollingInterval={10000}
-                sceneId={'58e02362287440d9a5bf3f8d6d6bfcf9'}
+                sceneId={mockScene}
                 showMeshesOnHover={true}
                 connectionLineColor="#000"
             />
@@ -251,7 +356,7 @@ export const MockWithSelection = (_args, { globals: { theme, locale } }) => {
                 adapter={new MockAdapter()}
                 scenesConfig={scenesConfig}
                 pollingInterval={10000}
-                sceneId={'58e02362287440d9a5bf3f8d6d6bfcf9'}
+                sceneId={mockScene}
                 enableMeshSelection={true}
                 showHoverOnSelected={true}
                 showMeshesOnHover={true}

--- a/src/Components/ADT3DViewer/ADT3DViewer.tsx
+++ b/src/Components/ADT3DViewer/ADT3DViewer.tsx
@@ -42,6 +42,7 @@ const ADT3DViewer: React.FC<IADT3DViewerProps & BaseComponentProps> = ({
     coloredMeshItems: coloredMeshItemsProp,
     zoomToMeshIds: zoomToMeshIdsProp,
     unzoomedMeshOpacity,
+    hideElementsPanel,
     hideViewModePickerUI
 }) => {
     const [coloredMeshItems, setColoredMeshItems] = useState<CustomMeshItem[]>(
@@ -74,21 +75,26 @@ const ADT3DViewer: React.FC<IADT3DViewerProps & BaseComponentProps> = ({
     }, []);
 
     useEffect(() => {
-        const newColoredMeshItems = [...coloredMeshItems];
-        sceneVisuals.forEach((sceneVisual) => {
-            sceneVisual.coloredMeshItems.forEach((sceneColoredMeshItem) => {
-                const existingColoredMeshItem = newColoredMeshItems.find(
-                    (nC) => nC.meshId === sceneColoredMeshItem.meshId
-                );
-                if (existingColoredMeshItem) {
-                    existingColoredMeshItem.color = sceneColoredMeshItem.color;
-                } else {
-                    newColoredMeshItems.push(sceneColoredMeshItem);
-                }
+        if (coloredMeshItemsProp) {
+            setColoredMeshItems(coloredMeshItemsProp);
+        } else {
+            const newColoredMeshItems = [...coloredMeshItems];
+            sceneVisuals.forEach((sceneVisual) => {
+                sceneVisual.coloredMeshItems.forEach((sceneColoredMeshItem) => {
+                    const existingColoredMeshItem = newColoredMeshItems.find(
+                        (nC) => nC.meshId === sceneColoredMeshItem.meshId
+                    );
+                    if (existingColoredMeshItem) {
+                        existingColoredMeshItem.color =
+                            sceneColoredMeshItem.color;
+                    } else {
+                        newColoredMeshItems.push(sceneColoredMeshItem);
+                    }
+                });
             });
-        });
-        setColoredMeshItems(newColoredMeshItems);
-    }, [sceneVisuals]);
+            setColoredMeshItems(newColoredMeshItems);
+        }
+    }, [sceneVisuals, coloredMeshItemsProp]);
 
     // panel items includes partial SceneVisual object with filtered properties needed to render elements panel overlay
     const panelItems: Array<ViewerElementsPanelItem> = useMemo(
@@ -199,6 +205,12 @@ const ADT3DViewer: React.FC<IADT3DViewerProps & BaseComponentProps> = ({
         []
     );
 
+    useEffect(() => {
+        if (zoomToMeshIdsProp) {
+            setZoomToMeshIds(zoomToMeshIdsProp);
+        }
+    }, [zoomToMeshIdsProp]);
+
     return (
         <BaseComponent
             isLoading={isLoading && !sceneVisuals}
@@ -206,14 +218,16 @@ const ADT3DViewer: React.FC<IADT3DViewerProps & BaseComponentProps> = ({
             locale={locale}
         >
             <div id={sceneWrapperId} className="cb-adt-3dviewer-wrapper">
-                <ElementsPanelModal
-                    theme={theme}
-                    locale={locale}
-                    panelItems={panelItems}
-                    isLoading={isLoading}
-                    onItemClick={onElementPanelItemClicked}
-                    onItemHover={(item) => item.type}
-                />
+                {!hideElementsPanel && (
+                    <ElementsPanelModal
+                        theme={theme}
+                        locale={locale}
+                        panelItems={panelItems}
+                        isLoading={isLoading}
+                        onItemClick={onElementPanelItemClicked}
+                        onItemHover={(item) => item.type}
+                    />
+                )}
                 <SceneViewWrapper
                     adapter={adapter}
                     config={scenesConfig}

--- a/src/Components/ElementsPanel/Internal/ElementsList.tsx
+++ b/src/Components/ElementsPanel/Internal/ElementsList.tsx
@@ -234,8 +234,9 @@ function getListItems(
                         overflow: 'hidden'
                     }}
                 >
-                    {statuses.map((status) => (
+                    {statuses.map((status, index) => (
                         <div
+                            key={index}
                             className={
                                 getElementsPanelStatusStyles(
                                     getSceneElementStatusColor(

--- a/src/Models/Constants/Interfaces.ts
+++ b/src/Models/Constants/Interfaces.ts
@@ -685,6 +685,7 @@ export interface IADT3DViewerProps {
     zoomToMeshIds?: string[];
     unzoomedMeshOpacity?: number;
     hideViewModePickerUI?: boolean;
+    hideElementsPanel?: boolean;
 }
 
 export interface IADT3DViewerMode {


### PR DESCRIPTION
### Summary of changes 🔍 
> Fix broken ADT3DViewer stories
> Add new viewer story for coloring and zooming
> Fix ADT3DViewer ignoring coloring and zoom props (regression)
> Strategy is now if coloring/zooming props are provided by caller, they supersede anything in the viewer
> Add hideElementPanel prop to ADT3DViewer
> Fix a couple of unrelated warnings

### Testing 🧪
 > Run through the ADT3DViewer stories and check they all work including the new color/zoom

### Checklist ✔️
- [ ] Linked associated issue (if present)
- [ ] Added relevant labels
- [ ] Requested developer reviews
- [ ] Request UI review from design / PM
- [ ] Verify all code checks are passing