### PR TITLE
Add hooks linter plugin 

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,7 +2,8 @@
     "root": true,
     "parser": "@typescript-eslint/parser",
     "plugins": [
-        "@typescript-eslint"
+        "@typescript-eslint",
+        "react-hooks"
     ],
     "extends": [
         "eslint:recommended",
@@ -13,6 +14,7 @@
     "rules": {
         "no-debugger": "error",
         "no-multiple-empty-lines": "error",
+        "react-hooks/exhaustive-deps": "off",
         "@typescript-eslint/explicit-module-boundary-types": [
             "off"
         ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
                 "axios": "^0.21.1",
                 "axios-retry": "^3.1.9",
                 "copy-to-clipboard": "^3.3.1",
+                "eslint-plugin-react-hooks": "^4.5.0",
                 "expr-eval": "^2.0.2",
                 "fast-json-patch": "^3.0.0-1",
                 "fast-xml-parser": "^4.0.4",
@@ -563,7 +564,6 @@
             "version": "7.16.7",
             "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
             "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
-            "devOptional": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -610,7 +610,6 @@
             "version": "7.16.10",
             "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.10.tgz",
             "integrity": "sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==",
-            "devOptional": true,
             "dependencies": {
                 "@babel/helper-validator-identifier": "^7.16.7",
                 "chalk": "^2.0.0",
@@ -2733,7 +2732,6 @@
         },
         "node_modules/@eslint/eslintrc": {
             "version": "0.4.0",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ajv": "^6.12.4",
@@ -2754,7 +2752,6 @@
             "version": "6.12.6",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-            "dev": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -2768,7 +2765,6 @@
         },
         "node_modules/@eslint/eslintrc/node_modules/globals": {
             "version": "12.4.0",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "type-fest": "^0.8.1"
@@ -2783,8 +2779,7 @@
         "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-            "dev": true
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
         },
         "node_modules/@fluentui/date-time-utilities": {
             "version": "8.1.1",
@@ -13234,7 +13229,6 @@
         },
         "node_modules/acorn": {
             "version": "7.4.1",
-            "dev": true,
             "license": "MIT",
             "bin": {
                 "acorn": "bin/acorn"
@@ -13254,7 +13248,6 @@
         },
         "node_modules/acorn-jsx": {
             "version": "5.3.1",
-            "dev": true,
             "license": "MIT",
             "peerDependencies": {
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -13369,7 +13362,6 @@
         },
         "node_modules/ansi-colors": {
             "version": "4.1.1",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -13413,7 +13405,6 @@
         },
         "node_modules/ansi-regex": {
             "version": "5.0.1",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -13421,7 +13412,6 @@
         },
         "node_modules/ansi-styles": {
             "version": "3.2.1",
-            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "color-convert": "^1.9.0"
@@ -13525,7 +13515,6 @@
         },
         "node_modules/argparse": {
             "version": "1.0.10",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "sprintf-js": "~1.0.2"
@@ -13768,7 +13757,6 @@
         },
         "node_modules/astral-regex": {
             "version": "2.0.0",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -15372,7 +15360,6 @@
         },
         "node_modules/callsites": {
             "version": "3.1.0",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -15482,7 +15469,6 @@
         },
         "node_modules/chalk": {
             "version": "2.4.2",
-            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "ansi-styles": "^3.2.1",
@@ -16111,7 +16097,6 @@
         },
         "node_modules/color-convert": {
             "version": "1.9.3",
-            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "color-name": "1.1.3"
@@ -16119,7 +16104,6 @@
         },
         "node_modules/color-name": {
             "version": "1.1.3",
-            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/color-support": {
@@ -16839,7 +16823,6 @@
         },
         "node_modules/cross-spawn": {
             "version": "7.0.3",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "path-key": "^3.1.0",
@@ -17780,7 +17763,6 @@
         },
         "node_modules/deep-is": {
             "version": "0.1.3",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/deep-object-diff": {
@@ -18043,7 +18025,6 @@
         },
         "node_modules/doctrine": {
             "version": "3.0.0",
-            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "esutils": "^2.0.2"
@@ -18349,7 +18330,6 @@
         },
         "node_modules/emoji-regex": {
             "version": "8.0.0",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/emojis-list": {
@@ -18448,7 +18428,6 @@
         },
         "node_modules/enquirer": {
             "version": "2.3.6",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ansi-colors": "^4.1.1"
@@ -18709,7 +18688,6 @@
         },
         "node_modules/escape-string-regexp": {
             "version": "1.0.5",
-            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.8.0"
@@ -18801,7 +18779,6 @@
         },
         "node_modules/eslint": {
             "version": "7.22.0",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/code-frame": "7.12.11",
@@ -18863,9 +18840,19 @@
                 "eslint": ">=7.0.0"
             }
         },
+        "node_modules/eslint-plugin-react-hooks": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.5.0.tgz",
+            "integrity": "sha512-8k1gRt7D7h03kd+SAAlzXkQwWK22BnK6GKZG+FJA6BAGy22CFvl8kCIXKpVux0cCxMWDQUPqSok0LKaZ0aOcCw==",
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
+            }
+        },
         "node_modules/eslint-scope": {
             "version": "5.1.1",
-            "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "esrecurse": "^4.3.0",
@@ -18877,7 +18864,6 @@
         },
         "node_modules/eslint-utils": {
             "version": "2.1.0",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "eslint-visitor-keys": "^1.1.0"
@@ -18891,7 +18877,6 @@
         },
         "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
             "version": "1.3.0",
-            "dev": true,
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=4"
@@ -18899,7 +18884,6 @@
         },
         "node_modules/eslint-visitor-keys": {
             "version": "2.0.0",
-            "dev": true,
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=10"
@@ -18986,7 +18970,6 @@
         },
         "node_modules/eslint/node_modules/@babel/code-frame": {
             "version": "7.12.11",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/highlight": "^7.10.4"
@@ -18996,7 +18979,6 @@
             "version": "6.12.6",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-            "dev": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -19010,7 +18992,6 @@
         },
         "node_modules/eslint/node_modules/ansi-styles": {
             "version": "4.3.0",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "color-convert": "^2.0.1"
@@ -19024,7 +19005,6 @@
         },
         "node_modules/eslint/node_modules/chalk": {
             "version": "4.1.0",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ansi-styles": "^4.1.0",
@@ -19039,7 +19019,6 @@
         },
         "node_modules/eslint/node_modules/color-convert": {
             "version": "2.0.1",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "color-name": "~1.1.4"
@@ -19050,12 +19029,10 @@
         },
         "node_modules/eslint/node_modules/color-name": {
             "version": "1.1.4",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/eslint/node_modules/globals": {
             "version": "13.6.0",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "type-fest": "^0.20.2"
@@ -19069,7 +19046,6 @@
         },
         "node_modules/eslint/node_modules/has-flag": {
             "version": "4.0.0",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -19078,12 +19054,10 @@
         "node_modules/eslint/node_modules/json-schema-traverse": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-            "dev": true
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
         },
         "node_modules/eslint/node_modules/semver": {
             "version": "7.3.4",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -19097,7 +19071,6 @@
         },
         "node_modules/eslint/node_modules/supports-color": {
             "version": "7.2.0",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "has-flag": "^4.0.0"
@@ -19108,7 +19081,6 @@
         },
         "node_modules/eslint/node_modules/type-fest": {
             "version": "0.20.2",
-            "dev": true,
             "license": "(MIT OR CC0-1.0)",
             "engines": {
                 "node": ">=10"
@@ -19127,7 +19099,6 @@
         },
         "node_modules/espree": {
             "version": "7.3.1",
-            "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "acorn": "^7.4.0",
@@ -19140,7 +19111,6 @@
         },
         "node_modules/espree/node_modules/eslint-visitor-keys": {
             "version": "1.3.0",
-            "dev": true,
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=4"
@@ -19148,7 +19118,6 @@
         },
         "node_modules/esprima": {
             "version": "4.0.1",
-            "dev": true,
             "license": "BSD-2-Clause",
             "bin": {
                 "esparse": "bin/esparse.js",
@@ -19160,7 +19129,6 @@
         },
         "node_modules/esquery": {
             "version": "1.4.0",
-            "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
                 "estraverse": "^5.1.0"
@@ -19171,7 +19139,6 @@
         },
         "node_modules/esquery/node_modules/estraverse": {
             "version": "5.2.0",
-            "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=4.0"
@@ -19179,7 +19146,6 @@
         },
         "node_modules/esrecurse": {
             "version": "4.3.0",
-            "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "estraverse": "^5.2.0"
@@ -19190,7 +19156,6 @@
         },
         "node_modules/esrecurse/node_modules/estraverse": {
             "version": "5.2.0",
-            "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=4.0"
@@ -19198,7 +19163,6 @@
         },
         "node_modules/estraverse": {
             "version": "4.3.0",
-            "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=4.0"
@@ -19224,7 +19188,6 @@
         },
         "node_modules/esutils": {
             "version": "2.0.3",
-            "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=0.10.0"
@@ -19909,12 +19872,10 @@
         },
         "node_modules/fast-json-stable-stringify": {
             "version": "2.1.0",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/fast-levenshtein": {
             "version": "2.0.6",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/fast-xml-parser": {
@@ -19985,7 +19946,6 @@
         },
         "node_modules/file-entry-cache": {
             "version": "6.0.1",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "flat-cache": "^3.0.4"
@@ -20266,7 +20226,6 @@
         },
         "node_modules/flat-cache": {
             "version": "3.0.4",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "flatted": "^3.1.0",
@@ -20278,7 +20237,6 @@
         },
         "node_modules/flatted": {
             "version": "3.1.1",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/flush-write-stream": {
@@ -20691,7 +20649,6 @@
         },
         "node_modules/functional-red-black-tree": {
             "version": "1.0.1",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/functions-have-names": {
@@ -20959,7 +20916,6 @@
         },
         "node_modules/glob-parent": {
             "version": "5.1.2",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "is-glob": "^4.0.1"
@@ -21322,7 +21278,6 @@
         },
         "node_modules/has-flag": {
             "version": "3.0.0",
-            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=4"
@@ -21990,7 +21945,6 @@
         },
         "node_modules/ignore": {
             "version": "4.0.6",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 4"
@@ -22006,7 +21960,6 @@
         },
         "node_modules/import-fresh": {
             "version": "3.3.0",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "parent-module": "^1.0.0",
@@ -22063,7 +22016,6 @@
         },
         "node_modules/imurmurhash": {
             "version": "0.1.4",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.8.19"
@@ -22539,7 +22491,6 @@
         },
         "node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -22867,7 +22818,6 @@
         },
         "node_modules/isexe": {
             "version": "2.0.0",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/isobject": {
@@ -24670,7 +24620,6 @@
         },
         "node_modules/js-yaml": {
             "version": "3.14.1",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "argparse": "^1.0.7",
@@ -24869,7 +24818,6 @@
         },
         "node_modules/json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/json-stringify-safe": {
@@ -25048,7 +24996,6 @@
         },
         "node_modules/levn": {
             "version": "0.4.1",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "prelude-ls": "^1.2.1",
@@ -25562,7 +25509,6 @@
         },
         "node_modules/lru-cache": {
             "version": "6.0.0",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -26498,7 +26444,6 @@
         },
         "node_modules/natural-compare": {
             "version": "1.4.0",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/negotiator": {
@@ -31635,7 +31580,6 @@
         },
         "node_modules/optionator": {
             "version": "0.9.1",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "deep-is": "^0.1.3",
@@ -31887,7 +31831,6 @@
         },
         "node_modules/parent-module": {
             "version": "1.0.1",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "callsites": "^3.0.0"
@@ -32021,7 +31964,6 @@
         },
         "node_modules/path-key": {
             "version": "3.1.1",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -33575,7 +33517,6 @@
         },
         "node_modules/prelude-ls": {
             "version": "1.2.1",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8.0"
@@ -33689,7 +33630,6 @@
         },
         "node_modules/progress": {
             "version": "2.0.3",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.4.0"
@@ -34863,7 +34803,6 @@
         },
         "node_modules/regexpp": {
             "version": "3.1.0",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -35449,7 +35388,6 @@
         },
         "node_modules/resolve-from": {
             "version": "4.0.0",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=4"
@@ -35530,7 +35468,6 @@
         },
         "node_modules/rimraf": {
             "version": "3.0.2",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "glob": "^7.1.3"
@@ -36768,7 +36705,6 @@
         },
         "node_modules/shebang-command": {
             "version": "2.0.0",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "shebang-regex": "^3.0.0"
@@ -36779,7 +36715,6 @@
         },
         "node_modules/shebang-regex": {
             "version": "3.0.0",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -36887,7 +36822,6 @@
         },
         "node_modules/slice-ansi": {
             "version": "4.0.0",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ansi-styles": "^4.0.0",
@@ -36903,7 +36837,6 @@
         },
         "node_modules/slice-ansi/node_modules/ansi-styles": {
             "version": "4.3.0",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "color-convert": "^2.0.1"
@@ -36917,7 +36850,6 @@
         },
         "node_modules/slice-ansi/node_modules/color-convert": {
             "version": "2.0.1",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "color-name": "~1.1.4"
@@ -36928,7 +36860,6 @@
         },
         "node_modules/slice-ansi/node_modules/color-name": {
             "version": "1.1.4",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/snapdragon": {
@@ -37215,7 +37146,6 @@
         },
         "node_modules/sprintf-js": {
             "version": "1.0.3",
-            "dev": true,
             "license": "BSD-3-Clause"
         },
         "node_modules/sshpk": {
@@ -37510,7 +37440,6 @@
         },
         "node_modules/string-width": {
             "version": "4.2.3",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "emoji-regex": "^8.0.0",
@@ -37523,7 +37452,6 @@
         },
         "node_modules/string-width/node_modules/strip-ansi": {
             "version": "6.0.1",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^5.0.1"
@@ -37608,7 +37536,6 @@
         },
         "node_modules/strip-ansi": {
             "version": "6.0.0",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^5.0.0"
@@ -37662,7 +37589,6 @@
         },
         "node_modules/strip-json-comments": {
             "version": "3.1.1",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -38215,7 +38141,6 @@
         },
         "node_modules/supports-color": {
             "version": "5.5.0",
-            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "has-flag": "^3.0.0"
@@ -38330,7 +38255,6 @@
         },
         "node_modules/table": {
             "version": "6.0.7",
-            "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
                 "ajv": "^7.0.2",
@@ -38344,7 +38268,6 @@
         },
         "node_modules/table/node_modules/ajv": {
             "version": "7.2.1",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
@@ -38585,7 +38508,6 @@
         },
         "node_modules/text-table": {
             "version": "0.2.0",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/thenify": {
@@ -39199,7 +39121,6 @@
         },
         "node_modules/type-check": {
             "version": "0.4.0",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "prelude-ls": "^1.2.1"
@@ -39218,7 +39139,6 @@
         },
         "node_modules/type-fest": {
             "version": "0.8.1",
-            "dev": true,
             "license": "(MIT OR CC0-1.0)",
             "engines": {
                 "node": ">=8"
@@ -39866,7 +39786,6 @@
         },
         "node_modules/v8-compile-cache": {
             "version": "2.3.0",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/v8-to-istanbul": {
@@ -40742,7 +40661,6 @@
         },
         "node_modules/which": {
             "version": "2.0.2",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "isexe": "^2.0.0"
@@ -40795,7 +40713,6 @@
         },
         "node_modules/word-wrap": {
             "version": "1.2.3",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -40950,7 +40867,6 @@
         },
         "node_modules/yallist": {
             "version": "4.0.0",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/yaml": {
@@ -41428,8 +41344,7 @@
         "@babel/helper-validator-identifier": {
             "version": "7.16.7",
             "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
-            "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
-            "devOptional": true
+            "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw=="
         },
         "@babel/helper-validator-option": {
             "version": "7.16.7",
@@ -41464,7 +41379,6 @@
             "version": "7.16.10",
             "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.10.tgz",
             "integrity": "sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==",
-            "devOptional": true,
             "requires": {
                 "@babel/helper-validator-identifier": "^7.16.7",
                 "chalk": "^2.0.0",
@@ -42889,7 +42803,6 @@
         },
         "@eslint/eslintrc": {
             "version": "0.4.0",
-            "dev": true,
             "requires": {
                 "ajv": "^6.12.4",
                 "debug": "^4.1.1",
@@ -42906,7 +42819,6 @@
                     "version": "6.12.6",
                     "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
                     "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-                    "dev": true,
                     "requires": {
                         "fast-deep-equal": "^3.1.1",
                         "fast-json-stable-stringify": "^2.0.0",
@@ -42916,7 +42828,6 @@
                 },
                 "globals": {
                     "version": "12.4.0",
-                    "dev": true,
                     "requires": {
                         "type-fest": "^0.8.1"
                     }
@@ -42924,8 +42835,7 @@
                 "json-schema-traverse": {
                     "version": "0.4.1",
                     "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-                    "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-                    "dev": true
+                    "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
                 }
             }
         },
@@ -50028,8 +49938,7 @@
             }
         },
         "acorn": {
-            "version": "7.4.1",
-            "dev": true
+            "version": "7.4.1"
         },
         "acorn-globals": {
             "version": "6.0.0",
@@ -50041,7 +49950,6 @@
         },
         "acorn-jsx": {
             "version": "5.3.1",
-            "dev": true,
             "requires": {}
         },
         "acorn-walk": {
@@ -50122,8 +50030,7 @@
             }
         },
         "ansi-colors": {
-            "version": "4.1.1",
-            "dev": true
+            "version": "4.1.1"
         },
         "ansi-escapes": {
             "version": "4.3.1",
@@ -50143,12 +50050,10 @@
             "dev": true
         },
         "ansi-regex": {
-            "version": "5.0.1",
-            "dev": true
+            "version": "5.0.1"
         },
         "ansi-styles": {
             "version": "3.2.1",
-            "devOptional": true,
             "requires": {
                 "color-convert": "^1.9.0"
             }
@@ -50227,7 +50132,6 @@
         },
         "argparse": {
             "version": "1.0.10",
-            "dev": true,
             "requires": {
                 "sprintf-js": "~1.0.2"
             }
@@ -50387,8 +50291,7 @@
             }
         },
         "astral-regex": {
-            "version": "2.0.0",
-            "dev": true
+            "version": "2.0.0"
         },
         "async-each": {
             "version": "1.0.3",
@@ -51511,8 +51414,7 @@
             "version": "1.0.1"
         },
         "callsites": {
-            "version": "3.1.0",
-            "dev": true
+            "version": "3.1.0"
         },
         "camel-case": {
             "version": "4.1.2",
@@ -51582,7 +51484,6 @@
         },
         "chalk": {
             "version": "2.4.2",
-            "devOptional": true,
             "requires": {
                 "ansi-styles": "^3.2.1",
                 "escape-string-regexp": "^1.0.5",
@@ -51983,14 +51884,12 @@
         },
         "color-convert": {
             "version": "1.9.3",
-            "devOptional": true,
             "requires": {
                 "color-name": "1.1.3"
             }
         },
         "color-name": {
-            "version": "1.1.3",
-            "devOptional": true
+            "version": "1.1.3"
         },
         "color-support": {
             "version": "1.1.3",
@@ -52514,7 +52413,6 @@
         },
         "cross-spawn": {
             "version": "7.0.3",
-            "dev": true,
             "requires": {
                 "path-key": "^3.1.0",
                 "shebang-command": "^2.0.0",
@@ -53245,8 +53143,7 @@
             "dev": true
         },
         "deep-is": {
-            "version": "0.1.3",
-            "dev": true
+            "version": "0.1.3"
         },
         "deep-object-diff": {
             "version": "1.1.0",
@@ -53423,7 +53320,6 @@
         },
         "doctrine": {
             "version": "3.0.0",
-            "dev": true,
             "requires": {
                 "esutils": "^2.0.2"
             }
@@ -53663,8 +53559,7 @@
             "dev": true
         },
         "emoji-regex": {
-            "version": "8.0.0",
-            "dev": true
+            "version": "8.0.0"
         },
         "emojis-list": {
             "version": "3.0.0",
@@ -53740,7 +53635,6 @@
         },
         "enquirer": {
             "version": "2.3.6",
-            "dev": true,
             "requires": {
                 "ansi-colors": "^4.1.1"
             }
@@ -53933,8 +53827,7 @@
             "dev": true
         },
         "escape-string-regexp": {
-            "version": "1.0.5",
-            "devOptional": true
+            "version": "1.0.5"
         },
         "escodegen": {
             "version": "2.0.0",
@@ -53991,7 +53884,6 @@
         },
         "eslint": {
             "version": "7.22.0",
-            "dev": true,
             "requires": {
                 "@babel/code-frame": "7.12.11",
                 "@eslint/eslintrc": "^0.4.0",
@@ -54034,7 +53926,6 @@
             "dependencies": {
                 "@babel/code-frame": {
                     "version": "7.12.11",
-                    "dev": true,
                     "requires": {
                         "@babel/highlight": "^7.10.4"
                     }
@@ -54043,7 +53934,6 @@
                     "version": "6.12.6",
                     "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
                     "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-                    "dev": true,
                     "requires": {
                         "fast-deep-equal": "^3.1.1",
                         "fast-json-stable-stringify": "^2.0.0",
@@ -54053,14 +53943,12 @@
                 },
                 "ansi-styles": {
                     "version": "4.3.0",
-                    "dev": true,
                     "requires": {
                         "color-convert": "^2.0.1"
                     }
                 },
                 "chalk": {
                     "version": "4.1.0",
-                    "dev": true,
                     "requires": {
                         "ansi-styles": "^4.1.0",
                         "supports-color": "^7.1.0"
@@ -54068,49 +53956,41 @@
                 },
                 "color-convert": {
                     "version": "2.0.1",
-                    "dev": true,
                     "requires": {
                         "color-name": "~1.1.4"
                     }
                 },
                 "color-name": {
-                    "version": "1.1.4",
-                    "dev": true
+                    "version": "1.1.4"
                 },
                 "globals": {
                     "version": "13.6.0",
-                    "dev": true,
                     "requires": {
                         "type-fest": "^0.20.2"
                     }
                 },
                 "has-flag": {
-                    "version": "4.0.0",
-                    "dev": true
+                    "version": "4.0.0"
                 },
                 "json-schema-traverse": {
                     "version": "0.4.1",
                     "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-                    "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-                    "dev": true
+                    "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
                 },
                 "semver": {
                     "version": "7.3.4",
-                    "dev": true,
                     "requires": {
                         "lru-cache": "^6.0.0"
                     }
                 },
                 "supports-color": {
                     "version": "7.2.0",
-                    "dev": true,
                     "requires": {
                         "has-flag": "^4.0.0"
                     }
                 },
                 "type-fest": {
-                    "version": "0.20.2",
-                    "dev": true
+                    "version": "0.20.2"
                 }
             }
         },
@@ -54119,9 +53999,14 @@
             "dev": true,
             "requires": {}
         },
+        "eslint-plugin-react-hooks": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.5.0.tgz",
+            "integrity": "sha512-8k1gRt7D7h03kd+SAAlzXkQwWK22BnK6GKZG+FJA6BAGy22CFvl8kCIXKpVux0cCxMWDQUPqSok0LKaZ0aOcCw==",
+            "requires": {}
+        },
         "eslint-scope": {
             "version": "5.1.1",
-            "dev": true,
             "requires": {
                 "esrecurse": "^4.3.0",
                 "estraverse": "^4.1.1"
@@ -54129,20 +54014,17 @@
         },
         "eslint-utils": {
             "version": "2.1.0",
-            "dev": true,
             "requires": {
                 "eslint-visitor-keys": "^1.1.0"
             },
             "dependencies": {
                 "eslint-visitor-keys": {
-                    "version": "1.3.0",
-                    "dev": true
+                    "version": "1.3.0"
                 }
             }
         },
         "eslint-visitor-keys": {
-            "version": "2.0.0",
-            "dev": true
+            "version": "2.0.0"
         },
         "eslint-webpack-plugin": {
             "version": "2.5.2",
@@ -54201,7 +54083,6 @@
         },
         "espree": {
             "version": "7.3.1",
-            "dev": true,
             "requires": {
                 "acorn": "^7.4.0",
                 "acorn-jsx": "^5.3.1",
@@ -54209,44 +54090,37 @@
             },
             "dependencies": {
                 "eslint-visitor-keys": {
-                    "version": "1.3.0",
-                    "dev": true
+                    "version": "1.3.0"
                 }
             }
         },
         "esprima": {
-            "version": "4.0.1",
-            "dev": true
+            "version": "4.0.1"
         },
         "esquery": {
             "version": "1.4.0",
-            "dev": true,
             "requires": {
                 "estraverse": "^5.1.0"
             },
             "dependencies": {
                 "estraverse": {
-                    "version": "5.2.0",
-                    "dev": true
+                    "version": "5.2.0"
                 }
             }
         },
         "esrecurse": {
             "version": "4.3.0",
-            "dev": true,
             "requires": {
                 "estraverse": "^5.2.0"
             },
             "dependencies": {
                 "estraverse": {
-                    "version": "5.2.0",
-                    "dev": true
+                    "version": "5.2.0"
                 }
             }
         },
         "estraverse": {
-            "version": "4.3.0",
-            "dev": true
+            "version": "4.3.0"
         },
         "estree-to-babel": {
             "version": "3.2.1",
@@ -54262,8 +54136,7 @@
             "dev": true
         },
         "esutils": {
-            "version": "2.0.3",
-            "dev": true
+            "version": "2.0.3"
         },
         "etag": {
             "version": "1.8.1",
@@ -54767,12 +54640,10 @@
             "version": "3.0.0-1"
         },
         "fast-json-stable-stringify": {
-            "version": "2.1.0",
-            "dev": true
+            "version": "2.1.0"
         },
         "fast-levenshtein": {
-            "version": "2.0.6",
-            "dev": true
+            "version": "2.0.6"
         },
         "fast-xml-parser": {
             "version": "4.0.4",
@@ -54819,7 +54690,6 @@
         },
         "file-entry-cache": {
             "version": "6.0.1",
-            "dev": true,
             "requires": {
                 "flat-cache": "^3.0.4"
             }
@@ -55018,15 +54888,13 @@
         },
         "flat-cache": {
             "version": "3.0.4",
-            "dev": true,
             "requires": {
                 "flatted": "^3.1.0",
                 "rimraf": "^3.0.2"
             }
         },
         "flatted": {
-            "version": "3.1.1",
-            "dev": true
+            "version": "3.1.1"
         },
         "flush-write-stream": {
             "version": "1.1.1",
@@ -55306,8 +55174,7 @@
             }
         },
         "functional-red-black-tree": {
-            "version": "1.0.1",
-            "dev": true
+            "version": "1.0.1"
         },
         "functions-have-names": {
             "version": "1.2.2",
@@ -55497,7 +55364,6 @@
         },
         "glob-parent": {
             "version": "5.1.2",
-            "dev": true,
             "requires": {
                 "is-glob": "^4.0.1"
             }
@@ -55731,8 +55597,7 @@
             "dev": true
         },
         "has-flag": {
-            "version": "3.0.0",
-            "devOptional": true
+            "version": "3.0.0"
         },
         "has-glob": {
             "version": "1.0.0",
@@ -56175,15 +56040,13 @@
             "dev": true
         },
         "ignore": {
-            "version": "4.0.6",
-            "dev": true
+            "version": "4.0.6"
         },
         "immer": {
             "version": "9.0.6"
         },
         "import-fresh": {
             "version": "3.3.0",
-            "dev": true,
             "requires": {
                 "parent-module": "^1.0.0",
                 "resolve-from": "^4.0.0"
@@ -56215,8 +56078,7 @@
             }
         },
         "imurmurhash": {
-            "version": "0.1.4",
-            "dev": true
+            "version": "0.1.4"
         },
         "indent-string": {
             "version": "4.0.0",
@@ -56512,8 +56374,7 @@
             "dev": true
         },
         "is-fullwidth-code-point": {
-            "version": "3.0.0",
-            "dev": true
+            "version": "3.0.0"
         },
         "is-function": {
             "version": "1.0.2",
@@ -56696,8 +56557,7 @@
             "dev": true
         },
         "isexe": {
-            "version": "2.0.0",
-            "dev": true
+            "version": "2.0.0"
         },
         "isobject": {
             "version": "4.0.0",
@@ -57882,7 +57742,6 @@
         },
         "js-yaml": {
             "version": "3.14.1",
-            "dev": true,
             "requires": {
                 "argparse": "^1.0.7",
                 "esprima": "^4.0.0"
@@ -58019,8 +57878,7 @@
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
         },
         "json-stable-stringify-without-jsonify": {
-            "version": "1.0.1",
-            "dev": true
+            "version": "1.0.1"
         },
         "json-stringify-safe": {
             "version": "5.0.1"
@@ -58135,7 +57993,6 @@
         },
         "levn": {
             "version": "0.4.1",
-            "dev": true,
             "requires": {
                 "prelude-ls": "^1.2.1",
                 "type-check": "~0.4.0"
@@ -58480,7 +58337,6 @@
         },
         "lru-cache": {
             "version": "6.0.0",
-            "dev": true,
             "requires": {
                 "yallist": "^4.0.0"
             }
@@ -59126,8 +58982,7 @@
             }
         },
         "natural-compare": {
-            "version": "1.4.0",
-            "dev": true
+            "version": "1.4.0"
         },
         "negotiator": {
             "version": "0.6.2",
@@ -62863,7 +62718,6 @@
         },
         "optionator": {
             "version": "0.9.1",
-            "dev": true,
             "requires": {
                 "deep-is": "^0.1.3",
                 "fast-levenshtein": "^2.0.6",
@@ -63027,7 +62881,6 @@
         },
         "parent-module": {
             "version": "1.0.1",
-            "dev": true,
             "requires": {
                 "callsites": "^3.0.0"
             }
@@ -63117,8 +62970,7 @@
             }
         },
         "path-key": {
-            "version": "3.1.1",
-            "dev": true
+            "version": "3.1.1"
         },
         "path-parse": {
             "version": "1.0.7",
@@ -64106,8 +63958,7 @@
             "dev": true
         },
         "prelude-ls": {
-            "version": "1.2.1",
-            "dev": true
+            "version": "1.2.1"
         },
         "prettier": {
             "version": "2.2.1"
@@ -64173,8 +64024,7 @@
             "dev": true
         },
         "progress": {
-            "version": "2.0.3",
-            "dev": true
+            "version": "2.0.3"
         },
         "progress-stream": {
             "version": "2.0.0",
@@ -65004,8 +64854,7 @@
             }
         },
         "regexpp": {
-            "version": "3.1.0",
-            "dev": true
+            "version": "3.1.0"
         },
         "regexpu-core": {
             "version": "5.0.1",
@@ -65403,8 +65252,7 @@
             }
         },
         "resolve-from": {
-            "version": "4.0.0",
-            "dev": true
+            "version": "4.0.0"
         },
         "resolve-global": {
             "version": "1.0.0",
@@ -65453,7 +65301,6 @@
         },
         "rimraf": {
             "version": "3.0.2",
-            "dev": true,
             "requires": {
                 "glob": "^7.1.3"
             }
@@ -66299,14 +66146,12 @@
         },
         "shebang-command": {
             "version": "2.0.0",
-            "dev": true,
             "requires": {
                 "shebang-regex": "^3.0.0"
             }
         },
         "shebang-regex": {
-            "version": "3.0.0",
-            "dev": true
+            "version": "3.0.0"
         },
         "shelljs": {
             "version": "0.8.5",
@@ -66377,7 +66222,6 @@
         },
         "slice-ansi": {
             "version": "4.0.0",
-            "dev": true,
             "requires": {
                 "ansi-styles": "^4.0.0",
                 "astral-regex": "^2.0.0",
@@ -66386,21 +66230,18 @@
             "dependencies": {
                 "ansi-styles": {
                     "version": "4.3.0",
-                    "dev": true,
                     "requires": {
                         "color-convert": "^2.0.1"
                     }
                 },
                 "color-convert": {
                     "version": "2.0.1",
-                    "dev": true,
                     "requires": {
                         "color-name": "~1.1.4"
                     }
                 },
                 "color-name": {
-                    "version": "1.1.4",
-                    "dev": true
+                    "version": "1.1.4"
                 }
             }
         },
@@ -66611,8 +66452,7 @@
             }
         },
         "sprintf-js": {
-            "version": "1.0.3",
-            "dev": true
+            "version": "1.0.3"
         },
         "sshpk": {
             "version": "1.16.1",
@@ -66847,7 +66687,6 @@
         },
         "string-width": {
             "version": "4.2.3",
-            "dev": true,
             "requires": {
                 "emoji-regex": "^8.0.0",
                 "is-fullwidth-code-point": "^3.0.0",
@@ -66856,7 +66695,6 @@
             "dependencies": {
                 "strip-ansi": {
                     "version": "6.0.1",
-                    "dev": true,
                     "requires": {
                         "ansi-regex": "^5.0.1"
                     }
@@ -66913,7 +66751,6 @@
         },
         "strip-ansi": {
             "version": "6.0.0",
-            "dev": true,
             "requires": {
                 "ansi-regex": "^5.0.0"
             }
@@ -66942,8 +66779,7 @@
             }
         },
         "strip-json-comments": {
-            "version": "3.1.1",
-            "dev": true
+            "version": "3.1.1"
         },
         "strnum": {
             "version": "1.0.5",
@@ -67298,7 +67134,6 @@
         },
         "supports-color": {
             "version": "5.5.0",
-            "devOptional": true,
             "requires": {
                 "has-flag": "^3.0.0"
             }
@@ -67377,7 +67212,6 @@
         },
         "table": {
             "version": "6.0.7",
-            "dev": true,
             "requires": {
                 "ajv": "^7.0.2",
                 "lodash": "^4.17.20",
@@ -67387,7 +67221,6 @@
             "dependencies": {
                 "ajv": {
                     "version": "7.2.1",
-                    "dev": true,
                     "requires": {
                         "fast-deep-equal": "^3.1.1",
                         "json-schema-traverse": "^1.0.0",
@@ -67548,8 +67381,7 @@
             "dev": true
         },
         "text-table": {
-            "version": "0.2.0",
-            "dev": true
+            "version": "0.2.0"
         },
         "thenify": {
             "version": "3.3.1",
@@ -67997,7 +67829,6 @@
         },
         "type-check": {
             "version": "0.4.0",
-            "dev": true,
             "requires": {
                 "prelude-ls": "^1.2.1"
             }
@@ -68007,8 +67838,7 @@
             "dev": true
         },
         "type-fest": {
-            "version": "0.8.1",
-            "dev": true
+            "version": "0.8.1"
         },
         "type-is": {
             "version": "1.6.18",
@@ -68418,8 +68248,7 @@
             "dev": true
         },
         "v8-compile-cache": {
-            "version": "2.3.0",
-            "dev": true
+            "version": "2.3.0"
         },
         "v8-to-istanbul": {
             "version": "7.1.0",
@@ -69050,7 +68879,6 @@
         },
         "which": {
             "version": "2.0.2",
-            "dev": true,
             "requires": {
                 "isexe": "^2.0.0"
             }
@@ -69085,8 +68913,7 @@
             }
         },
         "word-wrap": {
-            "version": "1.2.3",
-            "dev": true
+            "version": "1.2.3"
         },
         "wordwrap": {
             "version": "1.0.0",
@@ -69183,8 +69010,7 @@
             "dev": true
         },
         "yallist": {
-            "version": "4.0.0",
-            "dev": true
+            "version": "4.0.0"
         },
         "yaml": {
             "version": "1.10.2",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
         "axios": "^0.21.1",
         "axios-retry": "^3.1.9",
         "copy-to-clipboard": "^3.3.1",
+        "eslint-plugin-react-hooks": "^4.5.0",
         "expr-eval": "^2.0.2",
         "fast-json-patch": "^3.0.0-1",
         "fast-xml-parser": "^4.0.4",


### PR DESCRIPTION
### Summary of changes 🔍 
Adding a lint rule to enforce the dependency lists for hooks like `useMemo`, `useCallback` & `useEffect` so that dependencies are not missed and thus cause runtime bugs from stale closures.

It's turned off for now because it's such a big change to fix the rules but this should help folks turn it on locally to check.

Enable `react-hooks/exhaustive-deps` in `.eslintrc.json`

Lint rule docs here: https://github.com/facebook/react/issues/14920

### Testing 🧪
 > [ Add any special instructions needed to test or view your changes such as environment URLs or other config details. ]

### Checklist ✔️
- [ ] Linked associated issue (if present)
- [ ] Added relevant labels
- [ ] Requested developer reviews
- [ ] Request UI review from design / PM
- [ ] Verify all code checks are passing