### PR TITLE
fix: allow all layers to be selected with prop

### DIFF
--- a/src/Components/ADT3DViewer/ADT3DViewer.stories.tsx
+++ b/src/Components/ADT3DViewer/ADT3DViewer.stories.tsx
@@ -362,9 +362,7 @@ export const MockWithSelection = (_args, { globals: { theme, locale } }) => {
 
 export const LayerSelect = (_args, { globals: { theme, locale } }) => {
     const scenesConfig = mockVConfig as I3DScenesConfig;
-    const [selectedLayerIds, setSelectedLayerIds] = useState<string[]>(
-        undefined
-    );
+    const [selectedLayerIds, setSelectedLayerIds] = useState<string[]>(null);
 
     return (
         <div style={{ width: '100%', height: '600px' }}>
@@ -374,7 +372,7 @@ export const LayerSelect = (_args, { globals: { theme, locale } }) => {
                 placeholder="Select layer..."
                 options={[
                     {
-                        data: undefined,
+                        data: null,
                         text: 'All',
                         key: 'all'
                     },

--- a/src/Components/ADT3DViewer/ADT3DViewer.stories.tsx
+++ b/src/Components/ADT3DViewer/ADT3DViewer.stories.tsx
@@ -362,7 +362,9 @@ export const MockWithSelection = (_args, { globals: { theme, locale } }) => {
 
 export const LayerSelect = (_args, { globals: { theme, locale } }) => {
     const scenesConfig = mockVConfig as I3DScenesConfig;
-    const [selectedLayerIds, setSelectedLayerIds] = useState<string[]>([]);
+    const [selectedLayerIds, setSelectedLayerIds] = useState<string[]>(
+        undefined
+    );
 
     return (
         <div style={{ width: '100%', height: '600px' }}>
@@ -372,10 +374,7 @@ export const LayerSelect = (_args, { globals: { theme, locale } }) => {
                 placeholder="Select layer..."
                 options={[
                     {
-                        data: [
-                            '8904b620aa83c649888dadc7c8fdf492',
-                            '9624b620aa83c649888dadc7c8fdf541'
-                        ],
+                        data: undefined,
                         text: 'All',
                         key: 'all'
                     },
@@ -393,6 +392,14 @@ export const LayerSelect = (_args, { globals: { theme, locale } }) => {
                         data: ['9624b620aa83c649888dadc7c8fdf541'],
                         text: 'Temperature',
                         key: 'temperature'
+                    },
+                    {
+                        data: [
+                            '9624b620aa83c649888dadc7c8fdf541',
+                            '8904b620aa83c649888dadc7c8fdf492'
+                        ],
+                        text: 'Temperature & Flow',
+                        key: 'temperatureFlow'
                     }
                 ]}
             />

--- a/src/Components/ADT3DViewer/ADT3DViewer.tsx
+++ b/src/Components/ADT3DViewer/ADT3DViewer.tsx
@@ -298,16 +298,19 @@ const ADT3DViewerBase: React.FC<IADT3DViewerProps> = ({
     ]);
 
     useEffect(() => {
-        if (selectedLayerIds) {
-            setSelectedLayerIds(selectedLayerIds, true);
-        } else {
-            // if layers are undefined or null set all layers as selected
-            const layers = [
-                ...(unlayeredBehaviorsPresent ? [DEFAULT_LAYER_ID] : []),
-                ...layersInScene.map((lis) => lis.id)
-            ];
+        // only set layers if selectedLayerIds has been passed as a prop
+        if (selectedLayerIds !== undefined) {
+            if (selectedLayerIds) {
+                setSelectedLayerIds(selectedLayerIds, true);
+            } else {
+                // if layers are null set all layers as selected
+                const layers = [
+                    ...(unlayeredBehaviorsPresent ? [DEFAULT_LAYER_ID] : []),
+                    ...layersInScene.map((lis) => lis.id)
+                ];
 
-            setSelectedLayerIds(layers, true);
+                setSelectedLayerIds(layers, true);
+            }
         }
     }, [selectedLayerIds]);
 

--- a/src/Components/ADT3DViewer/ADT3DViewer.tsx
+++ b/src/Components/ADT3DViewer/ADT3DViewer.tsx
@@ -300,6 +300,14 @@ const ADT3DViewerBase: React.FC<IADT3DViewerProps> = ({
     useEffect(() => {
         if (selectedLayerIds) {
             setSelectedLayerIds(selectedLayerIds, true);
+        } else {
+            // if layers are undefined or null set all layers as selected
+            const layers = [
+                ...(unlayeredBehaviorsPresent ? [DEFAULT_LAYER_ID] : []),
+                ...layersInScene.map((lis) => lis.id)
+            ];
+
+            setSelectedLayerIds(layers, true);
         }
     }, [selectedLayerIds]);
 


### PR DESCRIPTION
### Summary of changes 🔍 
> If null or undefined is passed to selected layer ids prop all layers will be selected, including default layer. Required fix for the hospital demo.


### Testing 🧪
 > [ Add any special instructions needed to test or view your changes such as environment URLs or other config details. ]

### Checklist ✔️
- [ ] Linked associated issue (if present)
- [ ] Added relevant labels
- [ ] Requested developer reviews
- [ ] Request UI review from design / PM
- [ ] Verify all code checks are passing