### PR TITLE
fix: Fix to selectedLayers prop when sceneid changed

### DIFF
--- a/src/Components/ADT3DViewer/ADT3DViewer.stories.tsx
+++ b/src/Components/ADT3DViewer/ADT3DViewer.stories.tsx
@@ -363,18 +363,21 @@ export const MockWithSelection = (_args, { globals: { theme, locale } }) => {
 export const LayerSelect = (_args, { globals: { theme, locale } }) => {
     const scenesConfig = mockVConfig as I3DScenesConfig;
     const [selectedLayerIds, setSelectedLayerIds] = useState<string[]>(null);
+    const [sceneId, setSceneId] = useState<string>(
+        'f7053e7537048e03be4d1e6f8f93aa8a'
+    );
 
     return (
         <div style={{ width: '100%', height: '600px' }}>
             <Dropdown
                 onChange={(_event, option) => setSelectedLayerIds(option.data)}
                 style={{ width: '200px' }}
-                placeholder="Select layer..."
                 options={[
                     {
                         data: null,
                         text: 'All',
-                        key: 'all'
+                        key: 'all',
+                        selected: true
                     },
                     {
                         data: [],
@@ -401,6 +404,23 @@ export const LayerSelect = (_args, { globals: { theme, locale } }) => {
                     }
                 ]}
             />
+            <Dropdown
+                onChange={(_event, option) => setSceneId(option.data)}
+                style={{ width: '200px' }}
+                options={[
+                    {
+                        data: 'f7053e7537048e03be4d1e6f8f93aa8a',
+                        text: 'Scene 1',
+                        key: 'f7053e7537048e03be4d1e6f8f93aa8a',
+                        selected: true
+                    },
+                    {
+                        data: 'f7053e7537048e03be4d1e6f8f93aa8b',
+                        text: 'Scene 2',
+                        key: 'f7053e7537048e03be4d1e6f8f93aa8b'
+                    }
+                ]}
+            />
             <ADT3DViewer
                 title="3D Viewer (Mock Data)"
                 theme={theme}
@@ -409,7 +429,7 @@ export const LayerSelect = (_args, { globals: { theme, locale } }) => {
                 adapter={new MockAdapter()}
                 scenesConfig={scenesConfig}
                 pollingInterval={10000}
-                sceneId={mockSceneId}
+                sceneId={sceneId}
                 connectionLineColor="#000"
             />
         </div>

--- a/src/Components/ADT3DViewer/ADT3DViewer.tsx
+++ b/src/Components/ADT3DViewer/ADT3DViewer.tsx
@@ -313,7 +313,7 @@ const ADT3DViewerBase: React.FC<IADT3DViewerProps> = ({
                 setSelectedLayerIds(layers, true);
             }
         }
-    }, [selectedLayerIds]);
+    }, [selectedLayerIds, sceneId]);
 
     const setSelectedElementId = useCallback(
         (elementId: string) => {

--- a/src/Components/ADT3DViewer/ADT3DViewer.tsx
+++ b/src/Components/ADT3DViewer/ADT3DViewer.tsx
@@ -298,6 +298,7 @@ const ADT3DViewerBase: React.FC<IADT3DViewerProps> = ({
         unlayeredBehaviorsPresent
     ]);
 
+    // this needs to run when sceneId is changed to ensure the correct layers are displayed
     useEffect(() => {
         // only set layers if selectedLayerIds has been passed as a prop
         if (selectedLayerIds !== undefined) {


### PR DESCRIPTION
### Summary of changes 🔍 
> When scene id was being changed on the viewer the layers were not being updated as expected. Extended story to include sceneid dropdown and updated useEffect


### Testing 🧪
 > [ Add any special instructions needed to test or view your changes such as environment URLs or other config details. ]

### Checklist ✔️
- [ ] Linked associated issue (if present)
- [ ] Added relevant labels
- [ ] Requested developer reviews
- [ ] Request UI review from design / PM
- [ ] Verify all code checks are passing