### PR TITLE
Move theme control to be with the rest of the header controls

### DIFF
--- a/src/Components/3DV/SceneViewWrapper.styles.ts
+++ b/src/Components/3DV/SceneViewWrapper.styles.ts
@@ -30,16 +30,6 @@ export const getStyles = (
         root: [classNames.root],
         leftHeaderControlsContainer: [classNames.leftHeader],
         subComponentStyles: {
-            rightHeaderControlsStack: {
-                root: {
-                    alignItems: 'center',
-                    // hacks for dayz. will remove when we pull the control up a layer
-                    right: mode === WrapperMode.Viewer ? 420 : 272,
-                    position: 'absolute',
-                    top: VIEWER_HEADER_TOP_OFFSET,
-                    zIndex: 1
-                }
-            },
             cameraControlsStack: {
                 root: {
                     bottom:

--- a/src/Components/3DV/SceneViewWrapper.styles.ts
+++ b/src/Components/3DV/SceneViewWrapper.styles.ts
@@ -1,7 +1,6 @@
 import {
     BUILDER_CAMERA_CONTROLS_BOTTOM_OFFSET,
-    VIEWER_CAMERA_CONTROLS_BOTTOM_OFFSET,
-    VIEWER_HEADER_TOP_OFFSET
+    VIEWER_CAMERA_CONTROLS_BOTTOM_OFFSET
 } from '../../Models/Constants/StyleConstants';
 import { WrapperMode } from './SceneView.types';
 import {

--- a/src/Components/3DV/SceneViewWrapper.tsx
+++ b/src/Components/3DV/SceneViewWrapper.tsx
@@ -31,7 +31,6 @@ import {
     ISceneViewWrapperStyleProps,
     ISceneViewWrapperStyles
 } from './SceneViewWrapper.types';
-import SceneThemePicker from '../ModelViewerModePicker/SceneThemePicker';
 import { useSceneThemeContext } from '../../Models/Context/SceneThemeContext/SceneThemeContext';
 import { WrapperMode } from './SceneView.types';
 
@@ -45,7 +44,6 @@ const SceneViewWrapper: React.FC<ISceneViewWrapperProps> = (props) => {
         adapter,
         addInProps,
         config,
-        hideViewModePickerUI,
         objectColorUpdated,
         sceneId,
         sceneViewProps,
@@ -211,12 +209,6 @@ const SceneViewWrapper: React.FC<ISceneViewWrapperProps> = (props) => {
                         )
                     }
                 />
-            </Stack>
-            <Stack
-                horizontal
-                styles={classNames.subComponentStyles.rightHeaderControlsStack}
-            >
-                {!hideViewModePickerUI && <SceneThemePicker />}
             </Stack>
         </div>
     );

--- a/src/Components/3DV/SceneViewWrapper.types.ts
+++ b/src/Components/3DV/SceneViewWrapper.types.ts
@@ -31,6 +31,5 @@ export interface ISceneViewWrapperStyles {
 }
 
 export interface ISceneViewWrapperSubComponentStyles {
-    rightHeaderControlsStack: IStackStyles;
     cameraControlsStack: IStackStyles;
 }

--- a/src/Components/ADT3DBuilder/ADT3DBuilder.tsx
+++ b/src/Components/ADT3DBuilder/ADT3DBuilder.tsx
@@ -33,7 +33,6 @@ const ADT3DBuilder: React.FC<IADT3DBuilderProps> = (props) => {
         showHoverOnSelected,
         outlinedMeshItems,
         objectColorUpdated,
-        hideViewModePickerUI,
         styles
     } = props;
 
@@ -67,7 +66,6 @@ const ADT3DBuilder: React.FC<IADT3DBuilderProps> = (props) => {
             <div className={classNames.wrapper}>
                 <SceneViewWrapper
                     objectColorUpdated={objectColorUpdated}
-                    hideViewModePickerUI={hideViewModePickerUI}
                     wrapperMode={WrapperMode.Builder}
                     sceneViewProps={{
                         ...svp,

--- a/src/Components/ADT3DBuilder/ADT3DBuilder.types.ts
+++ b/src/Components/ADT3DBuilder/ADT3DBuilder.types.ts
@@ -17,7 +17,6 @@ export interface IADT3DBuilderProps {
     showHoverOnSelected?: boolean;
     outlinedMeshItems?: CustomMeshItem[];
     objectColorUpdated?: (objectColor: IADTObjectColor) => void;
-    hideViewModePickerUI?: boolean;
     sceneViewProps?: ISceneViewProps;
     /**
      * Call to provide customized styling that will layer on top of the variant rules.

--- a/src/Components/ADT3DViewer/ADT3DViewer.tsx
+++ b/src/Components/ADT3DViewer/ADT3DViewer.tsx
@@ -62,6 +62,7 @@ import { SceneThemeContextProvider } from '../../Models/Context';
 import SceneBreadcrumbFactory from '../SceneBreadcrumb/SceneBreadcrumbFactory';
 import AlertBadge from '../AlertBadge/AlertBadge';
 import { useSceneThemeContext } from '../../Models/Context/SceneThemeContext/SceneThemeContext';
+import SceneThemePicker from '../ModelViewerModePicker/SceneThemePicker';
 
 const getClassNames = classNamesFunction<
     IADT3DViewerStyleProps,
@@ -702,7 +703,6 @@ const ADT3DViewerBase: React.FC<IADT3DViewerProps> = ({
                     sceneId={sceneId}
                     sceneVisuals={sceneVisuals}
                     addInProps={addInProps}
-                    hideViewModePickerUI={hideViewModePickerUI}
                     wrapperMode={WrapperMode.Viewer}
                     selectedVisual={selectedVisual}
                     sceneViewProps={{
@@ -732,7 +732,7 @@ const ADT3DViewerBase: React.FC<IADT3DViewerProps> = ({
                     tokens={{ childrenGap: 8 }}
                 >
                     <DeeplinkFlyout mode="Options" />
-                    {/* TODO: MOVE THEME PICKER HERE */}
+                    {!hideViewModePickerUI && <SceneThemePicker />}
                     <div className={classNames.layersPicker}>
                         <LayerDropdown
                             layers={layersInScene}

--- a/src/Models/Constants/Interfaces.ts
+++ b/src/Models/Constants/Interfaces.ts
@@ -716,7 +716,6 @@ export interface ISceneViewWrapperProps {
     sceneViewProps: ISceneViewProps;
     sceneVisuals?: SceneVisual[];
     addInProps?: IADT3DAddInProps;
-    hideViewModePickerUI?: boolean;
     selectedVisual?: Partial<SceneVisual>;
     objectColorUpdated?: (objectColor: IADTObjectColor) => void;
     wrapperMode: WrapperMode;


### PR DESCRIPTION
### Summary of changes 🔍 
When we refactored the theme context out to a standalone control, we delayed moving the actual control to the parent. Now it's ready. So we are moving it to be with the rest of the header controls.

### Checklist ✔️
- [ ] Linked associated issue (if present)
- [ ] Added relevant labels
- [ ] Requested developer reviews
- [ ] Request UI review from design / PM
- [ ] Verify all code checks are passing