### PR TITLE
Value widget: support for 0 & unset twin values

### DIFF
--- a/src/Components/BehaviorsModal/Internal/Widgets/ValueWidget/FormattedValue.tsx
+++ b/src/Components/BehaviorsModal/Internal/Widgets/ValueWidget/FormattedValue.tsx
@@ -10,18 +10,17 @@ interface IProps {
     locale: Locale;
     value: boolean | Date | number | string;
     type: IDTDLPropertyType;
-    isValid: boolean;
 }
 
 const invalidPlaceholder = '--';
 
-const FormattedValue: React.FC<IProps> = ({ locale, value, type, isValid }) => {
+const FormattedValue: React.FC<IProps> = ({ locale, value, type }) => {
     const theme = useTheme();
     const { t } = useTranslation();
     const styles = getStyles(theme);
 
-    // Show '--' if value is invalid (unset on twin for example)
-    if (!isValid) {
+    // Show '--' if value is null (unset on twin)
+    if (value === null || value === undefined) {
         return (
             <span
                 className={styles.expressionValueInvalidPlaceholder}

--- a/src/Components/BehaviorsModal/Internal/Widgets/ValueWidget/FormattedValue.tsx
+++ b/src/Components/BehaviorsModal/Internal/Widgets/ValueWidget/FormattedValue.tsx
@@ -5,14 +5,32 @@ import { Locale } from '../../../../../Models/Constants/Enums';
 import { IDTDLPropertyType } from '../../../../../Models/Types/Generated/3DScenesConfiguration-v1.0.0';
 import { getStyles } from './ValueWidget.styles';
 import { useTranslation } from 'react-i18next';
+
 interface IProps {
     locale: Locale;
     value: boolean | Date | number | string;
     type: IDTDLPropertyType;
+    isValid: boolean;
 }
-const FormattedValue: React.FC<IProps> = ({ locale, value, type }) => {
+
+const invalidPlaceholder = '--';
+
+const FormattedValue: React.FC<IProps> = ({ locale, value, type, isValid }) => {
     const theme = useTheme();
     const { t } = useTranslation();
+    const styles = getStyles(theme);
+
+    // Show '--' if value is invalid (unset on twin for example)
+    if (!isValid) {
+        return (
+            <span
+                className={styles.expressionValueInvalidPlaceholder}
+                title={t('invalidValue')}
+            >
+                {invalidPlaceholder}
+            </span>
+        );
+    }
 
     let stringValueToDisplay = '';
     const typedValue = ViewerConfigUtility.getTypedDTDLPropertyValue(
@@ -20,7 +38,6 @@ const FormattedValue: React.FC<IProps> = ({ locale, value, type }) => {
         type
     ); // get the typed value in case it is not in the data format it is set
 
-    const styles = getStyles(theme);
     if (typedValue instanceof Error) {
         return (
             <code className={styles.invalidExpressionValue}>

--- a/src/Components/BehaviorsModal/Internal/Widgets/ValueWidget/ValueWidget.styles.ts
+++ b/src/Components/BehaviorsModal/Internal/Widgets/ValueWidget/ValueWidget.styles.ts
@@ -15,6 +15,7 @@ const classNames = {
     expressionValuePrimary: `${behaviorsModalClassPrefix}-property-widget-expression-value-primary`,
     expressionValueSecondary: `${behaviorsModalClassPrefix}-property-widget-expression-value-secondary`,
     expressionValueListItem: `${behaviorsModalClassPrefix}-property-widget-expression-value-list-item`,
+    expressionValueInvalidPlaceholder: `${behaviorsModalClassPrefix}-property-widget-expression-value-invalid-placeholder`,
     invalidExpressionValue: `${behaviorsModalClassPrefix}-property-widget-expression-value-invalid`
 };
 
@@ -62,6 +63,18 @@ export const getStyles = memoizeFunction((theme: Theme) =>
                 display: 'flex',
                 flexDirection: 'column',
                 justifyContent: 'center',
+                ...overflowStyles
+            } as IStyle
+        ],
+        expressionValueInvalidPlaceholder: [
+            classNames.expressionValueInvalidPlaceholder,
+            {
+                width: '100%',
+                color: theme.palette.themePrimary,
+                textAlign: 'center',
+                fontSize: FontSizes.size32,
+                whiteSpace: 'pre-wrap',
+                overflowWrap: 'break-word',
                 ...overflowStyles
             } as IStyle
         ],

--- a/src/Components/BehaviorsModal/Internal/Widgets/ValueWidget/ValueWidget.tsx
+++ b/src/Components/BehaviorsModal/Internal/Widgets/ValueWidget/ValueWidget.tsx
@@ -2,7 +2,10 @@ import { useTheme } from '@fluentui/react';
 import { memoizeFunction } from '@fluentui/react';
 import React, { useContext, useMemo } from 'react';
 import { TFunction, useTranslation } from 'react-i18next';
-import { Locale } from '../../../../../Models/Constants/Enums';
+import {
+    BehaviorModalMode,
+    Locale
+} from '../../../../../Models/Constants/Enums';
 import { parseLinkedTwinExpression } from '../../../../../Models/Services/Utils';
 import {
     IDTDLPropertyType,
@@ -34,14 +37,26 @@ export const ValueWidget: React.FC<IProp> = ({ widget, placeholderValues }) => {
     const theme = useTheme();
     const { t, i18n } = useTranslation();
 
-    const { twins } = useContext(BehaviorsModalContext);
+    const { twins, mode } = useContext(BehaviorsModalContext);
     const { displayName, valueExpression, type } = widget.widgetConfiguration;
 
-    const parsedValue = useMemo(
-        () => parseLinkedTwinExpression(valueExpression, twins),
-
-        [valueExpression, twins]
-    );
+    const parseResult: { value: any; isValid: boolean } = useMemo(() => {
+        const parsedValue = parseLinkedTwinExpression(valueExpression, twins);
+        if (parsedValue === '') {
+            if (mode === BehaviorModalMode.viewer) {
+                return { value: null, isValid: false };
+            } else {
+                return {
+                    value:
+                        placeholderValues?.[type] ??
+                        getValuePlaceholders(t)[type],
+                    isValid: true
+                };
+            }
+        } else {
+            return { value: parsedValue, isValid: true };
+        }
+    }, [valueExpression, twins, mode, placeholderValues, type, t]);
 
     const styles = getStyles(theme);
     return (
@@ -49,11 +64,8 @@ export const ValueWidget: React.FC<IProp> = ({ widget, placeholderValues }) => {
             <div className={styles.expressionValueContainer}>
                 <FormattedValue
                     locale={i18n.language as Locale}
-                    value={
-                        parsedValue ||
-                        (placeholderValues?.[type] ??
-                            getValuePlaceholders(t)[type])
-                    }
+                    value={parseResult.value}
+                    isValid={parseResult.isValid}
                     type={type}
                 />
             </div>

--- a/src/Components/BehaviorsModal/Internal/Widgets/ValueWidget/ValueWidget.tsx
+++ b/src/Components/BehaviorsModal/Internal/Widgets/ValueWidget/ValueWidget.tsx
@@ -40,21 +40,18 @@ export const ValueWidget: React.FC<IProp> = ({ widget, placeholderValues }) => {
     const { twins, mode } = useContext(BehaviorsModalContext);
     const { displayName, valueExpression, type } = widget.widgetConfiguration;
 
-    const parseResult: { value: any; isValid: boolean } = useMemo(() => {
+    const parsedValue = useMemo(() => {
         const parsedValue = parseLinkedTwinExpression(valueExpression, twins);
         if (parsedValue === '') {
             if (mode === BehaviorModalMode.viewer) {
-                return { value: null, isValid: false };
+                return null;
             } else {
-                return {
-                    value:
-                        placeholderValues?.[type] ??
-                        getValuePlaceholders(t)[type],
-                    isValid: true
-                };
+                return (
+                    placeholderValues?.[type] ?? getValuePlaceholders(t)[type]
+                );
             }
         } else {
-            return { value: parsedValue, isValid: true };
+            return parsedValue;
         }
     }, [valueExpression, twins, mode, placeholderValues, type, t]);
 
@@ -64,8 +61,7 @@ export const ValueWidget: React.FC<IProp> = ({ widget, placeholderValues }) => {
             <div className={styles.expressionValueContainer}>
                 <FormattedValue
                     locale={i18n.language as Locale}
-                    value={parseResult.value}
-                    isValid={parseResult.isValid}
+                    value={parsedValue}
                     type={type}
                 />
             </div>


### PR DESCRIPTION
### Summary of changes 🔍 
- fixes #416 
- Support for values which parse to 0, previously treated as falsy rendering a value placeholder
- Support for unset twin values, now rendering as `'--'` rather than a value placeholder

## Unset property
![image](https://user-images.githubusercontent.com/18181049/169898277-fa3b0db5-daed-40c5-8cd7-3397f82f9097.png)

## 0 value
![image](https://user-images.githubusercontent.com/18181049/169898374-1b40fc12-45d8-4080-9dd7-1806e4877203.png)

### Testing 🧪
- Create a numeric value widget
- Set the value to 0 (update the twin property driving the expression such that the expression results in 0) & verify the value widget shows 0
- Unset the property on the twin that is linked to the value widget & verify the widget shows '--' rather than '123' or whatever the value placeholder for that type is

### Checklist ✔️
- [x] Linked associated issue (if present)
- [x] Added relevant labels
- [x] Requested developer reviews
- [ ] Request UI review from design / PM
- [ ] Verify all code checks are passing