### PR TITLE
Fixed typo in example component import in the "Getting Started" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ import {
     MsalAuthService,
     KeyValuePairCard,
     //...
-} from 'iot-cardboard-js';
+} from '@microsoft/iot-cardboard-js';
 ```
 
 This is the easiest method of importing components and, in most cases, will allow unused code to be tree shaken from our library.


### PR DESCRIPTION
### Summary of changes 🔍 
> Documentation change, import of components in readme changed to point at correct npm repo.

### Checklist ✔️
- [-] Linked associated issue (if present)
- [x] Added relevant labels
- [x] Requested developer reviews
- [x] Request UI review from design / PM
- [x] Verify all code checks are passing