### PR TITLE
Swallow non 2xx response on CORS check

### DIFF
--- a/src/Pages/ADT3DScenePage/ADT3DScenePage.tsx
+++ b/src/Pages/ADT3DScenePage/ADT3DScenePage.tsx
@@ -434,11 +434,17 @@ const ADT3DScenePageBase: React.FC<IADT3DScenePageProps> = ({
                 });
             } else {
                 const errors: Array<IComponentError> = getCorsPropertiesAdapterData?.adapterResult.getErrors();
-                errorCallbackSetRef.current = false;
-                dispatch({
-                    type: SET_ERRORS,
-                    payload: errors
-                });
+                // Only set errors if it is a CORSError (2xx, with invalid CORS configuration)
+                // This means we will swallow non 2xx responses when we check CORS
+                // We want to swallow all non-2xx errors on checking CORS because users could have valid access to the content of a container
+                // But may not have read access to CORS properties (which results in 403)
+                if (errors?.[0]?.type === ComponentErrorType.CORSError) {
+                    errorCallbackSetRef.current = false;
+                    dispatch({
+                        type: SET_ERRORS,
+                        payload: errors
+                    });
+                }
             }
         } else if (getCorsPropertiesAdapterData?.adapterResult.getData()) {
             dispatch({

--- a/src/Pages/ADT3DScenePage/ADT3DScenePage.tsx
+++ b/src/Pages/ADT3DScenePage/ADT3DScenePage.tsx
@@ -434,10 +434,11 @@ const ADT3DScenePageBase: React.FC<IADT3DScenePageProps> = ({
                 });
             } else {
                 const errors: Array<IComponentError> = getCorsPropertiesAdapterData?.adapterResult.getErrors();
-                // Only set errors if it is a CORSError (2xx, with invalid CORS configuration)
-                // This means we will swallow non 2xx responses when we check CORS
+                // Only set errors if it is a genuine CORSError (2xx, with invalid CORS configuration)
+                // This means we will swallow non-2xx errors when we check CORS
                 // We want to swallow all non-2xx errors on checking CORS because users could have valid access to the content of a container
                 // But may not have read access to CORS properties (which results in 403)
+                // This means that users who cannot read CORS configuration may not be able to load 3D models if CORS is misconfigured
                 if (errors?.[0]?.type === ComponentErrorType.CORSError) {
                     errorCallbackSetRef.current = false;
                     dispatch({

--- a/src/Pages/ADT3DScenePage/ADT3DScenePage.tsx
+++ b/src/Pages/ADT3DScenePage/ADT3DScenePage.tsx
@@ -445,6 +445,13 @@ const ADT3DScenePageBase: React.FC<IADT3DScenePageProps> = ({
                         type: SET_ERRORS,
                         payload: errors
                     });
+                } else {
+                    dispatch({
+                        type: SET_ERRORS,
+                        payload: []
+                    });
+                    errorCallbackSetRef.current = false;
+                    scenesConfig.callAdapter();
                 }
             }
         } else if (getCorsPropertiesAdapterData?.adapterResult.getData()) {


### PR DESCRIPTION
### Summary of changes 🔍 
This is a mitigation for issue [494](https://github.com/microsoft/iot-cardboard-js/issues/494)

It _does not solve the issue_ in general, it just means that we will swallow errors that occur when checking the CORS configuration, unless it is a valid 200 response and is genuinely misconfigured. 

### Testing 🧪
Find yourself a storage container that you are a reader and data owner of (but not owner).  Use it against main, notice that it 403s irreparably, despite the configuration being valid.  Pull this branch down.  Notice that you can get past the 403, but if CORS is misconfigured your environment will behave erratically (you will not be able to load 3D files)

### Checklist ✔️
- [ ] Linked associated issue (if present)
- [ ] Added relevant labels
- [ ] Requested developer reviews
- [ ] Request UI review from design / PM
- [ ] Verify all code checks are passing