### PR TITLE
Move mode picker to builder container

### DIFF
--- a/src/Components/ADT3DSceneBuilder/ADT3DSceneBuilder.tsx
+++ b/src/Components/ADT3DSceneBuilder/ADT3DSceneBuilder.tsx
@@ -654,11 +654,9 @@ const ADT3DSceneBuilder: React.FC<IADT3DSceneBuilderCardProps> = ({
                             objectColorUpdated={objectColorUpdated}
                             adapter={adapter as IADTAdapter}
                             modelUrl={
-                                state.config.configuration?.scenes[
-                                    state.config.configuration?.scenes.findIndex(
-                                        (s) => s.id === sceneId
-                                    )
-                                ]?.assets[0].url
+                                state.config.configuration?.scenes.find(
+                                    (x) => x.id === sceneId
+                                )?.assets[0].url
                             }
                             onMeshClicked={onMeshClicked}
                             onMeshHovered={onMeshHovered}

--- a/src/Pages/ADT3DScenePage/ADT3DScenePage.scss
+++ b/src/Pages/ADT3DScenePage/ADT3DScenePage.scss
@@ -100,8 +100,8 @@
 
 .cb-scene-page-mode-toggle-container {
     position: absolute;
-    right: 20px;
-    top: 20px;
+    right: 8px;
+    top: 0px;
     z-index: 1;
 }
 

--- a/src/Pages/ADT3DScenePage/ADT3DScenePage.tsx
+++ b/src/Pages/ADT3DScenePage/ADT3DScenePage.tsx
@@ -1,7 +1,6 @@
 import React, { createContext, useEffect, useReducer } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
-    ADT3DScenePageModes,
     ADT3DScenePageSteps,
     ComponentErrorType
 } from '../../Models/Constants/Enums';
@@ -18,7 +17,6 @@ import {
 } from './ADT3DScenePage.state';
 import {
     SET_ADT_SCENE_CONFIG,
-    SET_ADT_SCENE_PAGE_MODE,
     SET_CURRENT_STEP,
     SET_ERRORS,
     SET_SELECTED_BLOB_CONTAINER_URL,
@@ -35,7 +33,6 @@ import { ADT3DSceneBuilderContainer } from './Internal/ADT3DSceneBuilderContaine
 import useAdapter from '../../Models/Hooks/useAdapter';
 import ScenePageErrorHandlingWrapper from '../../Components/ScenePageErrorHandlingWrapper/ScenePageErrorHandlingWrapper';
 import BaseComponent from '../../Components/BaseComponent/BaseComponent';
-import FloatingScenePageModeToggle from './Internal/FloatingScenePageModeToggle';
 import EnvironmentPicker from '../../Components/EnvironmentPicker/EnvironmentPicker';
 import ADTAdapter from '../../Adapters/ADTAdapter';
 import {
@@ -125,15 +122,6 @@ const ADT3DScenePage: React.FC<IADT3DScenePageProps> = ({
         }
     };
 
-    const handleScenePageModeChange = (
-        newScenePageMode: ADT3DScenePageModes
-    ) => {
-        dispatch({
-            type: SET_ADT_SCENE_PAGE_MODE,
-            payload: newScenePageMode
-        });
-    };
-
     useEffect(() => {
         if (!scenesConfig.adapterResult.hasNoData()) {
             const config: I3DScenesConfig = scenesConfig.adapterResult.getData();
@@ -212,11 +200,6 @@ const ADT3DScenePage: React.FC<IADT3DScenePageProps> = ({
                     localeStrings={localeStrings}
                     containerClassName={'cb-scene-page-container'}
                 >
-                    <FloatingScenePageModeToggle
-                        scene={state.selectedScene}
-                        handleScenePageModeChange={handleScenePageModeChange}
-                        selectedMode={state.scenePageMode}
-                    />
                     {state.currentStep === ADT3DScenePageSteps.SceneLobby && (
                         <>
                             <div className="cb-scene-page-scene-environment-picker">

--- a/src/Pages/ADT3DScenePage/Internal/ADT3DSceneBuilderContainer.tsx
+++ b/src/Pages/ADT3DScenePage/Internal/ADT3DSceneBuilderContainer.tsx
@@ -1,9 +1,15 @@
-import React from 'react';
+import React, { useReducer } from 'react';
 import BaseComponent from '../../../Components/BaseComponent/BaseComponent';
 import { ADT3DScenePageModes } from '../../../Models/Constants/Enums';
 import ADT3DViewer from '../../../Components/ADT3DViewer/ADT3DViewer';
 import ADT3DSceneBuilder from '../../../Components/ADT3DSceneBuilder/ADT3DSceneBuilder';
 import { IADT3DSceneBuilderProps } from '../ADT3DScenePage.types';
+import FloatingScenePageModeToggle from './FloatingScenePageModeToggle';
+import { SET_ADT_SCENE_PAGE_MODE } from '../../../Models/Constants/ActionTypes';
+import {
+    ADT3DScenePageReducer,
+    defaultADT3DScenePageState
+} from '../ADT3DScenePage.state';
 
 export const ADT3DSceneBuilderContainer: React.FC<IADT3DSceneBuilderProps> = ({
     mode = ADT3DScenePageModes.BuildScene,
@@ -15,6 +21,19 @@ export const ADT3DSceneBuilderContainer: React.FC<IADT3DSceneBuilderProps> = ({
     localeStrings,
     refetchConfig
 }) => {
+    const [state, dispatch] = useReducer(
+        ADT3DScenePageReducer,
+        defaultADT3DScenePageState
+    );
+
+    const handleScenePageModeChange = (
+        newScenePageMode: ADT3DScenePageModes
+    ) => {
+        dispatch({
+            type: SET_ADT_SCENE_PAGE_MODE,
+            payload: newScenePageMode
+        });
+    };
     return (
         <BaseComponent
             theme={theme}
@@ -41,6 +60,11 @@ export const ADT3DSceneBuilderContainer: React.FC<IADT3DSceneBuilderProps> = ({
                     />
                 </div>
             )}
+            <FloatingScenePageModeToggle
+                scene={scene}
+                handleScenePageModeChange={handleScenePageModeChange}
+                selectedMode={state.scenePageMode}
+            />
         </BaseComponent>
     );
 };


### PR DESCRIPTION
### Summary of changes 🔍 
Today this mode picker is living in the scene page which doesn't really make sense, it should live where those two modes are actually used so this moves it to that component.

Visually it should still look the same

![image](https://user-images.githubusercontent.com/57726991/163067627-57ecf71c-3226-44c5-ad82-6a619b34f8b0.png)

### Checklist ✔️
- [ ] Linked associated issue (if present)
- [ ] Added relevant labels
- [ ] Requested developer reviews
- [ ] Request UI review from design / PM
- [ ] Verify all code checks are passing