### PR TITLE
Load all models is not appropriately handling continuation token

### DIFF
--- a/src/Adapters/ADTAdapter.ts
+++ b/src/Adapters/ADTAdapter.ts
@@ -70,6 +70,7 @@ import {
 import { ElementType } from '../Models/Classes/3DVConfig';
 import { ModelDict } from 'azure-iot-dtdl-parser/dist/parser/modelDict';
 import AdapterEntityCache from '../Models/Classes/AdapterEntityCache';
+import queryString from 'query-string';
 
 export default class ADTAdapter implements IADTAdapter {
     public tenantId: string;
@@ -251,9 +252,20 @@ export default class ADTAdapter implements IADTAdapter {
 
                         // If next link present, fetch next chunk
                         if (adtModelsApiData.result.data.nextLink) {
-                            await appendModels(
-                                adtModelsApiData.result.data.nextLink
-                            );
+                            try {
+                                const url = new URL(
+                                    adtModelsApiData.result.data.nextLink
+                                );
+                                const continuationToken = queryString.parse(
+                                    url.search
+                                ).continuationToken as string;
+                                await appendModels(continuationToken);
+                            } catch (e) {
+                                console.log(
+                                    'Continuation token for models call unsuccessfully parsed',
+                                    e
+                                );
+                            }
                         }
                     };
 


### PR DESCRIPTION
### Summary of changes 🔍 
Currently nextlink is a URL, not a continuation token.  I'm just parsing the URL to get the continuation token.  

Current issue
![image](https://user-images.githubusercontent.com/4854357/169187683-3608acd2-57ea-4c9b-b002-6a14bb6b2f83.png)

This results in an immediate 400 fetching the next chunk
![image](https://user-images.githubusercontent.com/4854357/169187821-43f987ce-6e90-40fb-8bd7-424be2cf66f3.png)

Now it works...
![image](https://user-images.githubusercontent.com/4854357/169187890-14ae687f-031f-4852-a2d5-dd9ced66922f.png)


### Testing 🧪
 > [ Add any special instructions needed to test or view your changes such as environment URLs or other config details. ]

### Checklist ✔️
- [ ] Linked associated issue (if present)
- [ ] Added relevant labels
- [ ] Requested developer reviews
- [ ] Request UI review from design / PM
- [ ] Verify all code checks are passing