### PR TITLE
fixed error where PI could not read fields of properties that were enums

### DIFF
--- a/src/Components/PropertyInspector/PropertyInspector.stories.local.tsx
+++ b/src/Components/PropertyInspector/PropertyInspector.stories.local.tsx
@@ -43,7 +43,7 @@ export const AdtTwin = (args, { globals: { theme, locale } }) => {
 AdtTwin.argTypes = {
     twinId: {
         control: { type: 'text' },
-        defaultValue: 'ActivePowerSensorTwin'
+        defaultValue: 'PasteurizationMachine_A01'
     }
 };
 

--- a/src/Components/PropertyInspector/PropertyInspector.stories.local.tsx
+++ b/src/Components/PropertyInspector/PropertyInspector.stories.local.tsx
@@ -43,7 +43,7 @@ export const AdtTwin = (args, { globals: { theme, locale } }) => {
 AdtTwin.argTypes = {
     twinId: {
         control: { type: 'text' },
-        defaultValue: 'PasteurizationMachine_A01'
+        defaultValue: 'ActivePowerSensorTwin'
     }
 };
 

--- a/src/Components/PropertyInspector/PropertyInspectoryModel.ts
+++ b/src/Components/PropertyInspector/PropertyInspectoryModel.ts
@@ -656,8 +656,8 @@ abstract class PropertyInspectorModel {
 
     static conformSyntax = (inputEl) => {
         // Update syntax of all object keys
-        if (!inputEl) return;
         if (typeof inputEl === 'object') {
+            if (!inputEl) return;
             Object.keys(inputEl).forEach((key) => {
                 // Update to simplified DTDL syntax (conform to our interface)
                 if (key in dtdlSyntaxMap) {

--- a/src/Components/PropertyInspector/PropertyInspectoryModel.ts
+++ b/src/Components/PropertyInspector/PropertyInspectoryModel.ts
@@ -177,6 +177,9 @@ abstract class PropertyInspectorModel {
         } else if (typeof modelProperty.schema === 'object') {
             switch (modelProperty.schema['@type']) {
                 case DTDLSchemaType.Object:
+                    PropertyInspectorModel.conformSyntax(
+                        modelProperty.schema?.fields
+                    );
                     return {
                         name: mapInfo ? mapInfo.key : modelProperty.name,
                         displayName: mapInfo
@@ -237,6 +240,7 @@ abstract class PropertyInspectorModel {
                         )
                     };
                 case DTDLSchemaType.Enum: {
+                    PropertyInspectorModel.conformSyntax(modelProperty);
                     return {
                         name: mapInfo ? mapInfo.key : modelProperty.name,
                         displayName: mapInfo
@@ -646,53 +650,61 @@ abstract class PropertyInspectorModel {
         }
     };
 
+    static replaceKeyInObj = (obj, oldKey, newKey) => {
+        delete Object.assign(obj, { [newKey]: obj[oldKey] })[oldKey];
+    };
+
+    static conformSyntax = (inputEl) => {
+        // Update syntax of all object keys
+        if (typeof inputEl === 'object') {
+            Object.keys(inputEl).forEach((key) => {
+                // Update to simplified DTDL syntax (conform to our interface)
+                if (key in dtdlSyntaxMap) {
+                    PropertyInspectorModel.replaceKeyInObj(
+                        inputEl,
+                        key,
+                        dtdlSyntaxMap[key]
+                    );
+                }
+
+                // If value @ key is string, check if string is present in syntax map
+                if (
+                    typeof inputEl[key] === 'string' &&
+                    inputEl[key] in dtdlSyntaxMap
+                ) {
+                    inputEl[key] = dtdlSyntaxMap[inputEl[key]];
+                }
+
+                // If value @ key is array, recursively iterate array items
+                if (Array.isArray(inputEl[key])) {
+                    inputEl[key].forEach((item) => {
+                        PropertyInspectorModel.conformSyntax(item);
+                    });
+                }
+
+                // if value @ key is object, recursively iterate object keys
+                if (inputEl[key] && typeof inputEl[key] === 'object') {
+                    PropertyInspectorModel.conformSyntax(inputEl[key]);
+                }
+            });
+        } else if (Array.isArray(inputEl)) {
+            inputEl.forEach((item, idx) => {
+                if (typeof item === 'string' && item in dtdlSyntaxMap) {
+                    PropertyInspectorModel.replaceKeyInObj(
+                        inputEl,
+                        idx,
+                        dtdlSyntaxMap[item]
+                    );
+                }
+            });
+        }
+    };
+
     static conformDtdlInterface = (model: DtdlInterface) => {
         if (!model) return null;
         const conformedModel = JSON.parse(JSON.stringify(model));
 
-        const replaceKeyInObj = (obj, oldKey, newKey) => {
-            delete Object.assign(obj, { [newKey]: obj[oldKey] })[oldKey];
-        };
-
-        const conformSyntax = (inputEl) => {
-            // Update syntax of all object keys
-            if (typeof inputEl === 'object') {
-                Object.keys(inputEl).forEach((key) => {
-                    // Update to simplified DTDL syntax (conform to our interface)
-                    if (key in dtdlSyntaxMap) {
-                        replaceKeyInObj(inputEl, key, dtdlSyntaxMap[key]);
-                    }
-
-                    // If value @ key is string, check if string is present in syntax map
-                    if (
-                        typeof inputEl[key] === 'string' &&
-                        inputEl[key] in dtdlSyntaxMap
-                    ) {
-                        inputEl[key] = dtdlSyntaxMap[inputEl[key]];
-                    }
-
-                    // If value @ key is array, recursively iterate array items
-                    if (Array.isArray(inputEl[key])) {
-                        inputEl[key].forEach((item) => {
-                            conformSyntax(item);
-                        });
-                    }
-
-                    // if value @ key is object, recursively iterate object keys
-                    if (inputEl[key] && typeof inputEl[key] === 'object') {
-                        conformSyntax(inputEl[key]);
-                    }
-                });
-            } else if (Array.isArray(inputEl)) {
-                inputEl.forEach((item, idx) => {
-                    if (typeof item === 'string' && item in dtdlSyntaxMap) {
-                        replaceKeyInObj(inputEl, idx, dtdlSyntaxMap[item]);
-                    }
-                });
-            }
-        };
-
-        conformSyntax(conformedModel);
+        PropertyInspectorModel.conformSyntax(conformedModel);
         return conformedModel;
     };
 

--- a/src/Components/PropertyInspector/PropertyInspectoryModel.ts
+++ b/src/Components/PropertyInspector/PropertyInspectoryModel.ts
@@ -656,6 +656,7 @@ abstract class PropertyInspectorModel {
 
     static conformSyntax = (inputEl) => {
         // Update syntax of all object keys
+        if (!inputEl) return;
         if (typeof inputEl === 'object') {
             Object.keys(inputEl).forEach((key) => {
                 // Update to simplified DTDL syntax (conform to our interface)

--- a/src/Components/PropertyInspector/PropertyTree/PropertyTree.scss
+++ b/src/Components/PropertyInspector/PropertyTree/PropertyTree.scss
@@ -94,10 +94,10 @@
                 border: 1px solid var(--cb-color-theme-primary);
                 outline: none;
             }
+        }
 
-            option {
-                background-color: var(--cb-color-input-edited-bg);
-            }
+        option {
+            background-color: var(--cb-color-input-edited-bg);
         }
 
         input,

--- a/src/Components/PropertyInspector/PropertyTree/PropertyTree.scss
+++ b/src/Components/PropertyInspector/PropertyTree/PropertyTree.scss
@@ -94,6 +94,10 @@
                 border: 1px solid var(--cb-color-theme-primary);
                 outline: none;
             }
+
+            option {
+                background-color: var(--cb-color-input-edited-bg);
+            }
         }
 
         input,


### PR DESCRIPTION
### Summary of changes 🔍 
Error in Property Inspector that showed up in the Explorer:
![image](https://user-images.githubusercontent.com/55771758/180496774-f1eb58a7-a428-4bb6-8c27-ac7232a04096.png)

After investigation, discovered that it was caused by fields of properties that are enums not being read properly. Here is the same twin in cardboard after the fix: 
![image](https://user-images.githubusercontent.com/55771758/180497120-9049dc00-202c-4cec-9832-d768b3466d1e.png)
![tempsnip](https://user-images.githubusercontent.com/55771758/180498078-0ebe8111-fbe9-4638-9b4c-3bc39b82d7da.png)

After this fix goes in, Explorer will need to be updated to consume the most recent version of cardboard.

### Testing 🧪
*** IF you would prefer not to clone these models yourself, just ping me and we can walk through using my ADT instead
Repro error in Explorer: 
1. git clone this repo: https://github.com/RealEstateCore/BRECK-DTDL.git
2. do git checkout 737a1c8b63 (will revert to dtdl v2)
3. go to https://explorer.digitaltwins.azure.net/
4. Upload folder "Point" (or, if you don't want to upload all 1000 models, upload the following files: Point.json, Sensor.json, Power_Sensor.json, Electric_Power_Sensor.json, and Active_Power_Sensor.json)
5. Select "Active Power Sensor" under models and create a twin; call it "ActivePowerSensorTwin" 
![image](https://user-images.githubusercontent.com/55771758/180498895-de39ecc6-8696-4790-a710-01e2d6b939f4.png)
6. Click twin in graph and see error as above

Repro error in cardboard:
1. Go to PropertyInspector.stories.local.tsx and change twin to "ActivePowerSensorTwin" 
![image](https://user-images.githubusercontent.com/55771758/180499194-d0db56e7-6b00-42af-8720-89474b1fd5aa.png)
2. Go to Storybook -> Property Inspector -> Adt Twin
3. You should see a similar error as in Explorer

Test this fix:
1. Pull this branch and go to Storybook -> Property Inspector -> Adt Twin
2. You should see the fields showing up properly as above; try editing and saving
3. Property Inspector in all other locations (ADT Explorer, Mock) should work the same

This PR also fixes error where Property Inspector dropdown has same color for text and background when property is unedited: 
![image](https://user-images.githubusercontent.com/55771758/180586041-77bef791-cc26-4d49-9f81-b77fea892b5a.png)
Should now look like:
![image](https://user-images.githubusercontent.com/55771758/180586116-0cc775fe-81d8-48a7-9bcb-256e61061bc2.png)
(And working with all themes)

### Checklist ✔️
- [ ] Linked associated issue (if present)
- [x] Added relevant labels
- [x] Requested developer reviews
- [ ] Request UI review from design / PM
- [ ] Verify all code checks are passing