### PR TITLE
Fix upload file issue for selecting existing file

### DIFF
--- a/src/Components/SceneList/Internal/SceneDialog.state.ts
+++ b/src/Components/SceneList/Internal/SceneDialog.state.ts
@@ -20,7 +20,6 @@ export const getDefaultSceneDialogState = (
         behaviorIDs: [],
         assets: []
     },
-    sceneBlobUrl: scene ? scene?.assets?.[0]?.url || '' : '',
     isShowOnGlobeEnabled: Boolean(
         !(isNaN(scene?.latitude) || isNaN(scene?.longitude))
     ),
@@ -52,7 +51,12 @@ export const SceneDialogReducer: (
                 draft.scene.longitude = action.payload.longitude;
                 break;
             case SceneDialogActionType.SET_SCENE_BLOB_URL:
-                draft.sceneBlobUrl = action.payload.sceneBlobUrl;
+                draft.scene.assets = [
+                    {
+                        type: '3DAsset',
+                        url: action.payload.sceneBlobUrl
+                    }
+                ];
                 break;
             case SceneDialogActionType.SET_IS_SELECTED_FILE_EXIST_IN_BLOB:
                 draft.isSelectedFileExistInBlob =

--- a/src/Components/SceneList/Internal/SceneDialog.tsx
+++ b/src/Components/SceneList/Internal/SceneDialog.tsx
@@ -35,6 +35,7 @@ import {
     getDefaultSceneDialogState,
     SceneDialogReducer
 } from './SceneDialog.state';
+import { IScene } from '../../../Models/Types/Generated/3DScenesConfiguration-v1.0.0';
 const fileUploadLabelTooltipStyles: ITooltipHostStyles = {
     root: {
         display: 'inline-block',
@@ -114,36 +115,6 @@ const SceneDialog: React.FC<ISceneDialogProps> = ({
         refetchDependencies: [adapter],
         isAdapterCalledOnMount: false
     });
-
-    useEffect(() => {
-        if (!put3DFileBlob.adapterResult.hasNoData()) {
-            const newlyAdded3DFile: IStorageBlob =
-                put3DFileBlob.adapterResult.result.data[0];
-            if (sceneToEdit) {
-                const sceneObjectForAddOrEdit = {
-                    ...sceneToEdit,
-                    assets: [
-                        {
-                            type: '3DAsset',
-                            url: newlyAdded3DFile.Path
-                        }
-                    ]
-                };
-                onEditScene(sceneObjectForAddOrEdit);
-            } else {
-                const sceneObjectForAddOrEdit = {
-                    ...state.scene,
-                    assets: [
-                        {
-                            type: '3DAsset',
-                            url: newlyAdded3DFile.Path
-                        }
-                    ]
-                };
-                onAddScene(sceneObjectForAddOrEdit);
-            }
-        }
-    }, [put3DFileBlob.adapterResult.result]);
 
     const dialogContentProps: IDialogContentProps = {
         type: DialogType.normal,
@@ -242,11 +213,7 @@ const SceneDialog: React.FC<ISceneDialogProps> = ({
                 fileToUpload: state.selectedFile
             });
         } else {
-            if (sceneToEdit) {
-                onEditScene(state.scene);
-            } else {
-                onAddScene(state.scene);
-            }
+            saveScene(undefined); // don't need the url, it's on the state
         }
     };
 
@@ -313,6 +280,38 @@ const SceneDialog: React.FC<ISceneDialogProps> = ({
         });
     }, []);
 
+    const saveScene = useCallback(
+        (fileUrl: string) => {
+            // need to store the newly stored file URL since the call just finished
+            const sceneToSave: IScene = fileUrl
+                ? {
+                      ...state.scene,
+                      assets: [
+                          {
+                              type: '3DAsset',
+                              url: fileUrl
+                          }
+                      ]
+                  }
+                : state.scene;
+            if (sceneToEdit) {
+                onEditScene(sceneToSave);
+            } else {
+                onAddScene(sceneToSave);
+            }
+        },
+        [onAddScene, onEditScene, sceneToEdit, state.scene]
+    );
+
+    // when storing the file finishes during save, trigger the callbacks
+    useEffect(() => {
+        if (!put3DFileBlob.adapterResult.hasNoData()) {
+            const newlyAdded3DFile: IStorageBlob =
+                put3DFileBlob.adapterResult.result.data[0];
+            saveScene(newlyAdded3DFile.Path);
+        }
+    }, [put3DFileBlob.adapterResult.result]);
+
     const isSubmitButtonDisabled = useMemo(() => {
         return (
             !state.scene.displayName ||
@@ -321,7 +320,7 @@ const SceneDialog: React.FC<ISceneDialogProps> = ({
                     isNaN(state.scene.longitude))) ||
             (state.selected3DFilePivotItem ===
                 SelectionModeOf3DFile.FromContainer &&
-                !state.sceneBlobUrl) ||
+                !state.scene.assets?.[0]?.url) ||
             (state.selected3DFilePivotItem ===
                 SelectionModeOf3DFile.FromComputer &&
                 (!state.selectedFile ||
@@ -331,12 +330,15 @@ const SceneDialog: React.FC<ISceneDialogProps> = ({
         );
     }, [
         state.scene.displayName,
-        state.sceneBlobUrl,
+        state.scene.latitude,
+        state.scene.longitude,
+        state.scene.assets,
+        state.isShowOnGlobeEnabled,
         state.selected3DFilePivotItem,
         state.selectedFile,
         state.isSelectedFileExistInBlob,
         state.isOverwriteFile,
-        put3DFileBlob
+        put3DFileBlob.isLoading
     ]);
     const styleStack: IStackStyles = {
         root: {

--- a/src/Components/SceneList/SceneList.types.ts
+++ b/src/Components/SceneList/SceneList.types.ts
@@ -33,7 +33,6 @@ export enum SelectionModeOf3DFile {
 
 export interface SceneDialogState {
     scene: IScene;
-    sceneBlobUrl: string;
     isSelectedFileExistInBlob: boolean;
     isOverwriteFile: boolean;
     blobsInContainer: IStorageBlob[];


### PR DESCRIPTION
### Summary of changes 🔍 
When creating a new scene or editing an existing one, it was not storing the blobl URL for the selected file if you select a file from the container.

Fixes issue #653 

### Testing 🧪
- [x] Create a new scene by uploading a new file
- [x] Create a new scene by using existing file in the container
- [x] Edit a scene and upload a new file
- [x] Edit a scene and select an existing file

### Checklist ✔️
- [ ] Linked associated issue (if present)
- [ ] Added relevant labels
- [ ] Requested developer reviews
- [ ] Request UI review from design / PM
- [ ] Verify all code checks are passing