### PR TITLE
Behavior Deletion does not persist in Elements Form

### DIFF
--- a/src/Components/ADT3DSceneBuilder/Internal/Elements/ElementForm.tsx
+++ b/src/Components/ADT3DSceneBuilder/Internal/Elements/ElementForm.tsx
@@ -71,7 +71,6 @@ const SceneElementForm: React.FC<IADT3DSceneBuilderElementFormProps> = ({
         setColoredMeshItems,
         elementTwinAliasFormInfo
     } = useContext(SceneBuilderContext);
-
     const existingElementsRef = useRef(null);
     const newElementsRef = useRef(null);
     const [elementToEdit, setElementToEdit] = useState<ITwinToObjectMapping>(
@@ -145,9 +144,16 @@ const SceneElementForm: React.FC<IADT3DSceneBuilderElementFormProps> = ({
             // BEGINNING of behaviors update which this element exists in
             if (behaviorsToEdit) {
                 for (const behavior of behaviorsToEdit) {
+                    const selectedLayerIds = ViewerConfigUtility.getActiveLayersForBehavior(
+                        config,
+                        behavior.id
+                    );
+
                     updatedConfig = ViewerConfigUtility.editBehavior(
                         updatedConfig,
-                        behavior
+                        behavior,
+                        selectedLayerIds,
+                        [elementToEdit]
                     );
 
                     // add the behavior to the current scene if it is not there

--- a/src/Models/Classes/ViewerConfigUtility.ts
+++ b/src/Models/Classes/ViewerConfigUtility.ts
@@ -217,8 +217,7 @@ abstract class ViewerConfigUtility {
     static editBehavior(
         config: I3DScenesConfig,
         behavior: IBehavior,
-        selectedLayerIds?: string[],
-        removedElements?: ITwinToObjectMapping[]
+        selectedLayerIds?: string[]
     ): I3DScenesConfig {
         const updatedConfig = deepCopy(config);
         const updatedBehavior = deepCopy(behavior);
@@ -227,37 +226,6 @@ abstract class ViewerConfigUtility {
         const behaviorIdx = updatedConfig.configuration.behaviors.findIndex(
             (b) => b.id === behavior.id
         );
-
-        // Get element ids from config (old) and form behavior (new)
-        const oldElementsDataSource = updatedConfig.configuration.behaviors[
-            behaviorIdx
-        ]?.datasources.find(
-            (b) =>
-                b.type === DatasourceType.ElementTwinToObjectMappingDataSource
-        ) as IElementTwinToObjectMappingDataSource;
-        const newElementsDataSource = updatedBehavior.datasources.find(
-            (b) =>
-                b.type === DatasourceType.ElementTwinToObjectMappingDataSource
-        ) as IElementTwinToObjectMappingDataSource;
-
-        // If found, remove elements that have been cleared out from old config
-        // and merge with new behavior values
-        if (oldElementsDataSource && newElementsDataSource) {
-            let oldElementIds = [...oldElementsDataSource.elementIDs];
-            if (removedElements) {
-                const removedElementIds = removedElements.map(
-                    (element) => element.id
-                );
-                oldElementIds = oldElementsDataSource.elementIDs.filter(
-                    (elementid) => !removedElementIds.includes(elementid)
-                );
-            }
-            const mergedElementIds = Array.from(
-                new Set([...oldElementIds, ...newElementsDataSource.elementIDs])
-            );
-            newElementsDataSource.elementIDs = mergedElementIds;
-        }
-
         // Update modified behavior
         updatedConfig.configuration.behaviors[behaviorIdx] = updatedBehavior;
 

--- a/src/Models/Classes/ViewerConfigUtility.ts
+++ b/src/Models/Classes/ViewerConfigUtility.ts
@@ -217,7 +217,8 @@ abstract class ViewerConfigUtility {
     static editBehavior(
         config: I3DScenesConfig,
         behavior: IBehavior,
-        selectedLayerIds?: string[]
+        selectedLayerIds?: string[],
+        removedElements?: ITwinToObjectMapping[]
     ): I3DScenesConfig {
         const updatedConfig = deepCopy(config);
         const updatedBehavior = deepCopy(behavior);
@@ -226,6 +227,37 @@ abstract class ViewerConfigUtility {
         const behaviorIdx = updatedConfig.configuration.behaviors.findIndex(
             (b) => b.id === behavior.id
         );
+
+        // Get element ids from config (old) and form behavior (new)
+        const oldElementsDataSource = updatedConfig.configuration.behaviors[
+            behaviorIdx
+        ]?.datasources.find(
+            (b) =>
+                b.type === DatasourceType.ElementTwinToObjectMappingDataSource
+        ) as IElementTwinToObjectMappingDataSource;
+        const newElementsDataSource = updatedBehavior.datasources.find(
+            (b) =>
+                b.type === DatasourceType.ElementTwinToObjectMappingDataSource
+        ) as IElementTwinToObjectMappingDataSource;
+
+        // If found, remove elements that have been cleared out from old config
+        // and merge with new behavior values
+        if (oldElementsDataSource && newElementsDataSource) {
+            let oldElementIds = [...oldElementsDataSource.elementIDs];
+            if (removedElements) {
+                const removedElementIds = removedElements.map(
+                    (element) => element.id
+                );
+                oldElementIds = oldElementsDataSource.elementIDs.filter(
+                    (elementid) => !removedElementIds.includes(elementid)
+                );
+            }
+            const mergedElementIds = Array.from(
+                new Set([...oldElementIds, ...newElementsDataSource.elementIDs])
+            );
+            newElementsDataSource.elementIDs = mergedElementIds;
+        }
+
         // Update modified behavior
         updatedConfig.configuration.behaviors[behaviorIdx] = updatedBehavior;
 


### PR DESCRIPTION
### Summary of changes 🔍 
> When you try to delete a behavior from an element using the element form, the removal does not persist. Here is an issue that talks more about the bug: [https://github.com/microsoft/iot-cardboard-js/issues/512]. Debugging the code further, i found out that there were some lines of code that not only produced the wrong result and caused the persistence issue but weren't needed in the first place. So i removed it and things seem to be working as they should. 


### Testing 🧪
 > Pick or create an element that has behaviors associated with it. Try to delete and add some behaviors and see if things persist.

### Checklist ✔️
- [x] Linked associated issue (if present)
- [ ] Added relevant labels
- [ ] Requested developer reviews
- [ ] Request UI review from design / PM
- [ ] Verify all code checks are passing

https://msazure.visualstudio.com/One/_workitems/edit/14759233/