### PR TITLE
Bugfix for crashing layer when attached behavior is deleted

### DIFF
--- a/src/Models/Classes/ViewerConfigUtility.ts
+++ b/src/Models/Classes/ViewerConfigUtility.ts
@@ -269,6 +269,16 @@ abstract class ViewerConfigUtility {
                     scene.behaviorIDs.splice(matchingBehaviorIdIdx, 1);
                 }
             });
+
+            // If matching behavior Id found in ANY layers, splice out layers's behavior Id array
+            updatedConfig.configuration.layers.forEach((layer) => {
+                const matchingBehaviorIdIdx = layer.behaviorIDs.indexOf(
+                    behaviorId
+                );
+                if (matchingBehaviorIdIdx !== -1) {
+                    layer.behaviorIDs.splice(matchingBehaviorIdIdx, 1);
+                }
+            });
         }
         return updatedConfig;
     }


### PR DESCRIPTION
### Summary of changes 🔍 
Bugfix for app crashing when deleting a behavior from all scenes and the layer that behavior is attached to is clicked in scene layers dropdown


### Testing 🧪
See the steps in the linked bug

### Checklist ✔️
- [x] Linked associated issue (if present)
- [x] Added relevant labels
- [x] Requested developer reviews
- [ ] Request UI review from design / PM
- [x] Verify all code checks are passing