### PR TITLE
Bugfixes for environment picker

### DIFF
--- a/src/Components/EnvironmentPicker/EnvironmentPicker.tsx
+++ b/src/Components/EnvironmentPicker/EnvironmentPicker.tsx
@@ -491,20 +491,24 @@ const EnvironmentPicker = (props: EnvironmentPickerProps) => {
         toggleIsDialogHidden();
         dialogResettingValuesTimeoutRef.current = setTimeout(() => {
             // wait for dialog dismiss fade-out animation to reset the values
-            const selectedEnvironmentIndex = environments.findIndex(
-                (e: string | IADTInstance) =>
-                    getUrl(e) === getUrl(selectedEnvironment)
-            );
-            setEnvironmentToEdit(selectedEnvironment);
-            setContainerUrlToEdit(selectedContainerUrl);
-            if (selectedEnvironmentIndex === -1) {
-                setEnvironments(environments.concat(selectedEnvironment));
+            if (selectedEnvironment) {
+                const selectedEnvironmentIndex = environments.findIndex(
+                    (e: string | IADTInstance) =>
+                        getUrl(e) === getUrl(selectedEnvironment)
+                );
+                if (selectedEnvironmentIndex === -1) {
+                    setEnvironments(environments.concat(selectedEnvironment));
+                }
             }
+            setEnvironmentToEdit(selectedEnvironment);
+
             if (
+                selectedContainerUrl &&
                 containers.findIndex((e) => e === selectedContainerUrl) === -1
             ) {
                 setContainers(containers.concat(selectedContainerUrl));
             }
+            setContainerUrlToEdit(selectedContainerUrl);
         }, 500);
     }, [
         toggleIsDialogHidden,
@@ -667,7 +671,7 @@ const getUrl = (environment: string | IADTInstance) => {
     if (typeof environment === 'string') {
         return environment;
     } else {
-        addHttpsPrefix(environment.hostName);
+        return addHttpsPrefix(environment.hostName);
     }
 };
 


### PR DESCRIPTION
### Summary of changes 🔍 
See the linked issues:
- Filling out environment URL with empty local storage after environments have loaded from management calls results in invalid URL #434
- When no environment or container is set, open/close/open of environment picker causes unhandled exception #433


### Testing 🧪
See the linked issues to see the issues are fixed.

### Checklist ✔️
- [x] Linked associated issue (if present)
- [x] Added relevant labels
- [x] Requested developer reviews
- [ ] Request UI review from design / PM
- [x] Verify all code checks are passing