### PR TITLE
Fix for component property nesting

### DIFF
--- a/src/Components/ModelledPropertyBuilder/ModelledPropertyBuilder.model.ts
+++ b/src/Components/ModelledPropertyBuilder/ModelledPropertyBuilder.model.ts
@@ -249,7 +249,7 @@ const addEntity = (
         addInterface(
             componentEntry,
             entity.schema,
-            path,
+            path + '.' + entity.name,
             allowedPropertyValueTypes
         );
     }


### PR DESCRIPTION
Currently component properties are flattened in the modelled property builder data structure, but they need preserve their nesting path to work correctly.

### Bug image & description from private preview
![image](https://user-images.githubusercontent.com/18181049/168351373-af45f46e-8dbe-4847-bd69-326affc9e407.png)
> As I said in my initial message, deeply nested component properties are working, but through Custom expressions only. 
  When I try to use the Single Property Option, I see two issues:	
 > - The dropdown list shows all the properties in Flat mode, with no mention of the component => impossible to differentiate the properties if you have different component following the same Twin definition
>  - When I select an entry, it associates the PrimaryTwin.PropertyName expression, where we should have PrimaryTwin.ComponentName.PropertyName (what I do through the custom expression option)

### Summary of changes 🔍 
This is a one line change (missing path logic during component construction recursion) that fixes this issue

![image](https://user-images.githubusercontent.com/18181049/168348108-12268cb0-2441-48c8-9b85-5ad6ea715da7.png)


### Testing 🧪
 - Select a property within a component in the dropdown (any of the address properties in the Tesla example model)

### Checklist ✔️
- [x] Linked associated issue (if present)
- [ ] Added relevant labels
- [ ] Requested developer reviews
- [ ] Request UI review from design / PM
- [ ] Verify all code checks are passing