### PR TITLE
Improve mesh tab perf

### DIFF
--- a/src/Components/ADT3DSceneBuilder/ADT3DSceneBuilder.tsx
+++ b/src/Components/ADT3DSceneBuilder/ADT3DSceneBuilder.tsx
@@ -206,52 +206,60 @@ const ADT3DSceneBuilder: React.FC<IADT3DSceneBuilderCardProps> = ({
         []
     );
 
-    const setOutlinedMeshItems = (outlinedMeshItems: Array<CustomMeshItem>) => {
-        dispatch({
-            type: SET_MESH_IDS_TO_OUTLINE,
-            payload: outlinedMeshItems
-        });
-    };
+    const setOutlinedMeshItems = useCallback(
+        (outlinedMeshItems: Array<CustomMeshItem>) => {
+            dispatch({
+                type: SET_MESH_IDS_TO_OUTLINE,
+                payload: outlinedMeshItems
+            });
+        },
+        []
+    );
 
-    const setWidgetFormInfo = (widgetFormInfo: WidgetFormInfo) => {
+    const setWidgetFormInfo = useCallback((widgetFormInfo: WidgetFormInfo) => {
         dispatch({
             type: SET_WIDGET_FORM_INFO,
             payload: widgetFormInfo
         });
-    };
+    }, []);
 
-    const setBehaviorTwinAliasFormInfo = (
-        behaviorTwinAliasFormInfo: BehaviorTwinAliasFormInfo
-    ) => {
-        dispatch({
-            type: SET_BEHAVIOR_TWIN_ALIAS_FORM_INFO,
-            payload: behaviorTwinAliasFormInfo
-        });
-    };
+    const setBehaviorTwinAliasFormInfo = useCallback(
+        (behaviorTwinAliasFormInfo: BehaviorTwinAliasFormInfo) => {
+            dispatch({
+                type: SET_BEHAVIOR_TWIN_ALIAS_FORM_INFO,
+                payload: behaviorTwinAliasFormInfo
+            });
+        },
+        []
+    );
 
-    const setElementTwinAliasFormInfo = (
-        elementTwinAliasFormInfo: ElementTwinAliasFormInfo
-    ) => {
-        dispatch({
-            type: SET_ELEMENT_TWIN_ALIAS_FORM_INFO,
-            payload: elementTwinAliasFormInfo
-        });
-    };
+    const setElementTwinAliasFormInfo = useCallback(
+        (elementTwinAliasFormInfo: ElementTwinAliasFormInfo) => {
+            dispatch({
+                type: SET_ELEMENT_TWIN_ALIAS_FORM_INFO,
+                payload: elementTwinAliasFormInfo
+            });
+        },
+        []
+    );
 
-    const setIsLayerBuilderDialogOpen = (
-        isOpen: boolean,
-        behaviorId?: string,
-        onFocusDismiss?: (layerId: string) => void
-    ) => {
-        dispatch({
-            type: SET_IS_LAYER_BUILDER_DIALOG_OPEN,
-            payload: {
-                isOpen,
-                behaviorId: behaviorId,
-                onFocusDismiss
-            }
-        });
-    };
+    const setIsLayerBuilderDialogOpen = useCallback(
+        (
+            isOpen: boolean,
+            behaviorId?: string,
+            onFocusDismiss?: (layerId: string) => void
+        ) => {
+            dispatch({
+                type: SET_IS_LAYER_BUILDER_DIALOG_OPEN,
+                payload: {
+                    isOpen,
+                    behaviorId: behaviorId,
+                    onFocusDismiss
+                }
+            });
+        },
+        []
+    );
 
     const getScenesConfig = useAdapter({
         adapterMethod: () => adapter.getScenesConfig(),
@@ -656,12 +664,12 @@ const ADT3DSceneBuilder: React.FC<IADT3DSceneBuilderCardProps> = ({
         }
     };
 
-    const objectColorUpdated = (objectColor: IADTObjectColor) => {
+    const objectColorUpdated = useCallback((objectColor: IADTObjectColor) => {
         dispatch({
             type: SET_ADT_SCENE_OBJECT_COLOR,
             payload: objectColor
         });
-    };
+    }, []);
 
     const commonPanelStyles = getLeftPanelStyles(fluentTheme);
 

--- a/src/Components/ADT3DSceneBuilder/Internal/Elements/Internal/MeshTab.tsx
+++ b/src/Components/ADT3DSceneBuilder/Internal/Elements/Internal/MeshTab.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useState } from 'react';
 import { ITwinToObjectMapping } from '../../../../../Models/Types/Generated/3DScenesConfiguration-v1.0.0';
 import { useTranslation } from 'react-i18next';
 import { CardboardList } from '../../../../CardboardList';
@@ -23,13 +23,13 @@ const MeshTab: React.FC<MeshTabProps> = ({ elementToEdit }) => {
         SceneBuilderContext
     );
 
-    const compareListItems = () => {
+    const compareListItems = useCallback(() => {
         if (elementToEdit.objectIDs.length === listItems.length) {
             return false;
         } else {
             return true;
         }
-    };
+    }, [elementToEdit.objectIDs.length, listItems.length]);
 
     // generate the list of items to show
     useEffect(() => {
@@ -41,7 +41,12 @@ const MeshTab: React.FC<MeshTabProps> = ({ elementToEdit }) => {
             );
             setListItems(listItems);
         }
-    }, [elementToEdit.objectIDs, setColoredMeshItems, objectColor]);
+    }, [
+        elementToEdit.objectIDs,
+        setColoredMeshItems,
+        objectColor,
+        compareListItems
+    ]);
 
     const commonPanelStyles = getLeftPanelStyles(useTheme());
     return (


### PR DESCRIPTION
### Summary of changes 🔍 
This PR improves performance of the `onHover` event to all items in the Mesh list inside Elements. With the new condition, the list won't be generated on every item hover. Further improvements could be made to reduce number of renders; however, this at least should remove an expensive operation when it is not required. This should fix bug: https://github.com/microsoft/iot-cardboard-js/issues/242

### Testing 🧪
Open the list of Meshes of a certain element and move your mouse over the list of items.

Chromatic link: https://pasanch-meshtabperf--601c6b2fcd385c002100f14c.chromatic.com/?path=/story/components-adt3dscenebuilder--mock-3-d-builder

### Checklist ✔️
- [x] Linked associated issue (if present)
- [x] Added relevant labels
- [x] Requested developer reviews
- [x] Request UI review from design / PM
- [x] Verify all code checks are passing