### PR TITLE
Enable sorting Advanced Search Results List

### DIFF
--- a/src/Components/ADT3DSceneBuilder/Internal/Behaviors/Behaviors.tsx
+++ b/src/Components/ADT3DSceneBuilder/Internal/Behaviors/Behaviors.tsx
@@ -16,7 +16,7 @@ import { TFunction, useTranslation } from 'react-i18next';
 import ViewerConfigUtility from '../../../../Models/Classes/ViewerConfigUtility';
 import {
     deepCopy,
-    sortAlphabetically
+    sortAscendingOrDescending
 } from '../../../../Models/Services/Utils';
 
 import {
@@ -454,7 +454,7 @@ function getListItems(
         return viewModel;
     });
 
-    return listItems.sort(sortAlphabetically('textPrimary'));
+    return listItems.sort(sortAscendingOrDescending('textPrimary'));
 }
 
 export default SceneBehaviors;

--- a/src/Components/ADT3DSceneBuilder/Internal/Elements/Internal/BehaviorsTab.tsx
+++ b/src/Components/ADT3DSceneBuilder/Internal/Elements/Internal/BehaviorsTab.tsx
@@ -15,7 +15,7 @@ import { ICardboardListItem } from '../../../../CardboardList/CardboardList.type
 import { IBehavior } from '../../../../../Models/Types/Generated/3DScenesConfiguration-v1.0.0';
 import {
     getDebugLogger,
-    sortAlphabetically
+    sortAscendingOrDescending
 } from '../../../../../Models/Services/Utils';
 import { useElementFormContext } from '../../../../../Models/Context/ElementsFormContext/ElementFormContext';
 import { ElementFormContextActionType } from '../../../../../Models/Context/ElementsFormContext/ElementFormContext.types';
@@ -60,7 +60,7 @@ const BehaviorsTab: React.FC<IADT3DSceneBuilderElementBehaviorProps> = ({
                 .filter((behavior) =>
                     elementFormState.linkedBehaviorIds.includes(behavior.id)
                 )
-                .sort(sortAlphabetically('displayName')) || [],
+                .sort(sortAscendingOrDescending('displayName')) || [],
         [config?.configuration?.behaviors, elementFormState.linkedBehaviorIds]
     );
 
@@ -72,7 +72,7 @@ const BehaviorsTab: React.FC<IADT3DSceneBuilderElementBehaviorProps> = ({
                         (x) => x.id === behavior.id
                     );
                 })
-                .sort(sortAlphabetically('displayName')) || [],
+                .sort(sortAscendingOrDescending('displayName')) || [],
         [behaviorsOnElement, config?.configuration?.behaviors]
     );
 

--- a/src/Components/AdvancedSearch/Internal/AdvancedSearchResultDetailsList/AdvancedSearchResultDetailsList.tsx
+++ b/src/Components/AdvancedSearch/Internal/AdvancedSearchResultDetailsList/AdvancedSearchResultDetailsList.tsx
@@ -20,7 +20,7 @@ import {
 import { IADTTwin } from '../../../../Models/Constants';
 import { useTranslation } from 'react-i18next';
 import PropertyInspectorCallout from '../../../PropertyInspector/PropertyInspectorCallout/PropertyInspectorCallout';
-import { sortAlphabetically } from '../../../../Models/Services/Utils';
+import { ascendOrDescendSort } from '../../../../Models/Services/Utils';
 const getClassNames = classNamesFunction<
     IAdvancedSearchResultDetailsListStyleProps,
     IAdvancedSearchResultDetailsListStyles
@@ -38,10 +38,10 @@ const AdvancedSearchResultDetailsList: React.FC<IAdvancedSearchResultDetailsList
     const classNames = getClassNames(styles, {
         theme: useTheme()
     });
-    const sortKey = '$dtId';
+    const [sortKey, setSortKey] = useState<keyof IADTTwin>('$dtId');
     const [isSortedDescending, setSortDescending] = useState<boolean>(false);
     const listItems = twins.sort(
-        sortAlphabetically(sortKey, isSortedDescending)
+        ascendOrDescendSort(sortKey, isSortedDescending)
     );
 
     const staticColumns: IColumn[] = [
@@ -56,8 +56,9 @@ const AdvancedSearchResultDetailsList: React.FC<IAdvancedSearchResultDetailsList
             isPadded: true,
             onColumnClick: () => {
                 setSortDescending(
-                    isSortedDescending ? !isSortedDescending : true
+                    sortKey === '$dtId' ? !isSortedDescending : false
                 );
+                setSortKey('$dtId');
             }
         },
         {
@@ -76,7 +77,13 @@ const AdvancedSearchResultDetailsList: React.FC<IAdvancedSearchResultDetailsList
             fieldName: name,
             minWidth: 100,
             maxWidth: 150,
-            isResizable: true
+            isResizable: true,
+            onColumnClick: () => {
+                setSortDescending(
+                    sortKey === name ? !isSortedDescending : false
+                );
+                setSortKey(name);
+            }
         };
     });
 
