### PR TITLE
fix: revert last change to exclude node modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -96,7 +96,6 @@
                 "postcss-loader": "^4.2.0",
                 "postcss-url": "^10.1.3",
                 "prettier": "2.2.1",
-                "process": "^0.11.10",
                 "react": "^17.0.1",
                 "react-babylonjs": "^3.0.15",
                 "react-dom": "^17.0.1",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,6 @@
         "postcss-loader": "^4.2.0",
         "postcss-url": "^10.1.3",
         "prettier": "2.2.1",
-        "process": "^0.11.10",
         "react": "^17.0.1",
         "react-babylonjs": "^3.0.15",
         "react-dom": "^17.0.1",


### PR DESCRIPTION
### Summary of changes 🔍 
> The last change to exclude old node modules makes the build unconsumable
> It seems we are using utils and process


### Testing 🧪
 > [ Add any special instructions needed to test or view your changes such as environment URLs or other config details. ]

### Checklist ✔️
- [ ] Linked associated issue (if present)
- [ ] Added relevant labels
- [ ] Requested developer reviews
- [ ] Request UI review from design / PM
- [ ] Verify all code checks are passing