### PR TITLE
Export generated 3D Scenes Studio schema types

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -12,6 +12,9 @@ import svgr from '@svgr/rollup';
 import image from '@rollup/plugin-image';
 const parseExportListFromIndex = require('./tools/index-parser');
 
+const schemaTypesPath =
+    'src/Models/Types/Generated/3DScenesConfiguration-v1.0.0.d.ts';
+
 // Build map of library entry points -- this allows for splitting library into chunks & tree shaking
 const inputs = {
     index: 'src/index.ts',
@@ -83,7 +86,7 @@ const config = [
     },
     // Rollup .d.ts typing files associated to each chunk
     {
-        input: inputs,
+        input: { ...inputs, SchemaTypes: schemaTypesPath },
         output: [
             {
                 dir: 'dist',


### PR DESCRIPTION
### Summary of changes 🔍 
Creates `@microsoft/iot-cardboard-js/SchemaTypes` entry point for consumers to import the generated `3DScenesConfiguration-v1.0.0.d.ts` types.

These types are exposed on their own `SchemaTypes` entry point because the types are present as auto-generated `.d.ts` files.  The build wasn't working when these were barrel exported from the root `index` file because rollup does two passes in the build process.  First, it generates the actual ESM module chunks, then it uses the [rollup-plugin-dts](https://www.npmjs.com/package/rollup-plugin-dts) plugin to rollup up the associated types for each entry point.  There's likely  a way to get the generated types to show up on the root `@microsoft/iot-cardboard-js`, but if we're ok with having them live at the `SchemaTypes` entry point -- it's an easier change. 

### Testing 🧪
 If you want to test, build the library, then import the .tgz generated in `BuildArtifacts` into a consuming application (such as the hosted app).  You should be able to import `3DScenesConfiguration-v1.0.0.d.ts` types from the `@microsoft/iot-cardboard-js/SchemaTypes` path.

<img width="488" alt="image" src="https://user-images.githubusercontent.com/18181049/171739218-8270709c-eac6-42a4-b9ef-f3f60bfd10f2.png">


### Checklist ✔️
- [x] Linked associated issue (if present)
- [x] Added relevant labels
- [x] Requested developer reviews
- [x] Request UI review from design / PM
- [ ] Verify all code checks are passing