### PR TITLE
Fix: Avoid camera issue when scene changes while loading

### DIFF
--- a/src/Components/3DV/SceneView.tsx
+++ b/src/Components/3DV/SceneView.tsx
@@ -919,7 +919,9 @@ function SceneView(props: ISceneViewProps, ref) {
                 }
             );
 
-            if (success) {
+            // TODO: Wrap above promise in an AbortController to cancel in case of changing before the promise resolves
+            // Below line of code works, but it does not cancel the download of the first model, which we already navigated away from
+            if (success && modelUrl === modelUrlRef.current) {
                 sceneRef.current = sc;
 
                 preProcessMeshesOnLoad();

--- a/src/Components/3DV/SceneView.tsx
+++ b/src/Components/3DV/SceneView.tsx
@@ -919,8 +919,10 @@ function SceneView(props: ISceneViewProps, ref) {
                 }
             );
 
-            // TODO: Wrap above promise in an AbortController to cancel in case of changing before the promise resolves
-            // Below line of code works, but it does not cancel the download of the first model, which we already navigated away from
+            // TODO: Wrap above promise in an AbortController to cancel in case of changing scenes before the promise resolves
+            // Checking if url used in loadPromise method above matches url for model being shown in the screen avoids an error
+            // that occurs when trying to control the camera of an unloaded scene, but it does not cancel the download of the
+            // first model which we already navigated away from.
             if (success && modelUrl === modelUrlRef.current) {
                 sceneRef.current = sc;
 


### PR DESCRIPTION
### Summary of changes 🔍 
Modified logic after model load promise is successful in SceneView to not do anything in case the user navigated away while it was still loading. Ideally the Promise can be cancelled by an `AbortController` (https://developer.mozilla.org/en-US/docs/Web/API/AbortController), however that proved to be problematic and might be overkill if this component's logic is planned to be re-written.

### Testing 🧪
- Open Mock 3D Scene Page story
- Navigate to Luciana 1 scene
- While the model loads, change to another scene
- Validate the correct model is loading and previous model doesn't show up in screen at all.

Chromatic link: https://pasanch-scene-change--601c6b2fcd385c002100f14c.chromatic.com/?path=/story/pages-adt3dscenepage--mock-3-d-scene-page

### Checklist ✔️
- [x] Linked associated issue (if present)
- [x] Added relevant labels
- [ ] Requested developer reviews
- [x] Request UI review from design / PM
- [ ] Verify all code checks are passing