### PR TITLE
Logical State Icons for Alerts

### DIFF
--- a/src/Theming/Palettes.ts
+++ b/src/Theming/Palettes.ts
@@ -61,18 +61,18 @@ export const defaultSwatchIcons: IPickerOption[] = [
     {
         id: 'Shield',
         item: 'Shield'
-     },
-    {
-        id: 'statusCircleCheckMark',
-        item: 'statusCircleCheckMark'
     },
     {
-        id: 'statusCircleExclamation',
-        item: 'statusCircleExclamation'
+        id: 'accept',
+        item: 'accept'
     },
-    { 
-        id: 'statusCirleInfo',
-        item: 'statusCircleInfo'
+    {
+        id: 'warning',
+        item: 'warning'
+    },
+    {
+        id: 'lightbulb',
+        item: 'lightbulb'
     }
 ];
 

--- a/src/Theming/Palettes.ts
+++ b/src/Theming/Palettes.ts
@@ -63,16 +63,16 @@ export const defaultSwatchIcons: IPickerOption[] = [
         item: 'Shield'
     },
     {
-        id: 'accept',
-        item: 'accept'
+        id: 'Accept',
+        item: 'Accept'
     },
     {
-        id: 'warning',
-        item: 'warning'
+        id: 'Warning',
+        item: 'Warning'
     },
     {
-        id: 'lightbulb',
-        item: 'lightbulb'
+        id: 'Lightbulb',
+        item: 'Lightbulb'
     }
 ];
 

--- a/src/Theming/Palettes.ts
+++ b/src/Theming/Palettes.ts
@@ -61,6 +61,18 @@ export const defaultSwatchIcons: IPickerOption[] = [
     {
         id: 'Shield',
         item: 'Shield'
+     },
+    {
+        id: 'statusCircleCheckMark',
+        item: 'statusCircleCheckMark'
+    },
+    {
+        id: 'statusCircleExclamation',
+        item: 'statusCircleExclamation'
+    },
+    { 
+        id: 'statusCirleInfo',
+        item: 'statusCircleInfo'
     }
 ];
 


### PR DESCRIPTION
### Summary of changes 🔍 
Added three new Fluent icons to the Alert icon pallet.

These icons have been added so that we have more "logical" icon mappings from states,

For example:

"System Running Ok"  == "accept"
"Information" == "lightbulb"
"warning" == "warning"

These appear as in the builder as below

<img width="86" alt="image" src="https://user-images.githubusercontent.com/7986264/177759345-93de66b0-0d01-4710-8481-1eab50f5d416.png">

And Appear in the viewer as below

<img width="241" alt="image" src="https://user-images.githubusercontent.com/7986264/177759055-c555d316-f59d-4546-9ad9-1a55f6907371.png">

### Testing 🧪
 Run the story book and select the icons

### Checklist ✔️
- [x] Added relevant labels
- [x] Requested developer reviews
- [x] Request UI review from design / PM
- [ ] Verify all code checks are passing