### PR TITLE
tooltip hover fix

### DIFF
--- a/src/Components/TooltipCallout/TooltipCallout.styles.ts
+++ b/src/Components/TooltipCallout/TooltipCallout.styles.ts
@@ -12,7 +12,11 @@ export const getStyles = (
 ): ITooltipCalloutStyles => {
     const { theme } = props;
     return {
-        root: [classNames.root],
+        root: {
+            height: 'fit-content',
+            width: 'fit-content',
+            ...[classNames.root]
+        },
         subComponentStyles: {
             button: {
                 root: {
@@ -24,6 +28,11 @@ export const getStyles = (
                 root: {
                     maxWidth: 300,
                     padding: 8
+                    // },
+                    // beak: {
+                    //     border: '8px solid transparent',
+                    //     padding: '8px',
+                    //     margin: '8px'
                 }
             }
         }

--- a/src/Components/TooltipCallout/TooltipCallout.styles.ts
+++ b/src/Components/TooltipCallout/TooltipCallout.styles.ts
@@ -12,7 +12,7 @@ export const getStyles = (
 ): ITooltipCalloutStyles => {
     const { theme } = props;
     return {
-        root: classNames.root,
+        root: [classNames.root],
         subComponentStyles: {
             button: {
                 root: {

--- a/src/Components/TooltipCallout/TooltipCallout.styles.ts
+++ b/src/Components/TooltipCallout/TooltipCallout.styles.ts
@@ -12,11 +12,7 @@ export const getStyles = (
 ): ITooltipCalloutStyles => {
     const { theme } = props;
     return {
-        root: {
-            height: 'fit-content',
-            width: 'fit-content',
-            ...[classNames.root]
-        },
+        root: classNames.root,
         subComponentStyles: {
             button: {
                 root: {
@@ -26,13 +22,7 @@ export const getStyles = (
             },
             callout: {
                 root: {
-                    maxWidth: 300,
-                    padding: 8
-                    // },
-                    // beak: {
-                    //     border: '8px solid transparent',
-                    //     padding: '8px',
-                    //     margin: '8px'
+                    display: 'inline-block'
                 }
             }
         }

--- a/src/Components/TooltipCallout/TooltipCallout.tsx
+++ b/src/Components/TooltipCallout/TooltipCallout.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import {
     ITooltipCalloutProps,
     ITooltipCalloutStyleProps,
@@ -10,10 +10,11 @@ import {
     classNamesFunction,
     useTheme,
     styled,
-    Callout,
     DirectionalHint,
     IconButton,
-    Link
+    Link,
+    TooltipHost,
+    TooltipDelay
 } from '@fluentui/react';
 import { useTranslation } from 'react-i18next';
 
@@ -25,8 +26,6 @@ const getClassNames = classNamesFunction<
 const TooltipCallout: React.FC<ITooltipCalloutProps> = (props) => {
     const { content, calloutProps, dataTestId, styles } = props;
     const { buttonAriaLabel, calloutContent, iconName, link } = content;
-    // state
-    const [flyoutVisible, setFlyoutVisible] = useState(false);
 
     // hooks
     const id = useId();
@@ -38,43 +37,34 @@ const TooltipCallout: React.FC<ITooltipCalloutProps> = (props) => {
     });
 
     return (
-        <span
-            className={classNames.root}
-            onMouseEnter={() => setFlyoutVisible(true)}
-            onMouseLeave={() => setFlyoutVisible(false)}
-            onFocusCapture={() => setFlyoutVisible(true)}
-        >
-            <IconButton
-                ariaLabel={buttonAriaLabel}
-                data-testid={dataTestId}
-                id={id}
-                iconProps={{ iconName: iconName || 'Info' }}
-                styles={classNames.subComponentStyles.button()}
-            />
-            <Callout
+        <div>
+            <TooltipHost
                 directionalHint={DirectionalHint.rightCenter}
                 {...calloutProps}
-                target={`#${id}`}
-                hidden={!flyoutVisible}
-                onMouseEnter={() => {
-                    console.log('entered');
-                    setFlyoutVisible(true);
-                }}
-                onDismiss={() => setFlyoutVisible(false)}
-                onMouseLeave={() => setFlyoutVisible(false)}
-                onBlur={() => setFlyoutVisible(false)}
+                delay={TooltipDelay.zero}
                 styles={classNames.subComponentStyles.callout}
-                shouldUpdateWhenHidden
+                content={
+                    <div style={{ fontSize: '14px' }}>
+                        {calloutContent}
+                        {link && ' '}
+                        {link && (
+                            <Link target="_blank" href={link.url}>
+                                {link.text || t('learnMore')}
+                            </Link>
+                        )}
+                    </div>
+                }
+                style={{ maxWidth: '290px' }}
             >
-                {calloutContent}
-                {link && ' '}
-                {link && (
-                    <Link target="_blank" href={link.url}>
-                        {link.text || t('learnMore')}
-                    </Link>
-                )}
-            </Callout>
-        </span>
+                <IconButton
+                    ariaLabel={buttonAriaLabel}
+                    data-testid={dataTestId}
+                    id={id}
+                    iconProps={{ iconName: iconName || 'Info' }}
+                    styles={classNames.subComponentStyles.button()}
+                />
+            </TooltipHost>
+        </div>
     );
 };
 

--- a/src/Components/TooltipCallout/TooltipCallout.tsx
+++ b/src/Components/TooltipCallout/TooltipCallout.tsx
@@ -37,34 +37,32 @@ const TooltipCallout: React.FC<ITooltipCalloutProps> = (props) => {
     });
 
     return (
-        <div>
-            <TooltipHost
-                directionalHint={DirectionalHint.rightCenter}
-                {...calloutProps}
-                delay={TooltipDelay.zero}
-                styles={classNames.subComponentStyles.callout}
-                content={
-                    <div style={{ fontSize: '14px' }}>
-                        {calloutContent}
-                        {link && ' '}
-                        {link && (
-                            <Link target="_blank" href={link.url}>
-                                {link.text || t('learnMore')}
-                            </Link>
-                        )}
-                    </div>
-                }
-                style={{ maxWidth: '290px' }}
-            >
-                <IconButton
-                    ariaLabel={buttonAriaLabel}
-                    data-testid={dataTestId}
-                    id={id}
-                    iconProps={{ iconName: iconName || 'Info' }}
-                    styles={classNames.subComponentStyles.button()}
-                />
-            </TooltipHost>
-        </div>
+        <TooltipHost
+            directionalHint={DirectionalHint.rightCenter}
+            {...calloutProps}
+            delay={TooltipDelay.zero}
+            styles={classNames.subComponentStyles.callout}
+            content={
+                <div style={{ fontSize: '14px' }}>
+                    {calloutContent}
+                    {link && ' '}
+                    {link && (
+                        <Link target="_blank" href={link.url}>
+                            {link.text || t('learnMore')}
+                        </Link>
+                    )}
+                </div>
+            }
+            style={{ maxWidth: '290px' }}
+        >
+            <IconButton
+                ariaLabel={buttonAriaLabel}
+                data-testid={dataTestId}
+                id={id}
+                iconProps={{ iconName: iconName || 'Info' }}
+                styles={classNames.subComponentStyles.button()}
+            />
+        </TooltipHost>
     );
 };
 

--- a/src/Components/TooltipCallout/TooltipCallout.tsx
+++ b/src/Components/TooltipCallout/TooltipCallout.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
     ITooltipCalloutProps,
     ITooltipCalloutStyleProps,
     ITooltipCalloutStyles
 } from './TooltipCallout.types';
 import { getStyles } from './TooltipCallout.styles';
-import { useBoolean, useId } from '@fluentui/react-hooks';
+import { useId } from '@fluentui/react-hooks';
 import {
     classNamesFunction,
     useTheme,
@@ -26,7 +26,7 @@ const TooltipCallout: React.FC<ITooltipCalloutProps> = (props) => {
     const { content, calloutProps, dataTestId, styles } = props;
     const { buttonAriaLabel, calloutContent, iconName, link } = content;
     // state
-    const [flyoutVisible, { toggle: toggleFlyout }] = useBoolean(false);
+    const [flyoutVisible, setFlyoutVisible] = useState(false);
 
     // hooks
     const id = useId();
@@ -38,36 +38,43 @@ const TooltipCallout: React.FC<ITooltipCalloutProps> = (props) => {
     });
 
     return (
-        <div className={classNames.root}>
+        <span
+            className={classNames.root}
+            onMouseEnter={() => setFlyoutVisible(true)}
+            onMouseLeave={() => setFlyoutVisible(false)}
+            onFocusCapture={() => setFlyoutVisible(true)}
+        >
             <IconButton
                 ariaLabel={buttonAriaLabel}
                 data-testid={dataTestId}
                 id={id}
                 iconProps={{ iconName: iconName || 'Info' }}
-                onFocus={toggleFlyout}
-                onBlur={toggleFlyout}
-                onMouseEnter={toggleFlyout}
-                onMouseLeave={toggleFlyout}
                 styles={classNames.subComponentStyles.button()}
             />
-            {flyoutVisible && (
-                <Callout
-                    directionalHint={DirectionalHint.rightCenter}
-                    {...calloutProps}
-                    target={`#${id}`}
-                    onDismiss={toggleFlyout}
-                    styles={classNames.subComponentStyles.callout}
-                >
-                    {calloutContent}
-                    {link && ' '}
-                    {link && (
-                        <Link target="_blank" href={link.url}>
-                            {link.text || t('learnMore')}
-                        </Link>
-                    )}
-                </Callout>
-            )}
-        </div>
+            <Callout
+                directionalHint={DirectionalHint.rightCenter}
+                {...calloutProps}
+                target={`#${id}`}
+                hidden={!flyoutVisible}
+                onMouseEnter={() => {
+                    console.log('entered');
+                    setFlyoutVisible(true);
+                }}
+                onDismiss={() => setFlyoutVisible(false)}
+                onMouseLeave={() => setFlyoutVisible(false)}
+                onBlur={() => setFlyoutVisible(false)}
+                styles={classNames.subComponentStyles.callout}
+                shouldUpdateWhenHidden
+            >
+                {calloutContent}
+                {link && ' '}
+                {link && (
+                    <Link target="_blank" href={link.url}>
+                        {link.text || t('learnMore')}
+                    </Link>
+                )}
+            </Callout>
+        </span>
     );
 };
 

--- a/src/Components/TooltipCallout/TooltipCallout.types.ts
+++ b/src/Components/TooltipCallout/TooltipCallout.types.ts
@@ -1,10 +1,10 @@
 import {
     IButtonStyles,
-    ICalloutContentStyles,
-    ICalloutProps,
     IStyle,
     IStyleFunctionOrObject,
-    ITheme
+    ITheme,
+    ITooltipHostProps,
+    ITooltipStyles
 } from '@fluentui/react';
 import { IIconNames } from '../../Models/Constants';
 
@@ -22,7 +22,7 @@ export interface ITooltipCalloutContent {
 
 export interface ITooltipCalloutProps {
     content: ITooltipCalloutContent;
-    calloutProps?: Omit<ICalloutProps, 'target' | 'onDismiss' | 'styles'>;
+    calloutProps?: Omit<ITooltipHostProps, 'styles'>;
     dataTestId?: string;
     /**
      * Call to provide customized styling that will layer on top of the variant rules.
@@ -47,5 +47,5 @@ export interface ITooltipCalloutStyles {
 
 export interface ITooltipCalloutSubComponentStyles {
     button?: IButtonStyles;
-    callout?: Partial<ICalloutContentStyles>;
+    callout?: Partial<ITooltipStyles>;
 }


### PR DESCRIPTION
### Summary of changes 🔍 
See original issue here: https://github.com/microsoft/iot-cardboard-js/issues/524

![image](https://user-images.githubusercontent.com/55771758/182445824-28a84e54-63c5-4068-af4e-1718ad12bf29.png)

The TooltipCallout component could not be interacted with. This PR addresses the bug by replacing the component's Fluent Callout with Fluent Tooltip. 

As a result, there are a few cosmetic differences (such as a change in animation), but otherwise the functionality has improved/remained the same.

### Testing 🧪
Ensure that hovering/clicking behavior now works in the TooltipCallout stories.

See the fix in the original error site by going to BehaviorForm -> Edit Status Tab -> hover over Property expression "i" and ensure that you are able to click on "Learn more."

### Checklist ✔️
- [x] Linked associated issue (if present)
- [x] Added relevant labels
- [x] Requested developer reviews
- [ ] Request UI review from design / PM
- [ ] Verify all code checks are passing