### PR TITLE
Unused prop and ref cleanup

### DIFF
--- a/src/Components/ADT3DGlobe/ADT3DGlobe.tsx
+++ b/src/Components/ADT3DGlobe/ADT3DGlobe.tsx
@@ -24,10 +24,8 @@ const ADT3DGlobe: React.FC<IADT3DGlobeProps> = ({
 }) => {
     const [markers, setMarkers] = useState<Marker[]>([]);
     const [coloredMeshes, setColoredMeshes] = useState<CustomMeshItem[]>([]);
-    const sceneClickRef = useRef<any>();
     const sceneRef = useRef(null);
 
-    sceneClickRef.current = onSceneClick;
     const config = useAdapter({
         adapterMethod: () => adapter.getScenesConfig(),
         refetchDependencies: [adapter]

--- a/src/Pages/ADT3DScenePage/ADT3DScenePage.tsx
+++ b/src/Pages/ADT3DScenePage/ADT3DScenePage.tsx
@@ -622,11 +622,9 @@ const ADT3DScenePageBase: React.FC<IADT3DScenePageProps> = ({
                                     <>
                                         <div className="cb-scene-builder-and-viewer-container">
                                             <ADT3DSceneBuilderContainer
-                                                mode={deeplinkState.mode}
                                                 scenesConfig={
                                                     state.scenesConfig
                                                 }
-                                                sceneId={deeplinkState.sceneId}
                                                 adapter={adapter}
                                                 theme={theme}
                                                 locale={locale}

--- a/src/Pages/ADT3DScenePage/ADT3DScenePage.types.ts
+++ b/src/Pages/ADT3DScenePage/ADT3DScenePage.types.ts
@@ -44,8 +44,6 @@ export interface IADT3DScenePageProps extends IConsumeCompositeCardProps {
 
 export interface IADT3DSceneBuilderProps extends IConsumeCompositeCardProps {
     adapter: ADT3DSceneAdapter | MockAdapter;
-    mode: ADT3DScenePageModes;
-    sceneId: string;
     scenesConfig: I3DScenesConfig;
     refetchConfig?: () => void;
 }

--- a/src/Pages/ADT3DScenePage/Internal/ADT3DSceneBuilderContainer.tsx
+++ b/src/Pages/ADT3DScenePage/Internal/ADT3DSceneBuilderContainer.tsx
@@ -12,7 +12,6 @@ import { useDeeplinkContext } from '../../../Models/Context/DeeplinkContext/Deep
 
 export const ADT3DSceneBuilderContainer: React.FC<IADT3DSceneBuilderProps> = ({
     scenesConfig,
-    sceneId,
     adapter,
     theme,
     locale,
@@ -49,7 +48,7 @@ export const ADT3DSceneBuilderContainer: React.FC<IADT3DSceneBuilderProps> = ({
                 adapter={adapter}
                 mode={deeplinkState.mode}
                 refetchConfig={refetchConfig}
-                sceneId={sceneId}
+                sceneId={deeplinkState.sceneId}
                 scenesConfig={scenesConfig}
             />
         </BaseComponent>


### PR DESCRIPTION
### Summary of changes 🔍 
After some analysis of the codebase, I noticed several small details that I wanted to clean up:

1. Some props were being passed down to `ADT3DSceneBuilderContainer` are available in `DeepLinkContext` which is being used by the component. I removed that duplication in favor of the context.
2. A ref was unused in the ADT3DGlobe, which I removed.

### Testing 🧪
These changes should not affect the functionality of Globe or Builder.

### Checklist ✔️
- [ ] Linked associated issue (if present)
- [ ] Added relevant labels
- [ ] Requested developer reviews
- [ ] Request UI review from design / PM
- [ ] Verify all code checks are passing