### PR TITLE
fix: zooming out from element on click fix

### DIFF
--- a/src/Components/ADT3DViewer/ADT3DViewer.tsx
+++ b/src/Components/ADT3DViewer/ADT3DViewer.tsx
@@ -398,7 +398,8 @@ const ADT3DViewerBase: React.FC<IADT3DViewerProps & BaseComponentProps> = ({
     // mesh callbakcs
     const meshClick = (mesh: { id: string }, scene: any) => {
         // update the selected element on the context
-        setSelectedElementId(getElementByMeshId(mesh.id)?.id);
+        setSelectedElementId(getElementByMeshId(mesh?.id)?.id);
+
         if (sceneVisuals) {
             const sceneVisual = sceneVisuals.find((sceneVisual) =>
                 sceneVisual.element.objectIDs.find((id) => id === mesh?.id)


### PR DESCRIPTION
### Summary of changes 🔍 
> When clicking off an element to zoom out if the user clicked on blank space (not a mesh) it would not work.


### Testing 🧪
 > [ Add any special instructions needed to test or view your changes such as environment URLs or other config details. ]

### Checklist ✔️
- [ ] Linked associated issue (if present)
- [ ] Added relevant labels
- [ ] Requested developer reviews
- [ ] Request UI review from design / PM
- [ ] Verify all code checks are passing