@@ -87,7 +94,7 @@ const AdvancedSearchResultDetailsList: React.FC<IAdvancedSearchResultDetailsList
     // mark each column based on whether it's currently the one sorted
     columns.forEach((x) => {
         x.isSorted = sortKey === x.fieldName;
-        x.isSortedDescending = isSortedDescending;
+        x.isSortedDescending = x.isSorted ? isSortedDescending : false;
     });
 
     const renderItemColumn: IDetailsListProps['onRenderItemColumn'] = (

--- a/src/Components/AdvancedSearch/Internal/AdvancedSearchResultDetailsList/AdvancedSearchResultDetailsList.tsx
+++ b/src/Components/AdvancedSearch/Internal/AdvancedSearchResultDetailsList/AdvancedSearchResultDetailsList.tsx
@@ -20,7 +20,7 @@ import {
 import { IADTTwin } from '../../../../Models/Constants';
 import { useTranslation } from 'react-i18next';
 import PropertyInspectorCallout from '../../../PropertyInspector/PropertyInspectorCallout/PropertyInspectorCallout';
-import { ascendOrDescendSort } from '../../../../Models/Services/Utils';
+import { sortAscendingOrDescending } from '../../../../Models/Services/Utils';
 const getClassNames = classNamesFunction<
     IAdvancedSearchResultDetailsListStyleProps,
     IAdvancedSearchResultDetailsListStyles
@@ -41,7 +41,7 @@ const AdvancedSearchResultDetailsList: React.FC<IAdvancedSearchResultDetailsList
     const [sortKey, setSortKey] = useState<keyof IADTTwin>('$dtId');
     const [isSortedDescending, setSortDescending] = useState<boolean>(false);
     const listItems = twins.sort(
-        ascendOrDescendSort(sortKey, isSortedDescending)
+        sortAscendingOrDescending(sortKey, isSortedDescending)
     );
 
     const staticColumns: IColumn[] = [

--- a/src/Models/Services/Utils.ts
+++ b/src/Models/Services/Utils.ts
@@ -627,17 +627,24 @@ export const deleteModel = (id, data, models) => {
 };
 
 /**
- * Sort function to order items alphabetically. Case insensitive sort
+ * Sort function to order items from ascending or descending order. Case insensitive sort
  * NOTE: only works when property is one layer down
  * @param propertyName name of the property to sort on
  * @example listItems.sort(sortAlphabetically('textPrimary'))
  * @returns Sort function to pass to `.sort()`
  */
-export function sortAlphabetically<T>(propertyName: keyof T) {
+export function sortAlphabetically<T>(
+    propertyName: keyof T,
+    descending?: boolean
+) {
     return (a: T, b: T) => {
         const aVal = (a[propertyName] as unknown) as string;
         const bVal = (b[propertyName] as unknown) as string;
-        return aVal?.toLowerCase() > bVal?.toLowerCase() ? 1 : -1;
+        if (!descending) {
+            return aVal?.toLowerCase() > bVal?.toLowerCase() ? 1 : -1;
+        } else {
+            return aVal?.toLowerCase() < bVal?.toLowerCase() ? 1 : -1;
+        }
     };
 }
 

--- a/src/Models/Services/Utils.ts
+++ b/src/Models/Services/Utils.ts
@@ -648,6 +648,35 @@ export function sortAlphabetically<T>(
     };
 }
 
+/**
+ * Sort function to order items from ascending or descending order, for boolean, numbers and strings. Case insensitive sort
+ * NOTE: only works when property is one layer down
+ * @param propertyName name of the property to sort on
+ * @returns Sort function to pass to `.sort()`
+ */
+export function ascendOrDescendSort<T>(
+    propertyName: keyof T,
+    descending?: boolean
+) {
+    return (a: T, b: T) => {
+        let aVal = (a[String(propertyName)] as unknown) as string;
+        // handle the case where the property is not a string, if no value, fall back to empty string so we can sort undefined values consistently
+        aVal =
+            aVal && typeof aVal === 'string' ? aVal.toLowerCase() : aVal || '';
+        let bVal = (b[String(propertyName)] as unknown) as string;
+        // handle the case where the property is not a string, if no value, fall back to empty string so we can sort undefined values consistently
+        bVal =
+            bVal && typeof bVal === 'string' ? bVal.toLowerCase() : bVal || '';
+        let order = -1;
+        if (!descending) {
+            order = aVal > bVal ? 1 : -1;
+        } else {
+            order = aVal < bVal ? 1 : -1;
+        }
+        return order;
+    };
+}
+
 export function getDebugLogger(
     context: string,
     enabled: boolean

--- a/src/Models/Services/Utils.ts
+++ b/src/Models/Services/Utils.ts
@@ -627,34 +627,13 @@ export const deleteModel = (id, data, models) => {
 };
 
 /**
- * Sort function to order items from ascending or descending order. Case insensitive sort
- * NOTE: only works when property is one layer down
- * @param propertyName name of the property to sort on
- * @example listItems.sort(sortAlphabetically('textPrimary'))
- * @returns Sort function to pass to `.sort()`
- */
-export function sortAlphabetically<T>(
-    propertyName: keyof T,
-    descending?: boolean
-) {
-    return (a: T, b: T) => {
-        const aVal = (a[propertyName] as unknown) as string;
-        const bVal = (b[propertyName] as unknown) as string;
-        if (!descending) {
-            return aVal?.toLowerCase() > bVal?.toLowerCase() ? 1 : -1;
-        } else {
-            return aVal?.toLowerCase() < bVal?.toLowerCase() ? 1 : -1;
-        }
-    };
-}
-
-/**
  * Sort function to order items from ascending or descending order, for boolean, numbers and strings. Case insensitive sort
  * NOTE: only works when property is one layer down
  * @param propertyName name of the property to sort on
+ *  @example listItems.sort(sortAscendingOrDescending('textPrimary'))
  * @returns Sort function to pass to `.sort()`
  */
-export function ascendOrDescendSort<T>(
+export function sortAscendingOrDescending<T>(
     propertyName: keyof T,
     descending?: boolean
 ) {


### PR DESCRIPTION
### Summary of changes 🔍 
> You should be able to sort the twin ids from A-Z or Z-A order.


### Testing 🧪
 > Click on twin id column and see if the items and arrow icon are correct
### Checklist ✔️
- [ ] Linked associated issue (if present)
- [ ] Added relevant labels
- [ ] Requested developer reviews
- [ ] Request UI review from design / PM
- [ ] Verify all code checks are passing