### PR TITLE
fix: make the 3D viewer stories use the mock adapter

### DIFF
--- a/src/Components/ADT3DViewer/ADT3DViewer.stories.tsx
+++ b/src/Components/ADT3DViewer/ADT3DViewer.stories.tsx
@@ -1,7 +1,5 @@
 import React, { useState } from 'react';
 import useAuthParams from '../../../.storybook/useAuthParams';
-import ADTAdapter from '../../Adapters/ADTAdapter';
-import MsalAuthService from '../../Models/Services/MsalAuthService';
 import ADT3DViewer from './ADT3DViewer';
 import MockAdapter from '../../Adapters/MockAdapter';
 import mockVConfig from '../../Adapters/__mockData__/3DScenesConfiguration.json';
@@ -28,14 +26,7 @@ export const Engine = (_args, { globals: { theme, locale } }) => {
                 title="3D Viewer"
                 theme={theme}
                 locale={locale}
-                adapter={
-                    new ADTAdapter(
-                        authenticationParameters.adt.hostUrl,
-                        new MsalAuthService(
-                            authenticationParameters.adt.aadParameters
-                        )
-                    )
-                }
+                adapter={new MockAdapter()}
                 scenesConfig={scenesConfig}
                 pollingInterval={10000}
                 sceneId={mockScene}
@@ -57,14 +48,7 @@ export const EngineWithHover = (_args, { globals: { theme, locale } }) => {
                 title="3D Viewer"
                 theme={theme}
                 locale={locale}
-                adapter={
-                    new ADTAdapter(
-                        authenticationParameters.adt.hostUrl,
-                        new MsalAuthService(
-                            authenticationParameters.adt.aadParameters
-                        )
-                    )
-                }
+                adapter={new MockAdapter()}
                 scenesConfig={scenesConfig}
                 showMeshesOnHover={true}
                 pollingInterval={10000}
@@ -186,14 +170,7 @@ export const ZoomAndColor = (_args, { globals: { theme, locale } }) => {
                 title="3D Viewer"
                 theme={theme}
                 locale={locale}
-                adapter={
-                    new ADTAdapter(
-                        authenticationParameters.adt.hostUrl,
-                        new MsalAuthService(
-                            authenticationParameters.adt.aadParameters
-                        )
-                    )
-                }
+                adapter={new MockAdapter()}
                 scenesConfig={scenesConfig}
                 pollingInterval={10000}
                 sceneId={mockScene}
@@ -276,14 +253,7 @@ export const AddIn = (_args, { globals: { theme, locale } }) => {
                 title="3D Viewer"
                 theme={theme}
                 locale={locale}
-                adapter={
-                    new ADTAdapter(
-                        authenticationParameters.adt.hostUrl,
-                        new MsalAuthService(
-                            authenticationParameters.adt.aadParameters
-                        )
-                    )
-                }
+                adapter={new MockAdapter()}
                 scenesConfig={scenesConfig}
                 pollingInterval={10000}
                 sceneId={mockScene}


### PR DESCRIPTION
### Summary of changes 🔍 
3D viewer stories used to use a real adapter, but they dont need to.  Made them all use mock so that we can use them as regression tests


### Testing 🧪
Check out the new stories here...
![image](https://user-images.githubusercontent.com/4854357/160458145-5d63ef90-fe9e-4ec3-894f-75b3cc251ba6.png)


### Checklist ✔️
- [ ] Linked associated issue (if present)
- [ ] Added relevant labels
- [ ] Requested developer reviews
- [ ] Request UI review from design / PM
- [ ] Verify all code checks are passing