### PR TITLE
Fix: Aliased Twin properties

### DIFF
--- a/src/Adapters/ADTAdapter.ts
+++ b/src/Adapters/ADTAdapter.ts
@@ -977,13 +977,20 @@ export default class ADTAdapter implements IADTAdapter {
                                     config,
                                     sceneId
                                 );
+                                // Add primary twin Ids
                                 primaryTwinIds.forEach(
                                     (tid) =>
                                         (twinIdToResolvedTwinMap[tid] = true)
                                 );
-                                Object.entries(aliasedTwinMap).forEach(
-                                    (atm) =>
-                                        (twinIdToResolvedTwinMap[atm[1]] = true)
+
+                                // Add alias twin Ids
+                                Object.values(
+                                    aliasedTwinMap
+                                ).forEach((aliasIds) =>
+                                    aliasIds.forEach(
+                                        (id) =>
+                                            (twinIdToResolvedTwinMap[id] = true)
+                                    )
                                 );
                             }
                         }

--- a/src/Components/ModelledPropertyBuilder/ModelledPropertyBuilder.types.ts
+++ b/src/Components/ModelledPropertyBuilder/ModelledPropertyBuilder.types.ts
@@ -35,7 +35,7 @@ export interface ResolvedTwinIdParams {
     primaryTwinIds: string[];
 
     /** Optional map of alias to twinIds mappings. */
-    aliasedTwinMap?: Record<string, string>;
+    aliasedTwinMap?: Record<string, string[]>;
 }
 
 export interface ModelledPropertyBuilderProps {
@@ -124,7 +124,7 @@ export interface IModelledProperties {
 
 export interface ITagModelMap {
     [PRIMARY_TWIN_NAME]: string[];
-    aliasTags?: Record<string, string>;
+    aliasTags?: Record<string, string[]>;
 }
 
 export type PropertyExpression = {

--- a/src/Models/Classes/ViewerConfigUtility.ts
+++ b/src/Models/Classes/ViewerConfigUtility.ts
@@ -345,12 +345,12 @@ abstract class ViewerConfigUtility {
         behavior: IBehavior,
         config: I3DScenesConfig,
         sceneId: string
-    ): { primaryTwinIds: string[]; aliasedTwinMap: Record<string, string> } {
+    ): { primaryTwinIds: string[]; aliasedTwinMap: Record<string, string[]> } {
         const scene = config.configuration.scenes.find(
             (scene) => scene.id === sceneId
         );
-        const primaryTwinIds = new Map();
-        let aliasedTwinMap: Record<string, string> = {};
+        const primaryTwinIds = new Set<string>();
+        const internalAliasedTwinUniqueMap: Record<string, Set<string>> = {};
 
         // Get all element Ids associated with the behavior
         const elementIds = ViewerConfigUtility.getMappingIdsForBehavior(
@@ -364,35 +364,44 @@ abstract class ViewerConfigUtility {
                 // Check if objects Ids on element intersect with elementIds on behavior
                 if (elementIds.includes(elementInScene.id)) {
                     // Add elements primary twin
-                    primaryTwinIds.set(elementInScene.primaryTwinID, '');
+                    primaryTwinIds.add(elementInScene.primaryTwinID);
 
                     // Only add element alias if behavior contains alias
                     if (behavior.twinAliases && elementInScene.twinAliases) {
-                        const twinAliasesOnBehavior = {};
-
                         for (const [
                             elementAlias,
                             aliasedTwinId
                         ] of Object.entries(elementInScene.twinAliases)) {
                             if (behavior.twinAliases.includes(elementAlias)) {
-                                twinAliasesOnBehavior[
-                                    elementAlias
-                                ] = aliasedTwinId;
+                                if (
+                                    elementAlias in internalAliasedTwinUniqueMap
+                                ) {
+                                    internalAliasedTwinUniqueMap[
+                                        elementAlias
+                                    ].add(aliasedTwinId);
+                                } else {
+                                    internalAliasedTwinUniqueMap[
+                                        elementAlias
+                                    ] = new Set([aliasedTwinId]);
+                                }
                             }
                         }
-
-                        // Add elements twin aliases
-                        aliasedTwinMap = {
-                            ...aliasedTwinMap,
-                            ...twinAliasesOnBehavior
-                        };
                     }
                 }
             });
 
+        const aliasedTwinMap: Record<string, string[]> = {};
+
+        // Transform unique set of alias Ids into string array
+        for (const key of Object.keys(internalAliasedTwinUniqueMap)) {
+            aliasedTwinMap[key] = Array.from(
+                internalAliasedTwinUniqueMap[key].values()
+            );
+        }
+
         return {
             aliasedTwinMap,
-            primaryTwinIds: Array.from(primaryTwinIds.keys())
+            primaryTwinIds: Array.from(primaryTwinIds.values())
         };
     }
 


### PR DESCRIPTION
### Summary of changes 🔍 
- Fixes [ADO bug (Twin Aliases don't work...)](https://msazure.visualstudio.com/One/_workitems/edit/14558938) by updating `getTwinIdsForBehaviorInScene` method to return Ids for all aliased twins.  Refactored modelled property builder to account for this change.  Both **PrimaryTwins** & **AliasedTwins** will now show a merged set of properties derived from the combined models of each referenced twin.  The image below shows the ModelledPropertyBuilder merging properties for `TestAlias` where `A` are the properties from a Tesla model & `B` are the properties from a Pasteurization machine model.

  <img width="260" alt="image" src="https://user-images.githubusercontent.com/18181049/171510357-7fcc1898-c810-4488-b5ed-dd91e4926b44.png">

- Fixes [ADO bug (Aliased twins intellisense exposes the PrimaryTwin's properties)](https://msazure.visualstudio.com/One/_workitems/edit/14547801).  This seems to fix this bug as well.  Unless there is a special edge case that is causing intellisense aliases from breaking.
  <img width="321" alt="image" src="https://user-images.githubusercontent.com/18181049/171510074-f841e738-7dd8-4f9e-805d-0c3849a25129.png">



### Testing 🧪
- Create two element in the scene
- Create a behavior and add both elements to the behavior
- Navigate to the Twins tab of the behavior and create a new twin alias with distinct twin Ids for each attached element
  For example: 

  <img width="286" alt="image" src="https://user-images.githubusercontent.com/18181049/171510955-9b6c1906-500b-43f8-a8ff-cad515cbbbd2.png">

- Check the property dropdown (Status tab) & Intellisense control (Alerts tab) and verify that properties from the primary & aliased twins look correct.  Also verify that [aliased twin intellisense is working](https://msazure.visualstudio.com/One/_workitems/edit/14547801).

- Create a value widget using an aliased property.  Verify that in the viewer, elements on the behavior you created show data for the value widget (should only show data if the element's primary twin / alias actually has the property you selected)
- I did an additional sanity check by setting up a string value widget & visualizing the $dtId property for the alias I set up.  This shows that the runtime is fetching data for the different aliased twin Ids and shows them in the popover.
  <img width="279" alt="image" src="https://user-images.githubusercontent.com/18181049/171512012-29397cc0-a98e-484a-a70a-390c73db71aa.png">
  <img width="256" alt="image" src="https://user-images.githubusercontent.com/18181049/171511910-3f2e9714-0020-48b5-9fcf-6807c805535c.png">
  <img width="259" alt="image" src="https://user-images.githubusercontent.com/18181049/171511935-0334a78d-e639-47fb-9780-e10bb65f995f.png">


### Checklist ✔️
- [x] Linked associated issue (if present)
- [x] Added relevant labels
- [x] Requested developer reviews
- [ ] Request UI review from design / PM
- [ ] Verify all code checks are passing