### PR TITLE
feat: enable dynamic cache length for resources

### DIFF
--- a/src/Adapters/ADTAdapter.ts
+++ b/src/Adapters/ADTAdapter.ts
@@ -139,6 +139,10 @@ export default class ADTAdapter implements IADTAdapter {
         this.adtHostUrl = hostName;
     }
 
+    setTwinCacheLength(maxAge: number) {
+        this.adtTwinCache.setMaxAgeMs(maxAge);
+    }
+
     getRelationships(id: string) {
         const adapterMethodSandbox = new AdapterMethodSandbox(this.authService);
 

--- a/src/Adapters/MockAdapter.ts
+++ b/src/Adapters/MockAdapter.ts
@@ -130,6 +130,9 @@ export default class MockAdapter
         this.mockModels = (mockModelData as any) as DtdlInterface[];
         this.initializeMockTwinProperties();
     }
+    setTwinCacheLength(_maxAge: number): void {
+        // NO-OP on mock adapter since we don't have a cache
+    }
 
     async mockNetwork() {
         // If mocking network latency, wait for networkTimeoutMillis

--- a/src/Models/Classes/AdapterEntityCache.ts
+++ b/src/Models/Classes/AdapterEntityCache.ts
@@ -18,6 +18,11 @@ class AdapterEntityCache<T extends IAdapterData> {
         this.maxAgeMs = maxAgeMs;
     }
 
+    setMaxAgeMs(maxAge: number): void {
+        this.maxAgeMs = maxAge;
+        this.cachedEntities = new Map();
+    }
+
     /**
      * Retrieves an entity from the cache.  If the entity is stale, getEntityData will be executed to resolve the entity
      * @param key The key for the desired entity
@@ -71,7 +76,7 @@ class CachedEntity<T extends IAdapterData> {
     }
 
     public isStale(maxAgeMs: number) {
-        return this.createdTimeMs + maxAgeMs < new Date().valueOf();
+        return this.createdTimeMs + maxAgeMs < Date.now();
     }
 
     private async getAdapterResult(

--- a/src/Models/Constants/Interfaces.ts
+++ b/src/Models/Constants/Interfaces.ts
@@ -427,6 +427,12 @@ export interface IADT3DViewerAdapter {
         visibleLayerIds?: string[],
         bustCache?: boolean
     ): AdapterReturnType<ADT3DViewerData>;
+
+    /**
+     * Updates the cache lifetime for twin data and busts the current cache
+     * @param maxAge The duration in milliseconds that the cache should be valid
+     */
+    setTwinCacheLength(maxAge: number): void;
 }
 
 export interface IADTAdapter
@@ -439,6 +445,20 @@ export interface IADTAdapter
     getADTTwinsByModelId(
         params: AdapterMethodParamsForGetADTTwinsByModelId
     ): AdapterReturnType<ADTAdapterTwinsData>;
+
+    getSceneData(
+        sceneId: string,
+        config: I3DScenesConfig,
+        visibleLayerIds?: string[],
+        bustCache?: boolean
+    ): AdapterReturnType<ADT3DViewerData>;
+
+    /**
+     * Updates the cache lifetime for twin data and busts the current cache
+     * @param maxAge The duration in milliseconds that the cache should be valid
+     */
+    setTwinCacheLength(maxAge: number): void;
+
     searchADTTwins(
         params: AdapterMethodParamsForSearchADTTwins
     ): AdapterReturnType<ADTAdapterTwinsData>;

--- a/src/Models/Hooks/useRuntimeSceneData.ts
+++ b/src/Models/Hooks/useRuntimeSceneData.ts
@@ -58,6 +58,12 @@ export const useRuntimeSceneData = (
         pollingIntervalMillis: pollingInterval
     });
 
+    // notify the adapter of the updating polling interval so the cache length can be adjusted
+    useEffect(() => {
+        // use a value slightly lower than the interval so that there is not a race between the polling and the cache expiring
+        adapter.setTwinCacheLength(pollingInterval - 0.2 * pollingInterval);
+    }, [pollingInterval]);
+
     /**
      * After getting ADT3DViewerData (including scene visuals along with 3d model URL) from adapter, parse it to
      * update the colored meshes ids based on run expressions in behaviors against the returned ADT twin property data


### PR DESCRIPTION
### Summary of changes 🔍 
Allow the cache length for an entity to be updated dynamically. In particular, allow this when the user is selecting a refresh rate faster than the default cache length of 10 seconds.

### Testing 🧪
 > [ Add any special instructions needed to test or view your changes such as environment URLs or other config details. ]

### Checklist ✔️
- [ ] Linked associated issue (if present)
- [ ] Added relevant labels
- [ ] Requested developer reviews
- [ ] Request UI review from design / PM
- [ ] Verify all code checks are passing