### PR TITLE
Added dtId to Primary and all Twin aliases intellisense

### DIFF
--- a/src/Components/ModelledPropertyBuilder/ModelledPropertyBuilder.model.ts
+++ b/src/Components/ModelledPropertyBuilder/ModelledPropertyBuilder.model.ts
@@ -67,8 +67,6 @@ export const buildModelledProperties = async ({
             aliasedTwinMap
         );
 
-        // eslint-disable-next-line no-debugger
-        debugger;
         // Expand each model ID into DTDL property array
         modelledProperties.nestedFormat = expandModelIds(
             modelDict,


### PR DESCRIPTION
### Summary of changes 🔍 
Included $dtId as a modelled property in forms Intellisense.

### Testing 🧪
- Go to behavior form
- In Status/Alerts/Widget forms $dtId should be present as a property for all Twins.
- Add a Widget with that property, as a string type.
- Go to viewer and verify it is the correct digital twin id.

### Checklist ✔️
- [x] Linked associated issue (if present)
- [x] Added relevant labels
- [x] Requested developer reviews
- [x] Request UI review from design / PM
- [ ] Verify all code checks are passing