### PR TITLE
"clear status" button

### DIFF
--- a/src/Components/ADT3DSceneBuilder/Internal/Behaviors/Internal/StatusTab.tsx
+++ b/src/Components/ADT3DSceneBuilder/Internal/Behaviors/Internal/StatusTab.tsx
@@ -171,6 +171,7 @@ const StatusTab: React.FC<IStatusTabProps> = ({ onValidityChange }) => {
                         selectedElements
                     }}
                     mode={ModelledPropertyBuilderMode.TOGGLE}
+                    isClearEnabled={true}
                     propertyExpression={{
                         expression:
                             getStatusFromBehavior(behaviorToEdit)

--- a/src/Components/ModelledPropertyBuilder/ModelledPropertyBuilder.stories.tsx
+++ b/src/Components/ModelledPropertyBuilder/ModelledPropertyBuilder.stories.tsx
@@ -114,6 +114,15 @@ ToggleMode.args = {
     mode: ModelledPropertyBuilderMode.TOGGLE
 };
 
+export const ToggleModeWithClearButton = Template.bind(
+    {}
+) as ModelledPropertyBuilderStory;
+
+ToggleModeWithClearButton.args = {
+    mode: ModelledPropertyBuilderMode.TOGGLE,
+    clearButton: 'Clear'
+};
+
 export const ToggleModeInitialValue = Template.bind(
     {}
 ) as ModelledPropertyBuilderStory;

--- a/src/Components/ModelledPropertyBuilder/ModelledPropertyBuilder.stories.tsx
+++ b/src/Components/ModelledPropertyBuilder/ModelledPropertyBuilder.stories.tsx
@@ -120,7 +120,7 @@ export const ToggleModeWithClearButton = Template.bind(
 
 ToggleModeWithClearButton.args = {
     mode: ModelledPropertyBuilderMode.TOGGLE,
-    clearButton: 'Clear'
+    isClearEnabled: true
 };
 
 export const ToggleModeInitialValue = Template.bind(

--- a/src/Components/ModelledPropertyBuilder/ModelledPropertyBuilder.styles.ts
+++ b/src/Components/ModelledPropertyBuilder/ModelledPropertyBuilder.styles.ts
@@ -104,7 +104,7 @@ export const propertyExpressionLabelStyles: Partial<ILabelStyles> = {
 };
 
 export const getActionButtonStyles = memoizeFunction(
-    (theme: Theme): Partial<ILabelStyles> => ({
+    (theme: Theme): Partial<IButtonStyles> => ({
         root: {
             color: theme.palette.themePrimary,
             fontWeight: FontWeights.semibold,

--- a/src/Components/ModelledPropertyBuilder/ModelledPropertyBuilder.styles.ts
+++ b/src/Components/ModelledPropertyBuilder/ModelledPropertyBuilder.styles.ts
@@ -8,7 +8,9 @@ import {
     IChoiceGroupOptionStyles,
     FontWeights,
     FontSizes,
-    ILabelStyles
+    ILabelStyles,
+    IButtonStyles,
+    Theme
 } from '@fluentui/react';
 
 export const modelledPropertyBuilderClassPrefix = 'cb-modelledpropertybuilder';
@@ -100,3 +102,18 @@ export const propertyExpressionLabelStyles: Partial<ILabelStyles> = {
         paddingTop: 5
     }
 };
+
+export const getActionButtonStyles = memoizeFunction(
+    (theme: Theme): Partial<IButtonStyles> => ({
+        root: {
+            color: theme.palette.themePrimary,
+            height: 32,
+            paddingLeft: 0
+            // fontWeight: FontWeights.semibold
+        }
+        // flexContainer: { height: 32 },
+        // label: {
+        //     margin: 0
+        // }
+    })
+);

--- a/src/Components/ModelledPropertyBuilder/ModelledPropertyBuilder.styles.ts
+++ b/src/Components/ModelledPropertyBuilder/ModelledPropertyBuilder.styles.ts
@@ -104,16 +104,16 @@ export const propertyExpressionLabelStyles: Partial<ILabelStyles> = {
 };
 
 export const getActionButtonStyles = memoizeFunction(
-    (theme: Theme): Partial<IButtonStyles> => ({
+    (theme: Theme): Partial<ILabelStyles> => ({
         root: {
             color: theme.palette.themePrimary,
-            height: 32,
-            paddingLeft: 0
-            // fontWeight: FontWeights.semibold
+            fontWeight: FontWeights.semibold,
+            fontStyle: 'italic',
+            textDecoration: 'underline',
+            fontSize: FontSizes.size14,
+            paddingBottom: 0,
+            paddingTop: 5,
+            height: 'auto'
         }
-        // flexContainer: { height: 32 },
-        // label: {
-        //     margin: 0
-        // }
     })
 );

--- a/src/Components/ModelledPropertyBuilder/ModelledPropertyBuilder.tsx
+++ b/src/Components/ModelledPropertyBuilder/ModelledPropertyBuilder.tsx
@@ -28,6 +28,7 @@ import {
     IChoiceGroupOption,
     SpinnerSize,
     Text,
+    ActionButton,
     FontSizes
 } from '@fluentui/react';
 import { useTranslation } from 'react-i18next';
@@ -59,6 +60,7 @@ const ModelledPropertyBuilder: React.FC<ModelledPropertyBuilderProps> = ({
     intellisensePlaceholder,
     customLabel,
     customLabelTooltip,
+    clearButton,
     onInternalModeChanged
 }) => {
     const { t } = useTranslation();
@@ -140,6 +142,12 @@ const ModelledPropertyBuilder: React.FC<ModelledPropertyBuilderProps> = ({
         },
         [onChange]
     );
+
+    const onClickClearButton = useCallback(() => {
+        onChange({
+            expression: ''
+        });
+    }, [onChange]);
 
     const getIntellisenseProperty: GetPropertyNamesFunc = useCallback(
         (_twinId, { leafToken, tokens }) => {
@@ -246,6 +254,14 @@ const ModelledPropertyBuilder: React.FC<ModelledPropertyBuilderProps> = ({
                                 iconName: customLabelTooltip.iconName || 'Info'
                             }}
                         />
+                    )}
+                    {clearButton && (
+                        <ActionButton
+                            styles={propertyExpressionLabelStyles}
+                            onClick={onClickClearButton}
+                        >
+                            {customLabel ?? t('Clear')}
+                        </ActionButton>
                     )}
                 </Stack>
                 {(mode === ModelledPropertyBuilderMode.INTELLISENSE ||

--- a/src/Components/ModelledPropertyBuilder/ModelledPropertyBuilder.tsx
+++ b/src/Components/ModelledPropertyBuilder/ModelledPropertyBuilder.tsx
@@ -262,17 +262,14 @@ const ModelledPropertyBuilder: React.FC<ModelledPropertyBuilderProps> = ({
                         />
                     )}
                     {isClearEnabled && (
-                        // <ActionButton
-                        //     styles={propertyExpressionLabelStyles}
-                        //     onClick={onClickClearButton}
-                        // >
-                        //     {customLabel ?? t('Clear')}
-                        // </ActionButton>
                         <ActionButton
                             styles={actionButtonStyles}
-                            // className={styles.dropdownTitleText}
-                            text={'Clear'}
-                            // data-testid={'widgetForm-addWidget'}
+                            text={t(
+                                '3dSceneBuilder.ModelledPropertyBuilder.clearButtonText'
+                            )}
+                            data-testid={
+                                'modelled-property-builder-clear-button'
+                            }
                             onClick={onClickClearButton}
                         />
                     )}

--- a/src/Components/ModelledPropertyBuilder/ModelledPropertyBuilder.tsx
+++ b/src/Components/ModelledPropertyBuilder/ModelledPropertyBuilder.tsx
@@ -16,7 +16,8 @@ import {
     choiceGroupOptionStyles,
     choiceGroupStyles,
     getStyles,
-    propertyExpressionLabelStyles
+    propertyExpressionLabelStyles,
+    getActionButtonStyles
 } from './ModelledPropertyBuilder.styles';
 import {
     DropdownMenuItemType,
@@ -29,7 +30,8 @@ import {
     SpinnerSize,
     Text,
     ActionButton,
-    FontSizes
+    FontSizes,
+    useTheme
 } from '@fluentui/react';
 import { useTranslation } from 'react-i18next';
 import { useModelledProperties } from './useModelledProperties';
@@ -60,7 +62,7 @@ const ModelledPropertyBuilder: React.FC<ModelledPropertyBuilderProps> = ({
     intellisensePlaceholder,
     customLabel,
     customLabelTooltip,
-    clearButton,
+    isClearEnabled,
     onInternalModeChanged
 }) => {
     const { t } = useTranslation();
@@ -147,7 +149,8 @@ const ModelledPropertyBuilder: React.FC<ModelledPropertyBuilderProps> = ({
         onChange({
             expression: ''
         });
-    }, [onChange]);
+        setInternalMode(ModelledPropertyBuilderMode.PROPERTY_SELECT);
+    }, [onChange, propertyExpression]);
 
     const getIntellisenseProperty: GetPropertyNamesFunc = useCallback(
         (_twinId, { leafToken, tokens }) => {
@@ -234,6 +237,9 @@ const ModelledPropertyBuilder: React.FC<ModelledPropertyBuilderProps> = ({
         [modelledProperties?.nestedFormat]
     );
 
+    const theme = useTheme();
+    const actionButtonStyles = getActionButtonStyles(theme);
+
     return (
         <Stack tokens={{ childrenGap: 4 }} className={styles.root}>
             <div className={styles.labelContainer}>
@@ -255,13 +261,20 @@ const ModelledPropertyBuilder: React.FC<ModelledPropertyBuilderProps> = ({
                             }}
                         />
                     )}
-                    {clearButton && (
+                    {isClearEnabled && (
+                        // <ActionButton
+                        //     styles={propertyExpressionLabelStyles}
+                        //     onClick={onClickClearButton}
+                        // >
+                        //     {customLabel ?? t('Clear')}
+                        // </ActionButton>
                         <ActionButton
-                            styles={propertyExpressionLabelStyles}
+                            styles={actionButtonStyles}
+                            // className={styles.dropdownTitleText}
+                            text={'Clear'}
+                            // data-testid={'widgetForm-addWidget'}
                             onClick={onClickClearButton}
-                        >
-                            {customLabel ?? t('Clear')}
-                        </ActionButton>
+                        />
                     )}
                 </Stack>
                 {(mode === ModelledPropertyBuilderMode.INTELLISENSE ||

--- a/src/Components/ModelledPropertyBuilder/ModelledPropertyBuilder.types.ts
+++ b/src/Components/ModelledPropertyBuilder/ModelledPropertyBuilder.types.ts
@@ -65,7 +65,7 @@ export interface ModelledPropertyBuilderProps {
     customLabelTooltip?: ITooltipCalloutContent;
 
     /** Clears all value ranges and sets properties to 'None' */
-    clearButton?: string;
+    isClearEnabled?: boolean;
 
     /** Visual indication that this field is required.  Defaults to false */
     required?: boolean;

--- a/src/Components/ModelledPropertyBuilder/ModelledPropertyBuilder.types.ts
+++ b/src/Components/ModelledPropertyBuilder/ModelledPropertyBuilder.types.ts
@@ -64,6 +64,9 @@ export interface ModelledPropertyBuilderProps {
     /** Custom tooltip next to the label for the control */
     customLabelTooltip?: ITooltipCalloutContent;
 
+    /** Clears all value ranges and sets properties to 'None' */
+    clearButton?: string;
+
     /** Visual indication that this field is required.  Defaults to false */
     required?: boolean;
 

--- a/src/Resources/Locales/cs.json
+++ b/src/Resources/Locales/cs.json
@@ -489,7 +489,8 @@
       "customExpression": "Vlastní (pokročilé)",
       "dropdownPlaceholder": "Vyberte nemovitost",
       "toggleLabel": "Režim výrazu",
-      "none": "Žádný"
+      "none": "Žádný",
+      "clearButtonText": "Jasný"
     },
     "numericExpressionPlaceholder": "Zadejte výraz, který se vyhodnotí jako číslo",
     "behaviorId": "ID chování",

--- a/src/Resources/Locales/de.json
+++ b/src/Resources/Locales/de.json
@@ -489,7 +489,8 @@
       "customExpression": "Benutzerdefiniert (erweitert)",
       "dropdownPlaceholder": "Wählen Sie eine Immobilie aus",
       "toggleLabel": "Ausdrucksmodus",
-      "none": "Nichts"
+      "none": "Nichts",
+      "clearButtonText": "Klar"
     },
     "numericExpressionPlaceholder": "Geben Sie einen Ausdruck ein, der zu einer Zahl ausgewertet wird.",
     "behaviorId": "Verhaltens-ID",

--- a/src/Resources/Locales/en.json
+++ b/src/Resources/Locales/en.json
@@ -494,7 +494,8 @@
             "customExpression": "Custom (advanced)",
             "dropdownPlaceholder": "Select a property",
             "toggleLabel": "Expression mode",
-            "none": "None"
+            "none": "None",
+            "clearButtonText": "Clear"
         },
         "numericExpressionPlaceholder": "Enter an expression which evaluates to a number",
         "behaviorId": "Behavior Id",

--- a/src/Resources/Locales/es.json
+++ b/src/Resources/Locales/es.json
@@ -489,7 +489,8 @@
       "customExpression": "Personalizado (avanzado)",
       "dropdownPlaceholder": "Seleccione una propiedad",
       "toggleLabel": "Modo de expresión",
-      "none": "Ninguno"
+      "none": "Ninguno",
+      "clearButtonText": "Claro"
     },
     "numericExpressionPlaceholder": "Introduzca una expresión que evalúe a un número",
     "behaviorId": "Identificador de comportamiento",

--- a/src/Resources/Locales/fr.json
+++ b/src/Resources/Locales/fr.json
@@ -489,7 +489,8 @@
       "customExpression": "Personnalisé (avancé)",
       "dropdownPlaceholder": "Sélectionner une propriété",
       "toggleLabel": "Mode d’expression",
-      "none": "Aucun"
+      "none": "Aucun",
+      "clearButtonText": "Clair"
     },
     "numericExpressionPlaceholder": "Entrez une expression qui s’évalue à un nombre",
     "behaviorId": "ID de comportement",

--- a/src/Resources/Locales/hu.json
+++ b/src/Resources/Locales/hu.json
@@ -489,7 +489,8 @@
       "customExpression": "Egyéni (speciális)",
       "dropdownPlaceholder": "Tulajdonság kijelölése",
       "toggleLabel": "Kifejezésmód",
-      "none": "Egyik sem"
+      "none": "Egyik sem",
+      "clearButtonText": "Világos"
     },
     "numericExpressionPlaceholder": "Számmá kiértékelt kifejezés megadása",
     "behaviorId": "Viselkedésazonosító",

--- a/src/Resources/Locales/it.json
+++ b/src/Resources/Locales/it.json
@@ -489,7 +489,8 @@
       "customExpression": "Personalizzato (avanzato)",
       "dropdownPlaceholder": "Seleziona una proprietà",
       "toggleLabel": "Modalità espressione",
-      "none": "Nessuno"
+      "none": "Nessuno",
+      "clearButtonText": "Chiaro"
     },
     "numericExpressionPlaceholder": "Immettere un'espressione che restituisce un numero",
     "behaviorId": "ID comportamento",

--- a/src/Resources/Locales/ja.json
+++ b/src/Resources/Locales/ja.json
@@ -489,7 +489,8 @@
       "customExpression": "カスタム (詳細)",
       "dropdownPlaceholder": "プロパティの選択",
       "toggleLabel": "式モード",
-      "none": "何一つ"
+      "none": "何一つ",
+      "clearButtonText": "クリア"
     },
     "numericExpressionPlaceholder": "数値に評価される式を入力します。",
     "behaviorId": "動作 ID",

--- a/src/Resources/Locales/ko.json
+++ b/src/Resources/Locales/ko.json
@@ -489,7 +489,8 @@
       "customExpression": "사용자 지정(고급)",
       "dropdownPlaceholder": "속성 선택",
       "toggleLabel": "표현식 모드",
-      "none": "없음"
+      "none": "없음",
+      "clearButtonText": "맑다"
     },
     "numericExpressionPlaceholder": "숫자로 평가되는 표현식을 입력합니다.",
     "behaviorId": "동작 ID",

--- a/src/Resources/Locales/nl.json
+++ b/src/Resources/Locales/nl.json
@@ -489,7 +489,8 @@
       "customExpression": "Aangepast (geavanceerd)",
       "dropdownPlaceholder": "Selecteer een woning",
       "toggleLabel": "Expressiemodus",
-      "none": "Geen"
+      "none": "Geen",
+      "clearButtonText": "Duidelijk"
     },
     "numericExpressionPlaceholder": "Een expressie invoeren die evalueert tot een getal",
     "behaviorId": "Gedrag Id",

--- a/src/Resources/Locales/pl.json
+++ b/src/Resources/Locales/pl.json
@@ -489,7 +489,8 @@
       "customExpression": "Niestandardowy (zaawansowany)",
       "dropdownPlaceholder": "Wybierz właściwość",
       "toggleLabel": "Tryb ekspresji",
-      "none": "Żaden"
+      "none": "Żaden",
+      "clearButtonText": "Jasny"
     },
     "numericExpressionPlaceholder": "Wprowadzanie wyrażenia, którego wynikiem jest liczba",
     "behaviorId": "Identyfikator zachowania",

--- a/src/Resources/Locales/pt-pt.json
+++ b/src/Resources/Locales/pt-pt.json
@@ -489,7 +489,8 @@
       "customExpression": "Personalizado (avançado)",
       "dropdownPlaceholder": "Selecione um imóvel",
       "toggleLabel": "Modo de expressão",
-      "none": "Nenhum."
+      "none": "Nenhum.",
+      "clearButtonText": "Claro"
     },
     "numericExpressionPlaceholder": "Insira uma expressão que avalia um número",
     "behaviorId": "ID de comportamento",

--- a/src/Resources/Locales/pt.json
+++ b/src/Resources/Locales/pt.json
@@ -489,7 +489,8 @@
       "customExpression": "Personalizado (avançado)",
       "dropdownPlaceholder": "Selecione uma propriedade",
       "toggleLabel": "Modo de expressão",
-      "none": "Nenhum"
+      "none": "Nenhum",
+      "clearButtonText": "Claro"
     },
     "numericExpressionPlaceholder": "Digite uma expressão que avalia para um número",
     "behaviorId": "ID de comportamento",

--- a/src/Resources/Locales/ru.json
+++ b/src/Resources/Locales/ru.json
@@ -489,7 +489,8 @@
       "customExpression": "Пользовательский (расширенный)",
       "dropdownPlaceholder": "Выберите недвижимость",
       "toggleLabel": "Режим выражения",
-      "none": "Никакой"
+      "none": "Никакой",
+      "clearButtonText": "Ясный"
     },
     "numericExpressionPlaceholder": "Введите выражение, вычисляющее число",
     "behaviorId": "Идентификатор поведения",

--- a/src/Resources/Locales/sv.json
+++ b/src/Resources/Locales/sv.json
@@ -489,7 +489,8 @@
       "customExpression": "Anpassad (avancerad)",
       "dropdownPlaceholder": "Välj en egenskap",
       "toggleLabel": "Uttrycksläge",
-      "none": "Ingen"
+      "none": "Ingen",
+      "clearButtonText": "Klar"
     },
     "numericExpressionPlaceholder": "Ange ett uttryck som utvärderas till ett tal",
     "behaviorId": "Beteende ID",

--- a/src/Resources/Locales/tr.json
+++ b/src/Resources/Locales/tr.json
@@ -489,7 +489,8 @@
       "customExpression": "Özel (gelişmiş)",
       "dropdownPlaceholder": "Bir mülk seçin",
       "toggleLabel": "İfade modu",
-      "none": "Hiç kimse"
+      "none": "Hiç kimse",
+      "clearButtonText": "Berrak"
     },
     "numericExpressionPlaceholder": "Bir sayıyı değerlendiren bir ifade girin",
     "behaviorId": "Davranış Kimliği",

--- a/src/Resources/Locales/zh-Hans.json
+++ b/src/Resources/Locales/zh-Hans.json
@@ -489,7 +489,8 @@
       "customExpression": "自定义（高级）",
       "dropdownPlaceholder": "选择房产",
       "toggleLabel": "表达方式",
-      "none": "没有"
+      "none": "没有",
+      "clearButtonText": "清楚"
     },
     "numericExpressionPlaceholder": "输入计算结果为数字的表达式",
     "behaviorId": "行为 ID",


### PR DESCRIPTION
### Summary of changes 🔍 
> [ Summarize what your PR is about.  Include images / screenshots if relevant. ]

Addresses [Bug 14324520](https://msazure.visualstudio.com/One/_workitems/edit/14324520): There's no way to remove "status" from a behavior once it's been configured 

Creates a clear button based on [these designs](https://www.figma.com/file/LsmZeVOZJgwZs75HPTQmgU/3D-Scenes-Mock-Screens?node-id=45547%3A225577) to be used in the Status tab.

![image](https://user-images.githubusercontent.com/55771758/171515611-8b32b76b-2143-4554-b2c7-9ae7527a8ef2.png)

![image](https://user-images.githubusercontent.com/55771758/171515672-e951b033-4484-450d-804f-711c6074a467.png)


### Testing 🧪
 > [ Add any special instructions needed to test or view your changes such as environment URLs or other config details. ]

ModelledPropertyBuilder -> Toggle Mode With Clear Button -> 

1. Select value from dropdown when Single property is toggled -> click Clear -> should say "None"
2. Toggle Custom (advanced) -> click Clear -> switch to Single property & "None"
3. Toggle Custom (advanced) -> enter value -> click Clear -> switch to Single property & "None"

Repeat with Behavior Form -> Edit Status Tab

### In Progress

Wanted to get feedback on what I have so far because not sure if I'm currently following best practices, especially with regard to pulling in the styles. Stuck on getting the clear button to "float right" (CSS tinkering advice welcome), and also still figuring out how to create a story in which the button is clicked automatically.

### Checklist ✔️
- [ ] Linked associated issue (if present)
- [ ] Added relevant labels
- [ ] Requested developer reviews
- [ ] Request UI review from design / PM
- [ ] Verify all code checks are passing