### PR TITLE
fix: limits to camera calculated based on model

### DIFF
--- a/src/Components/3DV/SceneView.tsx
+++ b/src/Components/3DV/SceneView.tsx
@@ -376,10 +376,11 @@ function SceneView(props: ISceneViewProps, ref) {
                         cameraRef.current.zoomOn(meshes, true);
                         cameraRef.current.radius = radius;
                         cameraRef.current.lowerRadiusLimit = 0;
-                        cameraRef.current.upperRadiusLimit =
-                            Math.max(width, height, depth) * 3;
+                        // set upperRadiusLimit to be greater than the starting radius to allow the user to zoom out if they wish
+                        cameraRef.current.upperRadiusLimit = radius * 2;
+                        // set the maxZ of the camera to be higher than the upperRadiusLimit to ensure it will not clip when zoomed out
                         cameraRef.current.maxZ =
-                            Math.max(width, height, depth) * 5;
+                            cameraRef.current.upperRadiusLimit * 2;
                         cameraRef.current.wheelPrecision =
                             (3 * 40) / bbox.boundingSphere.radius;
 

--- a/src/Components/3DV/SceneView.tsx
+++ b/src/Components/3DV/SceneView.tsx
@@ -371,13 +371,15 @@ function SceneView(props: ISceneViewProps, ref) {
                             sceneRef.current
                         );
 
-                        camera.maxZ = Math.max(width, height, depth) * 2;
-
                         camera.attachControl(canvas, false);
-                        camera.lowerRadiusLimit = 0;
                         cameraRef.current = camera;
                         cameraRef.current.zoomOn(meshes, true);
                         cameraRef.current.radius = radius;
+                        cameraRef.current.lowerRadiusLimit = 0;
+                        cameraRef.current.upperRadiusLimit =
+                            Math.max(width, height, depth) * 3;
+                        cameraRef.current.maxZ =
+                            Math.max(width, height, depth) * 5;
                         cameraRef.current.wheelPrecision =
                             (3 * 40) / bbox.boundingSphere.radius;
 

--- a/src/Components/3DV/SceneView.tsx
+++ b/src/Components/3DV/SceneView.tsx
@@ -371,6 +371,8 @@ function SceneView(props: ISceneViewProps, ref) {
                             sceneRef.current
                         );
 
+                        camera.maxZ = Math.max(width, height, depth) * 2;
+
                         camera.attachControl(canvas, false);
                         camera.lowerRadiusLimit = 0;
                         cameraRef.current = camera;


### PR DESCRIPTION
### Summary of changes 🔍 
> The camera limits were clipping large models, added code to calculate maxZ and radius for the camera.


### Testing 🧪
 > [ Add any special instructions needed to test or view your changes such as environment URLs or other config details. ]

### Checklist ✔️
- [ ] Linked associated issue (if present)
- [ ] Added relevant labels
- [ ] Requested developer reviews
- [ ] Request UI review from design / PM
- [ ] Verify all code checks are passing