### PR TITLE
Add metrics telemetry event and rename existing types

### DIFF
--- a/src/Components/SceneList/SceneList.tsx
+++ b/src/Components/SceneList/SceneList.tsx
@@ -331,6 +331,9 @@ const SceneList: React.FC<SceneListProps> = ({
                         <ActionButton
                             iconProps={{ iconName: 'Add' }}
                             onClick={() => {
+                                useTelemetry().sendEventTelemetry({
+                                    name: 'Create scene - open'
+                                });
                                 setIsSceneDialogOpen(true);
                             }}
                             disabled={
@@ -442,7 +445,7 @@ const SceneList: React.FC<SceneListProps> = ({
                     sceneToEdit={selectedScene}
                     onEditScene={(updatedScene) => {
                         useTelemetry().sendEventTelemetry({
-                            name: 'Edit scene confirm'
+                            name: 'Edit scene - confirm'
                         });
                         editScene.callAdapter({
                             config: config,
@@ -452,7 +455,7 @@ const SceneList: React.FC<SceneListProps> = ({
                     }}
                     onAddScene={(newScene) => {
                         useTelemetry().sendEventTelemetry({
-                            name: 'Create scene confirm'
+                            name: 'Create scene - confirm'
                         });
                         let newId = createGUID();
                         const existingIds = sceneList.map((s) => s.id);

--- a/src/Components/SceneList/SceneList.tsx
+++ b/src/Components/SceneList/SceneList.tsx
@@ -55,6 +55,7 @@ const SceneList: React.FC<SceneListProps> = ({
         adapterMethod: () => adapter.getScenesConfig(),
         refetchDependencies: [adapter]
     });
+    const { sendEventTelemetry } = useTelemetry();
 
     const addScene = useAdapter({
         adapterMethod: (params: { config: I3DScenesConfig; scene: IScene }) =>
@@ -208,7 +209,7 @@ const SceneList: React.FC<SceneListProps> = ({
                                 event.stopPropagation();
                                 setSelectedScene(item);
                                 setIsSceneDialogOpen(true);
-                                useTelemetry().sendEventTelemetry({
+                                sendEventTelemetry({
                                     name: 'Edit scene - open'
                                 });
                             }}
@@ -222,7 +223,7 @@ const SceneList: React.FC<SceneListProps> = ({
                                 event.stopPropagation();
                                 setSelectedScene(item);
                                 setIsConfirmDeleteDialogOpen(true);
-                                useTelemetry().sendEventTelemetry({
+                                sendEventTelemetry({
                                     name: 'Delete scene - open'
                                 });
                             }}
@@ -331,7 +332,7 @@ const SceneList: React.FC<SceneListProps> = ({
                         <ActionButton
                             iconProps={{ iconName: 'Add' }}
                             onClick={() => {
-                                useTelemetry().sendEventTelemetry({
+                                sendEventTelemetry({
                                     name: 'Create scene - open'
                                 });
                                 setIsSceneDialogOpen(true);
@@ -385,7 +386,7 @@ const SceneList: React.FC<SceneListProps> = ({
                         <DialogFooter>
                             <DefaultButton
                                 onClick={() => {
-                                    useTelemetry().sendEventTelemetry({
+                                    sendEventTelemetry({
                                         name: 'Delete scene - cancel'
                                     });
                                     setIsConfirmDeleteDialogOpen(false);
@@ -394,7 +395,7 @@ const SceneList: React.FC<SceneListProps> = ({
                             />
                             <PrimaryButton
                                 onClick={() => {
-                                    useTelemetry().sendEventTelemetry({
+                                    sendEventTelemetry({
                                         name: 'Delete scene - confirm'
                                     });
                                     deleteScene.callAdapter({
@@ -444,7 +445,7 @@ const SceneList: React.FC<SceneListProps> = ({
                     }}
                     sceneToEdit={selectedScene}
                     onEditScene={(updatedScene) => {
-                        useTelemetry().sendEventTelemetry({
+                        sendEventTelemetry({
                             name: 'Edit scene - confirm'
                         });
                         editScene.callAdapter({
@@ -454,7 +455,7 @@ const SceneList: React.FC<SceneListProps> = ({
                         });
                     }}
                     onAddScene={(newScene) => {
-                        useTelemetry().sendEventTelemetry({
+                        sendEventTelemetry({
                             name: 'Create scene - confirm'
                         });
                         let newId = createGUID();

--- a/src/Components/SceneList/SceneList.tsx
+++ b/src/Components/SceneList/SceneList.tsx
@@ -41,6 +41,7 @@ import {
 } from '../../Models/Types/Generated/3DScenesConfiguration-v1.0.0';
 import IllustrationMessage from '../IllustrationMessage/IllustrationMessage';
 import NoResults from '../../Resources/Static/noResults.svg';
+import useTelemetry from '../../Models/Hooks/useTelemetry';
 
 const SceneList: React.FC<SceneListProps> = ({
     adapter,
@@ -207,6 +208,9 @@ const SceneList: React.FC<SceneListProps> = ({
                                 event.stopPropagation();
                                 setSelectedScene(item);
                                 setIsSceneDialogOpen(true);
+                                useTelemetry().sendEventTelemetry({
+                                    name: 'Edit scene - open'
+                                });
                             }}
                             className={'cb-scenes-action-button'}
                         />
@@ -218,6 +222,9 @@ const SceneList: React.FC<SceneListProps> = ({
                                 event.stopPropagation();
                                 setSelectedScene(item);
                                 setIsConfirmDeleteDialogOpen(true);
+                                useTelemetry().sendEventTelemetry({
+                                    name: 'Delete scene - open'
+                                });
                             }}
                             className={'cb-scenes-action-button'}
                         />
@@ -374,13 +381,19 @@ const SceneList: React.FC<SceneListProps> = ({
                     >
                         <DialogFooter>
                             <DefaultButton
-                                onClick={() =>
-                                    setIsConfirmDeleteDialogOpen(false)
-                                }
+                                onClick={() => {
+                                    useTelemetry().sendEventTelemetry({
+                                        name: 'Delete scene - cancel'
+                                    });
+                                    setIsConfirmDeleteDialogOpen(false);
+                                }}
                                 text={t('cancel')}
                             />
                             <PrimaryButton
                                 onClick={() => {
+                                    useTelemetry().sendEventTelemetry({
+                                        name: 'Delete scene - confirm'
+                                    });
                                     deleteScene.callAdapter({
                                         config: config,
                                         sceneId: selectedScene.id
@@ -428,6 +441,9 @@ const SceneList: React.FC<SceneListProps> = ({
                     }}
                     sceneToEdit={selectedScene}
                     onEditScene={(updatedScene) => {
+                        useTelemetry().sendEventTelemetry({
+                            name: 'Edit scene confirm'
+                        });
                         editScene.callAdapter({
                             config: config,
                             sceneId: updatedScene.id,
@@ -435,6 +451,9 @@ const SceneList: React.FC<SceneListProps> = ({
                         });
                     }}
                     onAddScene={(newScene) => {
+                        useTelemetry().sendEventTelemetry({
+                            name: 'Create scene confirm'
+                        });
                         let newId = createGUID();
                         const existingIds = sceneList.map((s) => s.id);
                         while (existingIds.includes(newId)) {

--- a/src/Models/Hooks/useTelemetry.ts
+++ b/src/Models/Hooks/useTelemetry.ts
@@ -1,9 +1,9 @@
 import {
-    EventTelemetry,
-    ExceptionTelemetry,
-    MetricTelemetry,
-    RequestTelemetry,
-    TraceTelemetry
+    TelemetryEvent,
+    TelemetryException,
+    TelemetryMetric,
+    TelemetryRequest,
+    TelemetryTrace
 } from '../Services/TelemetryService/Telemetry';
 import TelemetryService from '../Services/TelemetryService/TelemetryService';
 import {
@@ -19,18 +19,18 @@ const useTelemetry = () => {
         sendTelemetry: TelemetryService.sendTelemetry,
         sendRequestTelemetry: (telemetryParams: IRequestTelemetryParams) =>
             TelemetryService.sendTelemetry(
-                new RequestTelemetry(telemetryParams)
+                new TelemetryRequest(telemetryParams)
             ),
         sendExceptionTelemetry: (telemetryParams: IExceptionTelemetryParams) =>
             TelemetryService.sendTelemetry(
-                new ExceptionTelemetry(telemetryParams)
+                new TelemetryException(telemetryParams)
             ),
         sendTraceTelemetry: (telemetryParams: ITraceTelemetryParams) =>
-            TelemetryService.sendTelemetry(new TraceTelemetry(telemetryParams)),
+            TelemetryService.sendTelemetry(new TelemetryTrace(telemetryParams)),
         sendEventTelemetry: (telemetryParams: IBaseTelemetryParams) =>
-            TelemetryService.sendTelemetry(new EventTelemetry(telemetryParams)),
+            TelemetryService.sendTelemetry(new TelemetryEvent(telemetryParams)),
         sendMetricTelemetry: (telemetryParams: IMetricTelemetryParams) =>
-            TelemetryService.sendTelemetry(new MetricTelemetry(telemetryParams))
+            TelemetryService.sendTelemetry(new TelemetryMetric(telemetryParams))
     };
 };
 

--- a/src/Models/Hooks/useTelemetry.ts
+++ b/src/Models/Hooks/useTelemetry.ts
@@ -1,6 +1,7 @@
 import {
     EventTelemetry,
     ExceptionTelemetry,
+    MetricTelemetry,
     RequestTelemetry,
     TraceTelemetry
 } from '../Services/TelemetryService/Telemetry';
@@ -8,6 +9,7 @@ import TelemetryService from '../Services/TelemetryService/TelemetryService';
 import {
     IBaseTelemetryParams,
     IExceptionTelemetryParams,
+    IMetricTelemetryParams,
     IRequestTelemetryParams,
     ITraceTelemetryParams
 } from '../Services/TelemetryService/TelemetryService.types';
@@ -15,26 +17,20 @@ import {
 const useTelemetry = () => {
     return {
         sendTelemetry: TelemetryService.sendTelemetry,
-        sendRequestTelemetry: (
-            requestTelemetryParams: IRequestTelemetryParams
-        ) =>
+        sendRequestTelemetry: (telemetryParams: IRequestTelemetryParams) =>
             TelemetryService.sendTelemetry(
-                new RequestTelemetry(requestTelemetryParams)
+                new RequestTelemetry(telemetryParams)
             ),
-        sendExceptionTelemetry: (
-            exceptionTelemetryParams: IExceptionTelemetryParams
-        ) =>
+        sendExceptionTelemetry: (telemetryParams: IExceptionTelemetryParams) =>
             TelemetryService.sendTelemetry(
-                new ExceptionTelemetry(exceptionTelemetryParams)
+                new ExceptionTelemetry(telemetryParams)
             ),
-        sendTraceTelemetry: (traceTelemetryParams: ITraceTelemetryParams) =>
-            TelemetryService.sendTelemetry(
-                new TraceTelemetry(traceTelemetryParams)
-            ),
-        sendEventTelemetry: (eventTelemetryParams: IBaseTelemetryParams) =>
-            TelemetryService.sendTelemetry(
-                new EventTelemetry(eventTelemetryParams)
-            )
+        sendTraceTelemetry: (telemetryParams: ITraceTelemetryParams) =>
+            TelemetryService.sendTelemetry(new TraceTelemetry(telemetryParams)),
+        sendEventTelemetry: (telemetryParams: IBaseTelemetryParams) =>
+            TelemetryService.sendTelemetry(new EventTelemetry(telemetryParams)),
+        sendMetricTelemetry: (telemetryParams: IMetricTelemetryParams) =>
+            TelemetryService.sendTelemetry(new MetricTelemetry(telemetryParams))
     };
 };
 

--- a/src/Models/Services/TelemetryService/Telemetry.ts
+++ b/src/Models/Services/TelemetryService/Telemetry.ts
@@ -2,11 +2,19 @@ import {
     CustomProperties,
     IBaseTelemetryParams,
     IExceptionTelemetryParams,
+    IMetricTelemetryParams,
     IRequestTelemetryParams,
     ITraceTelemetryParams,
     SeverityLevel,
     TelemetryType
 } from './TelemetryService.types';
+
+export type ITelemetryEvent =
+    | EventTelemetry
+    | ExceptionTelemetry
+    | MetricTelemetry
+    | RequestTelemetry
+    | TraceTelemetry;
 
 export abstract class Telemetry {
     name: string;
@@ -29,6 +37,7 @@ export abstract class Telemetry {
  * https://docs.microsoft.com/en-us/azure/azure-monitor/app/data-model-request-telemetry
  */
 export class RequestTelemetry extends Telemetry {
+    type: TelemetryType.request;
     name: string;
     url: string;
     success: boolean;
@@ -59,6 +68,7 @@ export class RequestTelemetry extends Telemetry {
  * https://docs.microsoft.com/en-us/azure/azure-monitor/app/data-model-exception-telemetry
  */
 export class ExceptionTelemetry extends Telemetry {
+    type: TelemetryType.exception;
     exceptionId: string;
     severityLevel: SeverityLevel;
     message: string;
@@ -84,6 +94,7 @@ export class ExceptionTelemetry extends Telemetry {
  * https://docs.microsoft.com/en-us/azure/azure-monitor/app/data-model-trace-telemetry
  */
 export class TraceTelemetry extends Telemetry {
+    type: TelemetryType.trace;
     message: string;
     severityLevel: SeverityLevel;
 
@@ -103,7 +114,33 @@ export class TraceTelemetry extends Telemetry {
  * https://docs.microsoft.com/en-us/azure/azure-monitor/app/data-model-event-telemetry
  */
 export class EventTelemetry extends Telemetry {
+    type: TelemetryType.event;
     constructor({ name, customProperties }: IBaseTelemetryParams) {
-        super(name, TelemetryType.trace, customProperties);
+        super(name, TelemetryType.event, customProperties);
+    }
+}
+
+/** Telemetry for application measurements (Typically it is a state of the app like queue length, or duration something took to complete)
+ * https://docs.microsoft.com/en-us/azure/azure-monitor/app/data-model-metric-telemetry
+ */
+export class MetricTelemetry extends Telemetry {
+    type: TelemetryType.metric;
+    average: number;
+    min?: number;
+    max?: number;
+    sampleSize?: number;
+    constructor({
+        name,
+        average,
+        min,
+        max,
+        sampleSize,
+        customProperties
+    }: IMetricTelemetryParams) {
+        super(name, TelemetryType.event, customProperties);
+        this.average = average;
+        this.min = min;
+        this.max = max;
+        this.sampleSize = sampleSize || 1;
     }
 }

--- a/src/Models/Services/TelemetryService/Telemetry.ts
+++ b/src/Models/Services/TelemetryService/Telemetry.ts
@@ -9,7 +9,7 @@ import {
     TelemetryType
 } from './TelemetryService.types';
 
-export type ITelemetryEvent =
+export type ITelemetryItem =
     | EventTelemetry
     | ExceptionTelemetry
     | MetricTelemetry

--- a/src/Models/Services/TelemetryService/Telemetry.ts
+++ b/src/Models/Services/TelemetryService/Telemetry.ts
@@ -9,12 +9,12 @@ import {
     TelemetryType
 } from './TelemetryService.types';
 
-export type ITelemetryItem =
-    | EventTelemetry
-    | ExceptionTelemetry
-    | MetricTelemetry
-    | RequestTelemetry
-    | TraceTelemetry;
+export type TelemetryItem =
+    | TelemetryEvent
+    | TelemetryException
+    | TelemetryMetric
+    | TelemetryRequest
+    | TelemetryTrace;
 
 export abstract class Telemetry {
     name: string;
@@ -36,7 +36,7 @@ export abstract class Telemetry {
 /** Telemetry for network requests
  * https://docs.microsoft.com/en-us/azure/azure-monitor/app/data-model-request-telemetry
  */
-export class RequestTelemetry extends Telemetry {
+export class TelemetryRequest extends Telemetry {
     type: TelemetryType.request;
     name: string;
     url: string;
@@ -67,7 +67,7 @@ export class RequestTelemetry extends Telemetry {
 /** Telemetry for exceptions
  * https://docs.microsoft.com/en-us/azure/azure-monitor/app/data-model-exception-telemetry
  */
-export class ExceptionTelemetry extends Telemetry {
+export class TelemetryException extends Telemetry {
     type: TelemetryType.exception;
     exceptionId: string;
     severityLevel: SeverityLevel;
@@ -93,7 +93,7 @@ export class ExceptionTelemetry extends Telemetry {
 /** Telemetry for trace statements (similar to log entries)
  * https://docs.microsoft.com/en-us/azure/azure-monitor/app/data-model-trace-telemetry
  */
-export class TraceTelemetry extends Telemetry {
+export class TelemetryTrace extends Telemetry {
     type: TelemetryType.trace;
     message: string;
     severityLevel: SeverityLevel;
@@ -113,7 +113,7 @@ export class TraceTelemetry extends Telemetry {
 /** Telemetry for application events (Typically it is a user interaction such as button click)
  * https://docs.microsoft.com/en-us/azure/azure-monitor/app/data-model-event-telemetry
  */
-export class EventTelemetry extends Telemetry {
+export class TelemetryEvent extends Telemetry {
     type: TelemetryType.event;
     constructor({ name, customProperties }: IBaseTelemetryParams) {
         super(name, TelemetryType.event, customProperties);
@@ -123,7 +123,7 @@ export class EventTelemetry extends Telemetry {
 /** Telemetry for application measurements (Typically it is a state of the app like queue length, or duration something took to complete)
  * https://docs.microsoft.com/en-us/azure/azure-monitor/app/data-model-metric-telemetry
  */
-export class MetricTelemetry extends Telemetry {
+export class TelemetryMetric extends Telemetry {
     type: TelemetryType.metric;
     average: number;
     min?: number;

--- a/src/Models/Services/TelemetryService/TelemetryService.ts
+++ b/src/Models/Services/TelemetryService/TelemetryService.ts
@@ -1,17 +1,26 @@
-import { Telemetry } from './Telemetry';
+import { getDebugLogger } from '../Utils';
+import { ITelemetryEvent } from './Telemetry';
+
+const debugLogging = false;
+const logDebugConsole = getDebugLogger('TelemetryService', debugLogging);
 
 class TelemetryService {
-    static telemetryCallback;
+    static telemetryCallback: (telemetry: ITelemetryEvent) => void;
 
     // Attach telemetry processing callback from consuming application
     static registerTelemetryCallback(
-        telemetryCallback: (telemetry: Telemetry) => void
+        telemetryCallback: (telemetry: ITelemetryEvent) => void
     ) {
         TelemetryService.telemetryCallback = telemetryCallback;
     }
 
     // Report telemetry to telemetry processing callback (if present)
-    static sendTelemetry(telemetry: Telemetry) {
+    static sendTelemetry(telemetry: ITelemetryEvent) {
+        logDebugConsole(
+            'debug',
+            `[Telemetry] [${telemetry.type}] ${telemetry.name}`,
+            telemetry
+        );
         if (TelemetryService.telemetryCallback)
             TelemetryService.telemetryCallback(telemetry);
     }

--- a/src/Models/Services/TelemetryService/TelemetryService.ts
+++ b/src/Models/Services/TelemetryService/TelemetryService.ts
@@ -1,21 +1,21 @@
 import { getDebugLogger } from '../Utils';
-import { ITelemetryItem } from './Telemetry';
+import { TelemetryItem } from './Telemetry';
 
 const debugLogging = false;
 const logDebugConsole = getDebugLogger('TelemetryService', debugLogging);
 
 class TelemetryService {
-    static telemetryCallback: (telemetry: ITelemetryItem) => void;
+    static telemetryCallback: (telemetry: TelemetryItem) => void;
 
     // Attach telemetry processing callback from consuming application
     static registerTelemetryCallback(
-        telemetryCallback: (telemetry: ITelemetryItem) => void
+        telemetryCallback: (telemetry: TelemetryItem) => void
     ) {
         TelemetryService.telemetryCallback = telemetryCallback;
     }
 
     // Report telemetry to telemetry processing callback (if present)
-    static sendTelemetry(telemetry: ITelemetryItem) {
+    static sendTelemetry(telemetry: TelemetryItem) {
         logDebugConsole(
             'debug',
             `[Telemetry] [${telemetry.type}] ${telemetry.name}`,

--- a/src/Models/Services/TelemetryService/TelemetryService.ts
+++ b/src/Models/Services/TelemetryService/TelemetryService.ts
@@ -1,21 +1,21 @@
 import { getDebugLogger } from '../Utils';
-import { ITelemetryEvent } from './Telemetry';
+import { ITelemetryItem } from './Telemetry';
 
 const debugLogging = false;
 const logDebugConsole = getDebugLogger('TelemetryService', debugLogging);
 
 class TelemetryService {
-    static telemetryCallback: (telemetry: ITelemetryEvent) => void;
+    static telemetryCallback: (telemetry: ITelemetryItem) => void;
 
     // Attach telemetry processing callback from consuming application
     static registerTelemetryCallback(
-        telemetryCallback: (telemetry: ITelemetryEvent) => void
+        telemetryCallback: (telemetry: ITelemetryItem) => void
     ) {
         TelemetryService.telemetryCallback = telemetryCallback;
     }
 
     // Report telemetry to telemetry processing callback (if present)
-    static sendTelemetry(telemetry: ITelemetryEvent) {
+    static sendTelemetry(telemetry: ITelemetryItem) {
         logDebugConsole(
             'debug',
             `[Telemetry] [${telemetry.type}] ${telemetry.name}`,

--- a/src/Models/Services/TelemetryService/TelemetryService.types.ts
+++ b/src/Models/Services/TelemetryService/TelemetryService.types.ts
@@ -2,10 +2,11 @@
  * https://docs.microsoft.com/en-us/azure/azure-monitor/app/data-model
  */
 export enum TelemetryType {
-    request = 'request',
+    event = 'event',
     exception = 'exception',
-    trace = 'trace',
-    event = 'event'
+    metric = 'metric',
+    request = 'request',
+    trace = 'trace'
 }
 
 export interface ITelemetry {
@@ -49,4 +50,11 @@ export interface ITraceTelemetryParams extends IBaseTelemetryParams {
     message: string;
     /** Trace severity level */
     severityLevel?: SeverityLevel;
+}
+
+export interface IMetricTelemetryParams extends IBaseTelemetryParams {
+    average: number;
+    min?: number;
+    max?: number;
+    sampleSize?: number;
 }

--- a/src/Models/Services/TelemetryService/__tests__/TelemetryService.test.ts
+++ b/src/Models/Services/TelemetryService/__tests__/TelemetryService.test.ts
@@ -1,6 +1,7 @@
 import {
     EventTelemetry,
     ExceptionTelemetry,
+    MetricTelemetry,
     RequestTelemetry,
     Telemetry,
     TraceTelemetry
@@ -9,6 +10,7 @@ import TelemetryService from '../../../../Models/Services/TelemetryService/Telem
 import {
     IBaseTelemetryParams,
     IExceptionTelemetryParams,
+    IMetricTelemetryParams,
     IRequestTelemetryParams,
     ITraceTelemetryParams
 } from '../TelemetryService.types';
@@ -40,7 +42,12 @@ const testEvent: IBaseTelemetryParams = {
     name: 'test event'
 };
 
-let mockCallback;
+const testMetric: IMetricTelemetryParams = {
+    name: 'test event',
+    average: 12
+};
+
+let mockCallback: jest.Mock;
 
 describe('Telemetry service tests', () => {
     beforeEach(() => {
@@ -92,6 +99,17 @@ describe('Telemetry service tests', () => {
             const message: EventTelemetry = mockCallback.mock.calls[0][0];
             expect(message).toBeInstanceOf(EventTelemetry);
             expect(message.name).toBe(testEvent.name);
+        });
+    });
+
+    describe('Metric telemetry', () => {
+        test('Metric telemetry is sent successfully', () => {
+            TelemetryService.sendTelemetry(new MetricTelemetry(testMetric));
+            expect(mockCallback.mock.calls.length).toBe(1);
+            const message: MetricTelemetry = mockCallback.mock.calls[0][0];
+            expect(message).toBeInstanceOf(MetricTelemetry);
+            expect(message.name).toBe(testEvent.name);
+            expect(message.average).toBe(testMetric.average);
         });
     });
 });

--- a/src/Models/Services/TelemetryService/__tests__/TelemetryService.test.ts
+++ b/src/Models/Services/TelemetryService/__tests__/TelemetryService.test.ts
@@ -1,10 +1,10 @@
 import {
-    EventTelemetry,
-    ExceptionTelemetry,
-    MetricTelemetry,
-    RequestTelemetry,
+    TelemetryEvent,
+    TelemetryException,
+    TelemetryMetric,
+    TelemetryRequest,
     Telemetry,
-    TraceTelemetry
+    TelemetryTrace
 } from '../Telemetry';
 import TelemetryService from '../../../../Models/Services/TelemetryService/TelemetryService';
 import {
@@ -61,11 +61,11 @@ describe('Telemetry service tests', () => {
 
     describe('Request telemetry', () => {
         test('Request telemetry is sent successfully', () => {
-            TelemetryService.sendTelemetry(new RequestTelemetry(testRequest));
+            TelemetryService.sendTelemetry(new TelemetryRequest(testRequest));
             expect(mockCallback.mock.calls.length).toBe(1);
 
-            const message: RequestTelemetry = mockCallback.mock.calls[0][0];
-            expect(message).toBeInstanceOf(RequestTelemetry);
+            const message: TelemetryRequest = mockCallback.mock.calls[0][0];
+            expect(message).toBeInstanceOf(TelemetryRequest);
             expect(message.name).toBe(testRequest.name);
         });
     });
@@ -73,41 +73,41 @@ describe('Telemetry service tests', () => {
     describe('Exception telemetry', () => {
         test('Exception telemetry is sent successfully', () => {
             TelemetryService.sendTelemetry(
-                new ExceptionTelemetry(testException)
+                new TelemetryException(testException)
             );
             expect(mockCallback.mock.calls.length).toBe(1);
-            const message: ExceptionTelemetry = mockCallback.mock.calls[0][0];
-            expect(message).toBeInstanceOf(ExceptionTelemetry);
+            const message: TelemetryException = mockCallback.mock.calls[0][0];
+            expect(message).toBeInstanceOf(TelemetryException);
             expect(message.name).toBe(testException.name);
         });
     });
 
     describe('Trace telemetry', () => {
         test('Trace telemetry is sent successfully', () => {
-            TelemetryService.sendTelemetry(new TraceTelemetry(testTrace));
+            TelemetryService.sendTelemetry(new TelemetryTrace(testTrace));
             expect(mockCallback.mock.calls.length).toBe(1);
-            const message: TraceTelemetry = mockCallback.mock.calls[0][0];
-            expect(message).toBeInstanceOf(TraceTelemetry);
+            const message: TelemetryTrace = mockCallback.mock.calls[0][0];
+            expect(message).toBeInstanceOf(TelemetryTrace);
             expect(message.name).toBe(testTrace.name);
         });
     });
 
     describe('Event telemetry', () => {
         test('Event telemetry is sent successfully', () => {
-            TelemetryService.sendTelemetry(new EventTelemetry(testEvent));
+            TelemetryService.sendTelemetry(new TelemetryEvent(testEvent));
             expect(mockCallback.mock.calls.length).toBe(1);
-            const message: EventTelemetry = mockCallback.mock.calls[0][0];
-            expect(message).toBeInstanceOf(EventTelemetry);
+            const message: TelemetryEvent = mockCallback.mock.calls[0][0];
+            expect(message).toBeInstanceOf(TelemetryEvent);
             expect(message.name).toBe(testEvent.name);
         });
     });
 
     describe('Metric telemetry', () => {
         test('Metric telemetry is sent successfully', () => {
-            TelemetryService.sendTelemetry(new MetricTelemetry(testMetric));
+            TelemetryService.sendTelemetry(new TelemetryMetric(testMetric));
             expect(mockCallback.mock.calls.length).toBe(1);
-            const message: MetricTelemetry = mockCallback.mock.calls[0][0];
-            expect(message).toBeInstanceOf(MetricTelemetry);
+            const message: TelemetryMetric = mockCallback.mock.calls[0][0];
+            expect(message).toBeInstanceOf(TelemetryMetric);
             expect(message.name).toBe(testEvent.name);
             expect(message.average).toBe(testMetric.average);
         });


### PR DESCRIPTION
### Summary of changes 🔍 
Adds a telemetry event type for metrics and adds some logging to see telemetry even when running locally.

[Product Backlog Item 14663266](https://msazure.visualstudio.com/One/_workitems/edit/14663266): How do we do feature level app insights telemetry logging?

### Testing 🧪
- [x] Enable logging in the `TelemetryServices.ts` file and then take an action on the scene list like create, edit, delete. Look in the console to see the events firing.

### Checklist ✔️
- [x] Linked associated issue (if present)
- [x] Added relevant labels
- [x] Requested developer reviews
- [x] Request UI review from design / PM
- [x] Verify all code checks are passing