### PR TITLE
Close modal on scene change

### DIFF
--- a/src/Components/ADT3DViewer/ADT3DViewer.tsx
+++ b/src/Components/ADT3DViewer/ADT3DViewer.tsx
@@ -597,7 +597,7 @@ const ADT3DViewerBase: React.FC<IADT3DViewerProps> = ({
                 <SceneBreadcrumbFactory
                     sceneId={sceneId}
                     sceneName={sceneName}
-                    onCloseBehaviorsModal={onCloseBehaviorsModal}
+                    onSceneChange={onCloseBehaviorsModal}
                 />
                 {/* Left panel */}
                 <ViewerElementsPanelRenderer

--- a/src/Components/ADT3DViewer/ADT3DViewer.tsx
+++ b/src/Components/ADT3DViewer/ADT3DViewer.tsx
@@ -597,6 +597,7 @@ const ADT3DViewerBase: React.FC<IADT3DViewerProps> = ({
                 <SceneBreadcrumbFactory
                     sceneId={sceneId}
                     sceneName={sceneName}
+                    onCloseBehaviorsModal={onCloseBehaviorsModal}
                 />
                 {/* Left panel */}
                 <ViewerElementsPanelRenderer

--- a/src/Components/SceneBreadcrumb/BaseBreadcrumb.tsx
+++ b/src/Components/SceneBreadcrumb/BaseBreadcrumb.tsx
@@ -19,7 +19,8 @@ export const BaseBreadcrumb: React.FC<IBaseBreadcrumbProps> = ({
     sceneId,
     classNames,
     onSceneClick,
-    onCancelForm
+    onCancelForm,
+    onCloseBehaviorsModal
 }) => {
     const theme = useTheme();
     const { t } = useTranslation();
@@ -42,7 +43,12 @@ export const BaseBreadcrumb: React.FC<IBaseBreadcrumbProps> = ({
                 />
             );
         } else if (isAtSceneRoot && scenePageContext) {
-            return <SceneDropdown sceneId={sceneId} />;
+            return (
+                <SceneDropdown
+                    sceneId={sceneId}
+                    onCloseBehaviorsModal={onCloseBehaviorsModal}
+                />
+            );
         } else return defaultRender(props);
     };
 

--- a/src/Components/SceneBreadcrumb/BaseBreadcrumb.tsx
+++ b/src/Components/SceneBreadcrumb/BaseBreadcrumb.tsx
@@ -20,7 +20,7 @@ export const BaseBreadcrumb: React.FC<IBaseBreadcrumbProps> = ({
     classNames,
     onSceneClick,
     onCancelForm,
-    onCloseBehaviorsModal
+    onSceneChange
 }) => {
     const theme = useTheme();
     const { t } = useTranslation();
@@ -46,7 +46,7 @@ export const BaseBreadcrumb: React.FC<IBaseBreadcrumbProps> = ({
             return (
                 <SceneDropdown
                     sceneId={sceneId}
-                    onCloseBehaviorsModal={onCloseBehaviorsModal}
+                    onSceneChange={onSceneChange}
                 />
             );
         } else return defaultRender(props);

--- a/src/Components/SceneBreadcrumb/Internal/SceneDropdown.tsx
+++ b/src/Components/SceneBreadcrumb/Internal/SceneDropdown.tsx
@@ -7,7 +7,7 @@ import { SceneDropdownProps } from './SceneDropdown.types';
 
 const SceneDropdown: React.FC<SceneDropdownProps> = ({
     sceneId,
-    onCloseBehaviorsModal
+    onSceneChange
 }) => {
     const scenePageContext = useContext(ADT3DScenePageContext);
     if (!scenePageContext) {
@@ -24,8 +24,8 @@ const SceneDropdown: React.FC<SceneDropdownProps> = ({
         : [];
     const onChange = useCallback(
         (_e, option: IDropdownOption) => {
-            if (onCloseBehaviorsModal) {
-                onCloseBehaviorsModal();
+            if (onSceneChange) {
+                onSceneChange();
             }
             scenePageContext.handleOnSceneSwap(String(option.key));
         },

--- a/src/Components/SceneBreadcrumb/Internal/SceneDropdown.tsx
+++ b/src/Components/SceneBreadcrumb/Internal/SceneDropdown.tsx
@@ -5,7 +5,10 @@ import { ADT3DScenePageContext } from '../../../Pages/ADT3DScenePage/ADT3DSceneP
 import { dropdownStyles } from './SceneDropdown.styles';
 import { SceneDropdownProps } from './SceneDropdown.types';
 
-const SceneDropdown: React.FC<SceneDropdownProps> = ({ sceneId }) => {
+const SceneDropdown: React.FC<SceneDropdownProps> = ({
+    sceneId,
+    onCloseBehaviorsModal
+}) => {
     const scenePageContext = useContext(ADT3DScenePageContext);
     if (!scenePageContext) {
         return null;
@@ -21,6 +24,9 @@ const SceneDropdown: React.FC<SceneDropdownProps> = ({ sceneId }) => {
         : [];
     const onChange = useCallback(
         (_e, option: IDropdownOption) => {
+            if (onCloseBehaviorsModal) {
+                onCloseBehaviorsModal();
+            }
             scenePageContext.handleOnSceneSwap(String(option.key));
         },
         [scenePageContext]

--- a/src/Components/SceneBreadcrumb/Internal/SceneDropdown.types.tsx
+++ b/src/Components/SceneBreadcrumb/Internal/SceneDropdown.types.tsx
@@ -1,3 +1,4 @@
 export interface SceneDropdownProps {
     sceneId: string;
+    onCloseBehaviorsModal?: () => void;
 }

--- a/src/Components/SceneBreadcrumb/Internal/SceneDropdown.types.tsx
+++ b/src/Components/SceneBreadcrumb/Internal/SceneDropdown.types.tsx
@@ -1,4 +1,4 @@
 export interface SceneDropdownProps {
     sceneId: string;
-    onCloseBehaviorsModal?: () => void;
+    onSceneChange?: () => void;
 }

--- a/src/Components/SceneBreadcrumb/SceneBreadcrumb.types.ts
+++ b/src/Components/SceneBreadcrumb/SceneBreadcrumb.types.ts
@@ -15,7 +15,7 @@ export interface IBaseBreadcrumbProps {
     classNames: BreadcrumbClassNames;
     onSceneClick?: () => void;
     onCancelForm?: () => void;
-    onCloseBehaviorsModal?: () => void;
+    onSceneChange?: () => void;
     onRenderSceneItem?: (props?: IBreadcrumbItem) => JSX.Element;
 }
 
@@ -24,5 +24,5 @@ export interface ISceneBreadcrumbFactoryProps {
     sceneName: string;
     builderMode?: ADT3DSceneBuilderMode;
     onSceneClick?: () => void;
-    onCloseBehaviorsModal?: () => void;
+    onSceneChange?: () => void;
 }

--- a/src/Components/SceneBreadcrumb/SceneBreadcrumb.types.ts
+++ b/src/Components/SceneBreadcrumb/SceneBreadcrumb.types.ts
@@ -15,6 +15,7 @@ export interface IBaseBreadcrumbProps {
     classNames: BreadcrumbClassNames;
     onSceneClick?: () => void;
     onCancelForm?: () => void;
+    onCloseBehaviorsModal?: () => void;
     onRenderSceneItem?: (props?: IBreadcrumbItem) => JSX.Element;
 }
 
@@ -23,4 +24,5 @@ export interface ISceneBreadcrumbFactoryProps {
     sceneName: string;
     builderMode?: ADT3DSceneBuilderMode;
     onSceneClick?: () => void;
+    onCloseBehaviorsModal?: () => void;
 }

--- a/src/Components/SceneBreadcrumb/SceneBreadcrumbFactory.tsx
+++ b/src/Components/SceneBreadcrumb/SceneBreadcrumbFactory.tsx
@@ -35,7 +35,7 @@ const SceneBreadcrumbFactory: React.FC<ISceneBreadcrumbFactoryProps> = ({
     sceneName,
     builderMode,
     onSceneClick,
-    onCloseBehaviorsModal
+    onSceneChange
 }) => {
     const { t } = useTranslation();
 
@@ -215,7 +215,7 @@ const SceneBreadcrumbFactory: React.FC<ISceneBreadcrumbFactoryProps> = ({
                 isAtSceneRoot={true}
                 sceneName={sceneName}
                 sceneId={sceneId}
-                onCloseBehaviorsModal={onCloseBehaviorsModal}
+                onSceneChange={onSceneChange}
                 classNames={{
                     root: 'cb-viewer-breadcrumb-container',
                     breadcrumb: 'cb-viewer-breadcrumb',

--- a/src/Components/SceneBreadcrumb/SceneBreadcrumbFactory.tsx
+++ b/src/Components/SceneBreadcrumb/SceneBreadcrumbFactory.tsx
@@ -34,7 +34,8 @@ const SceneBreadcrumbFactory: React.FC<ISceneBreadcrumbFactoryProps> = ({
     sceneId,
     sceneName,
     builderMode,
-    onSceneClick
+    onSceneClick,
+    onCloseBehaviorsModal
 }) => {
     const { t } = useTranslation();
 
@@ -214,6 +215,7 @@ const SceneBreadcrumbFactory: React.FC<ISceneBreadcrumbFactoryProps> = ({
                 isAtSceneRoot={true}
                 sceneName={sceneName}
                 sceneId={sceneId}
+                onCloseBehaviorsModal={onCloseBehaviorsModal}
                 classNames={{
                     root: 'cb-viewer-breadcrumb-container',
                     breadcrumb: 'cb-viewer-breadcrumb',


### PR DESCRIPTION
### Summary of changes 🔍 
On view mode, when a user changes scene and has a selected element a pop-over persisted. Now the pop-over no longer persists the scene swap.

Resolves: #496 


### Testing 🧪
1. Go to view mode
2. Select an item
3. Change scenes with breadcrumb
4. Pop-over should no longer appear

### Checklist ✔️
- [x] Linked associated issue (if present)
- [x] Added relevant labels
- [x] Requested developer reviews
- [x] Request UI review from design / PM
- [ ] Verify all code checks are passing