### PR TITLE
Cleanup and prop consolidation

### DIFF
--- a/src/Components/ADT3DGlobe/ADT3DGlobe.tsx
+++ b/src/Components/ADT3DGlobe/ADT3DGlobe.tsx
@@ -24,10 +24,8 @@ const ADT3DGlobe: React.FC<IADT3DGlobeProps> = ({
 }) => {
     const [markers, setMarkers] = useState<Marker[]>([]);
     const [coloredMeshes, setColoredMeshes] = useState<CustomMeshItem[]>([]);
-    const sceneClickRef = useRef<any>();
     const sceneRef = useRef(null);
 
-    sceneClickRef.current = onSceneClick;
     const config = useAdapter({
         adapterMethod: () => adapter.getScenesConfig(),
         refetchDependencies: [adapter]

--- a/src/Components/ADT3DViewer/ADT3DViewer.stories.tsx
+++ b/src/Components/ADT3DViewer/ADT3DViewer.stories.tsx
@@ -3,7 +3,11 @@ import useAuthParams from '../../../.storybook/useAuthParams';
 import ADT3DViewer from './ADT3DViewer';
 import MockAdapter from '../../Adapters/MockAdapter';
 import mockVConfig from '../../Adapters/__mockData__/3DScenesConfiguration.json';
-import { ADT3DAddInEventData, IADT3DAddInProps } from '../../Models/Constants';
+import {
+    ADT3DAddInEventData,
+    ADT3DViewerExternalProps,
+    IADT3DAddInProps
+} from '../../Models/Constants';
 import {
     I3DScenesConfig,
     ITwinToObjectMapping
@@ -21,19 +25,22 @@ const mockSceneId = 'f7053e7537048e03be4d1e6f8f93aa8a';
 export const Engine = (_args, { globals: { theme, locale } }) => {
     const authenticationParameters = useAuthParams();
     const scenesConfig = mockVConfig as I3DScenesConfig;
+    const externalProps: ADT3DViewerExternalProps = {
+        connectionLineColor: '#000',
+        title: '3D Viewer'
+    };
     return !authenticationParameters ? (
         <div></div>
     ) : (
         <div style={{ width: '100%', height: '600px' }}>
             <ADT3DViewer
-                title="3D Viewer"
                 theme={theme}
                 locale={locale}
                 adapter={new MockAdapter()}
                 scenesConfig={scenesConfig}
                 pollingInterval={10000}
                 sceneId={mockSceneId}
-                connectionLineColor="#000"
+                externalProps={externalProps}
             />
         </div>
     );
@@ -42,21 +49,24 @@ export const Engine = (_args, { globals: { theme, locale } }) => {
 export const EngineWithHover = (_args, { globals: { theme, locale } }) => {
     const authenticationParameters = useAuthParams();
     const scenesConfig = mockVConfig as I3DScenesConfig;
+    const externalProps: ADT3DViewerExternalProps = {
+        connectionLineColor: '#000',
+        showMeshesOnHover: true,
+        title: '3D Viewer'
+    };
 
     return !authenticationParameters ? (
         <div></div>
     ) : (
         <div style={{ width: '100%', height: '600px' }}>
             <ADT3DViewer
-                title="3D Viewer"
                 theme={theme}
                 locale={locale}
                 adapter={new MockAdapter()}
                 scenesConfig={scenesConfig}
-                showMeshesOnHover={true}
                 pollingInterval={10000}
                 sceneId={mockSceneId}
-                connectionLineColor="#000"
+                externalProps={externalProps}
             />
         </div>
     );
@@ -132,6 +142,14 @@ export const ZoomAndColor = (_args, { globals: { theme, locale } }) => {
         });
     }
 
+    const externalProps: ADT3DViewerExternalProps = {
+        coloredMeshItems: coloredMeshes,
+        connectionLineColor: '#000',
+        hideElementsPanel: hideElementsPanel,
+        title: '3D Viewer',
+        zoomToElementId: zoomedElementId
+    };
+
     return !authenticationParameters ? (
         <div></div>
     ) : (
@@ -191,17 +209,13 @@ export const ZoomAndColor = (_args, { globals: { theme, locale } }) => {
                 </div>
             </div>
             <ADT3DViewer
-                title="3D Viewer"
                 theme={theme}
                 locale={locale}
                 adapter={new MockAdapter()}
                 scenesConfig={scenesConfig}
                 pollingInterval={10000}
                 sceneId={selectedScene.id}
-                connectionLineColor="#000"
-                coloredMeshItems={coloredMeshes}
-                zoomToElementId={zoomedElementId}
-                hideElementsPanel={hideElementsPanel}
+                externalProps={externalProps}
             />
         </div>
     );
@@ -269,20 +283,24 @@ export const AddIn = (_args, { globals: { theme, locale } }) => {
         onMeshClick
     };
 
+    const externalProps: ADT3DViewerExternalProps = {
+        connectionLineColor: '#000',
+        title: '3D Viewer'
+    };
+
     return !authenticationParameters ? (
         <div></div>
     ) : (
         <div style={{ width: '100%', height: '600px', position: 'relative' }}>
             <ADT3DViewer
-                title="3D Viewer"
                 theme={theme}
                 locale={locale}
                 adapter={new MockAdapter()}
                 scenesConfig={scenesConfig}
                 pollingInterval={10000}
                 sceneId={mockSceneId}
-                connectionLineColor="#000"
                 addInProps={addInProps}
+                externalProps={externalProps}
             />
             {data && (
                 <div style={addInDivStyle}>
@@ -301,18 +319,21 @@ export const AddIn = (_args, { globals: { theme, locale } }) => {
 
 export const Mock = (_args, { globals: { theme, locale } }) => {
     const scenesConfig = mockVConfig as I3DScenesConfig;
+    const externalProps: ADT3DViewerExternalProps = {
+        connectionLineColor: '#000',
+        title: '3D Viewer (Mock Data)'
+    };
 
     return (
         <div style={{ width: '100%', height: '600px' }}>
             <ADT3DViewer
-                title="3D Viewer (Mock Data)"
                 theme={theme}
                 locale={locale}
                 adapter={new MockAdapter()}
                 scenesConfig={scenesConfig}
                 pollingInterval={10000}
                 sceneId={mockSceneId}
-                connectionLineColor="#000"
+                externalProps={externalProps}
             />
         </div>
     );
@@ -320,19 +341,22 @@ export const Mock = (_args, { globals: { theme, locale } }) => {
 
 export const MockWithHover = (_args, { globals: { theme, locale } }) => {
     const scenesConfig = mockVConfig as I3DScenesConfig;
+    const externalProps: ADT3DViewerExternalProps = {
+        connectionLineColor: '#000',
+        showMeshesOnHover: true,
+        title: '3D Viewer (Mock Data)'
+    };
 
     return (
         <div style={{ width: '100%', height: '600px' }}>
             <ADT3DViewer
-                title="3D Viewer (Mock Data)"
                 theme={theme}
                 locale={locale}
                 adapter={new MockAdapter()}
                 scenesConfig={scenesConfig}
                 pollingInterval={10000}
                 sceneId={mockSceneId}
-                showMeshesOnHover={true}
-                connectionLineColor="#000"
+                externalProps={externalProps}
             />
         </div>
     );
@@ -340,21 +364,24 @@ export const MockWithHover = (_args, { globals: { theme, locale } }) => {
 
 export const MockWithSelection = (_args, { globals: { theme, locale } }) => {
     const scenesConfig = mockVConfig as I3DScenesConfig;
+    const externalProps: ADT3DViewerExternalProps = {
+        connectionLineColor: '#000',
+        enableMeshSelection: true,
+        showHoverOnSelected: true,
+        showMeshesOnHover: true,
+        title: '3D Viewer (Mock Data)'
+    };
 
     return (
         <div style={{ width: '100%', height: '600px' }}>
             <ADT3DViewer
-                title="3D Viewer (Mock Data)"
                 theme={theme}
                 locale={locale}
                 adapter={new MockAdapter()}
                 scenesConfig={scenesConfig}
                 pollingInterval={10000}
                 sceneId={mockSceneId}
-                enableMeshSelection={true}
-                showHoverOnSelected={true}
-                showMeshesOnHover={true}
-                connectionLineColor="#000"
+                externalProps={externalProps}
             />
         </div>
     );
@@ -366,6 +393,11 @@ export const LayerSelect = (_args, { globals: { theme, locale } }) => {
     const [sceneId, setSceneId] = useState<string>(
         'f7053e7537048e03be4d1e6f8f93aa8a'
     );
+    const externalProps: ADT3DViewerExternalProps = {
+        connectionLineColor: '#000',
+        selectedLayerIds: selectedLayerIds,
+        title: '3D Viewer (Mock Data)'
+    };
 
     return (
         <div style={{ width: '100%', height: '600px' }}>
@@ -422,15 +454,13 @@ export const LayerSelect = (_args, { globals: { theme, locale } }) => {
                 ]}
             />
             <ADT3DViewer
-                title="3D Viewer (Mock Data)"
                 theme={theme}
                 locale={locale}
-                selectedLayerIds={selectedLayerIds}
                 adapter={new MockAdapter()}
                 scenesConfig={scenesConfig}
                 pollingInterval={10000}
                 sceneId={sceneId}
-                connectionLineColor="#000"
+                externalProps={externalProps}
             />
         </div>
     );

--- a/src/Models/Constants/Interfaces.ts
+++ b/src/Models/Constants/Interfaces.ts
@@ -733,30 +733,34 @@ export interface IADT3DViewerProps extends BaseComponentProps {
     sceneId: string;
     scenesConfig: I3DScenesConfig;
     pollingInterval: number;
-    title?: string;
-    connectionLineColor?: string;
-    enableMeshSelection?: boolean;
+    externalProps?: ADT3DViewerExternalProps;
     addInProps?: IADT3DAddInProps;
     refetchConfig?: () => any;
-    showMeshesOnHover?: boolean;
-    showHoverOnSelected?: boolean;
-    coloredMeshItems?: CustomMeshItem[];
-    /**
-     * Ids of the elements to zoom the camera to focus on
-     */
-    zoomToElementId?: string;
-    unzoomedMeshOpacity?: number;
-    hideViewModePickerUI?: boolean;
-    hideElementsPanel?: boolean;
-    outlinedMeshItems?: CustomMeshItem[];
     /** show the toggle to switch between builder & viewer modes */
     showModeToggle?: boolean;
     sceneViewProps?: ISceneViewProps;
-    selectedLayerIds?: string[];
     /**
      * Call to provide customized styling that will layer on top of the variant rules.
      */
     styles?: IStyleFunctionOrObject<IADT3DViewerStyleProps, IADT3DViewerStyles>;
+}
+
+export interface ADT3DViewerExternalProps {
+    coloredMeshItems?: CustomMeshItem[];
+    connectionLineColor?: string;
+    enableMeshSelection?: boolean;
+    hideElementsPanel?: boolean;
+    hideViewModePickerUI?: boolean;
+    outlinedMeshItems?: CustomMeshItem[];
+    selectedLayerIds?: string[];
+    showHoverOnSelected?: boolean;
+    showMeshesOnHover?: boolean;
+    title?: string;
+    unzoomedMeshOpacity?: number;
+    /**
+     * Ids of the elements to zoom the camera to focus on
+     */
+    zoomToElementId?: string;
 }
 
 export interface ISceneViewerThemeCache {

--- a/src/Pages/ADT3DScenePage/ADT3DScenePage.tsx
+++ b/src/Pages/ADT3DScenePage/ADT3DScenePage.tsx
@@ -622,11 +622,9 @@ const ADT3DScenePageBase: React.FC<IADT3DScenePageProps> = ({
                                     <>
                                         <div className="cb-scene-builder-and-viewer-container">
                                             <ADT3DSceneBuilderContainer
-                                                mode={deeplinkState.mode}
                                                 scenesConfig={
                                                     state.scenesConfig
                                                 }
-                                                sceneId={deeplinkState.sceneId}
                                                 adapter={adapter}
                                                 theme={theme}
                                                 locale={locale}

--- a/src/Pages/ADT3DScenePage/ADT3DScenePage.types.ts
+++ b/src/Pages/ADT3DScenePage/ADT3DScenePage.types.ts
@@ -44,8 +44,6 @@ export interface IADT3DScenePageProps extends IConsumeCompositeCardProps {
 
 export interface IADT3DSceneBuilderProps extends IConsumeCompositeCardProps {
     adapter: ADT3DSceneAdapter | MockAdapter;
-    mode: ADT3DScenePageModes;
-    sceneId: string;
     scenesConfig: I3DScenesConfig;
     refetchConfig?: () => void;
 }

--- a/src/Pages/ADT3DScenePage/Internal/ADT3DSceneBuilderContainer.tsx
+++ b/src/Pages/ADT3DScenePage/Internal/ADT3DSceneBuilderContainer.tsx
@@ -12,7 +12,6 @@ import { useDeeplinkContext } from '../../../Models/Context/DeeplinkContext/Deep
 
 export const ADT3DSceneBuilderContainer: React.FC<IADT3DSceneBuilderProps> = ({
     scenesConfig,
-    sceneId,
     adapter,
     theme,
     locale,
@@ -49,7 +48,7 @@ export const ADT3DSceneBuilderContainer: React.FC<IADT3DSceneBuilderProps> = ({
                 adapter={adapter}
                 mode={deeplinkState.mode}
                 refetchConfig={refetchConfig}
-                sceneId={sceneId}
+                sceneId={deeplinkState.sceneId}
                 scenesConfig={scenesConfig}
             />
         </BaseComponent>


### PR DESCRIPTION
### Summary of changes 🔍 
After some analysis of the codebase, I noticed several small details that would improve it if cleaned up:
1. Some props were being passed down to components with access to context that contained that same information. I removed that duplication in favor of the context.
2. A ref was unused in the ADT3DGlobe, which I removed.
3. ADT3DViewer had a large number of props that are only included when the component is standalone, so I wrapped those in an object to make a clear distinction of which props are needed for that use case.

### Testing 🧪
3DV (stand-alone Viewer and Builder) stories should all work as intended.

### Checklist ✔️
- [ ] Linked associated issue (if present)
- [ ] Added relevant labels
- [ ] Requested developer reviews
- [ ] Request UI review from design / PM
- [ ] Verify all code checks are passing