### PR TITLE
Clear timeouts on unmount of scene refresh control

### DIFF
--- a/src/Components/DeeplinkFlyout/DeeplinkFlyout.tsx
+++ b/src/Components/DeeplinkFlyout/DeeplinkFlyout.tsx
@@ -134,8 +134,10 @@ const DeeplinkFlyout: React.FC<IDeeplinkFlyoutProps> = (props) => {
     );
 };
 
-export default styled<
-    IDeeplinkFlyoutProps,
-    IDeeplinkFlyoutStyleProps,
-    IDeeplinkFlyoutStyles
->(DeeplinkFlyout, getStyles);
+export default React.memo(
+    styled<
+        IDeeplinkFlyoutProps,
+        IDeeplinkFlyoutStyleProps,
+        IDeeplinkFlyoutStyles
+    >(DeeplinkFlyout, getStyles)
+);

--- a/src/Components/SceneRefreshButton/SceneRefreshButton.tsx
+++ b/src/Components/SceneRefreshButton/SceneRefreshButton.tsx
@@ -42,6 +42,7 @@ const SceneRefreshButton: React.FC<ISceneRefreshButtonProps> = (props) => {
         styles
     } = props;
     const iconAnimationTimeout = useRef<NodeJS.Timeout>();
+    const lastRefreshTimeout = useRef<NodeJS.Timeout>();
 
     // state
     const [isRefreshInProgress, setIsRefreshInProgress] = useState<boolean>(
@@ -76,8 +77,9 @@ const SceneRefreshButton: React.FC<ISceneRefreshButtonProps> = (props) => {
         }
     }, [isRefreshing]);
 
+    clearTimeout(lastRefreshTimeout.current);
     // to get live updating we have to trigger renders and recalculate on a regular cadence so set a timer to keep checking
-    setTimeout(() => {
+    lastRefreshTimeout.current = setTimeout(() => {
         const timeSince =
             lastRefreshTimeInMs > 0 ? Date.now() - lastRefreshTimeInMs : 0;
         const timeSinceRefresh = formatTimeInRelevantUnits(
@@ -92,6 +94,15 @@ const SceneRefreshButton: React.FC<ISceneRefreshButtonProps> = (props) => {
             formatTimeInRelevantUnits(refreshFrequency, DurationUnits.seconds),
         [refreshFrequency]
     );
+
+    // side effects
+    useEffect(() => {
+        // clear the timeouts on unmount
+        return () => {
+            clearTimeout(lastRefreshTimeout.current);
+            clearTimeout(iconAnimationTimeout.current);
+        };
+    }, []);
 
     return (
         <div className={classNames.root}>

--- a/src/Components/SceneRefreshButton/SceneRefreshButton.tsx
+++ b/src/Components/SceneRefreshButton/SceneRefreshButton.tsx
@@ -71,7 +71,7 @@ const SceneRefreshButton: React.FC<ISceneRefreshButtonProps> = (props) => {
         if (isRefreshing) {
             setIsRefreshInProgress(true); // apply the styling
             clearTimeout(iconAnimationTimeout.current); // clear any pending timeouts
-            setTimeout(() => {
+            iconAnimationTimeout.current = setTimeout(() => {
                 setIsRefreshInProgress(false);
             }, ANIMATION_DURATION_SECONDS * 1000 + 0.1); // give it enough time to finish the animation, then remove the style
         }

--- a/src/Components/SceneRefreshButton/SceneRefreshButton.tsx
+++ b/src/Components/SceneRefreshButton/SceneRefreshButton.tsx
@@ -41,8 +41,8 @@ const SceneRefreshButton: React.FC<ISceneRefreshButtonProps> = (props) => {
         refreshFrequency,
         styles
     } = props;
-    const iconAnimationTimeout = useRef<NodeJS.Timeout>();
-    const lastRefreshTimeout = useRef<NodeJS.Timeout>();
+    const iconAnimationTimeout = useRef(null);
+    const lastRefreshTimeout = useRef(null);
 
     // state
     const [isRefreshInProgress, setIsRefreshInProgress] = useState<boolean>(


### PR DESCRIPTION
### Summary of changes 🔍 
Fixes an error in the console due to unmounting the component and trying to update state in the timers.
![image](https://user-images.githubusercontent.com/57726991/184411950-67d17b6f-28c0-42b3-9c37-1a0afba350d5.png)

### Testing 🧪
- [x] Go to the 3DV -> Viewer stories and switch between stories. If you do this on main you'll see the error, on this branch you should not see it.

### Checklist ✔️
- [x] Added relevant labels
- [x] Requested developer reviews