### PR TITLE
Bug fix: Fix resolution of alias twin ids

### DIFF
--- a/src/Components/ModelledPropertyBuilder/ModelledPropertyBuilder.types.ts
+++ b/src/Components/ModelledPropertyBuilder/ModelledPropertyBuilder.types.ts
@@ -35,7 +35,7 @@ export interface ResolvedTwinIdParams {
     primaryTwinIds: string[];
 
     /** Optional map of alias to twinIds mappings. */
-    aliasedTwinMap?: Record<string, string>;
+    aliasedTwinIds?: string[];
 }
 
 export interface ModelledPropertyBuilderProps {

--- a/src/Components/ModelledPropertyBuilder/useModelledProperties.ts
+++ b/src/Components/ModelledPropertyBuilder/useModelledProperties.ts
@@ -43,7 +43,7 @@ export const useModelledProperties = ({
         if (isResolvedTwinIdMode(twinIdParams)) {
             return {
                 primaryTwinIds: twinIdParams.primaryTwinIds,
-                aliasedTwinMap: twinIdParams.aliasedTwinMap ?? {}
+                aliasedTwinIds: twinIdParams.aliasedTwinIds ?? []
             };
         } else {
             // Create a snapshot of the edited config by commiting the alias & behavior changes
@@ -67,7 +67,7 @@ export const useModelledProperties = ({
     }, [twinIdParams]);
 
     const disableAliasedTwins =
-        (isResolvedTwinIdMode(twinIdParams) && !twinIdParams.aliasedTwinMap) ||
+        (isResolvedTwinIdMode(twinIdParams) && !twinIdParams.aliasedTwinIds) ||
         (!isResolvedTwinIdMode(twinIdParams) &&
             twinIdParams.disableAliasedTwins);
 
@@ -82,7 +82,7 @@ export const useModelledProperties = ({
                 adapter,
                 primaryTwinIds: twinIds.primaryTwinIds,
                 ...(!disableAliasedTwins && {
-                    aliasedTwinMap: twinIds.aliasedTwinMap
+                    aliasedTwinIds: twinIds.aliasedTwinIds
                 }),
                 allowedPropertyValueTypes
             });
@@ -97,7 +97,7 @@ export const useModelledProperties = ({
         return () => {
             isMounted = false;
         };
-    }, [twinIds.primaryTwinIds, twinIds.aliasedTwinMap]);
+    }, [twinIds.primaryTwinIds, twinIds.aliasedTwinIds]);
 
     return { isLoading, modelledProperties };
 };


### PR DESCRIPTION
### Summary of changes 🔍 
#### The problem
There was a bug in our resolution of the aliased twin mappings where we only included the twinId of the last element assigned to an alias. This was due to an issue where we were returning a map of alias name to twin ids, but since multiple elements on a behavior will map to the same alias, that means we only end up returning the last twinId instead of all of them. 
[Bug 14558938](https://msazure.visualstudio.com/One/_workitems/edit/14558938): Twin aliases don't work....

#### The fix
Return an array of the twin ids that aliases resolve to. This is the only info we ever used anyways so it's pretty straightforward.

Before: 
![image](https://user-images.githubusercontent.com/57726991/171286718-8e25c513-6a7c-4dd3-990e-690094c02edd.png)


After:
![image](https://user-images.githubusercontent.com/57726991/171286634-9f4082c9-542a-4288-a264-825287ce98cf.png)


### Testing 🧪
 > [ Add any special instructions needed to test or view your changes such as environment URLs or other config details. ]

### Checklist ✔️
- [ ] Linked associated issue (if present)
- [ ] Added relevant labels
- [ ] Requested developer reviews
- [ ] Request UI review from design / PM
- [ ] Verify all code checks are passing