### PR TITLE
Icon picker focus state fix

### DIFF
--- a/src/Components/Pickers/IconSelectButton/IconPicker.styles.ts
+++ b/src/Components/Pickers/IconSelectButton/IconPicker.styles.ts
@@ -9,7 +9,10 @@ export const getStyles = (props: IIconPickerStyleProps): IIconPickerStyles => {
                     {
                         color: `${theme.semanticColors.bodyText} !important`,
                         border: `1px solid ${theme.semanticColors.inputBorder}`,
-                        borderRadius: '50%'
+                        borderRadius: '50%',
+                        ':after': {
+                            borderRadius: '50%'
+                        }
                     },
                     isItemSelected && {
                         borderWidth: 3


### PR DESCRIPTION
### Summary of changes 🔍 
Fixed Icon picker focus state, changed from being a square to a circle:
![image](https://user-images.githubusercontent.com/55852250/170388761-326d5280-85ad-4239-8a5b-d5fe70979182.png)

Resolves: #294 

### Testing 🧪
1. Open Behaviors form
2. Go to alerts tab
3. Focus an icon in icon callout, should have round focus ring around it.

### Checklist ✔️
- [ ] Linked associated issue (if present)
- [ ] Added relevant labels
- [ ] Requested developer reviews
- [ ] Request UI review from design / PM
- [ ] Verify all code checks are passing