### PR TITLE
[Telemetry] Wire up telemetry events for KPI metrics & initial user actions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
                 "react-syntax-highlighter": "^15.4.3",
                 "react-transition-group": "^4.4.2",
                 "recharts": "^2.1.8",
+                "ts-md5": "^1.3.1",
                 "ts-treemap": "^1.1.0",
                 "tsiclient": "^1.4.12",
                 "use-deep-compare-effect": "^1.8.1",
@@ -28836,6 +28837,12 @@
                 "signal-exit": "^3.0.2"
             }
         },
+        "node_modules/npm/node_modules/lodash._baseindexof": {
+            "version": "3.1.0",
+            "extraneous": true,
+            "inBundle": true,
+            "license": "MIT"
+        },
         "node_modules/npm/node_modules/lodash._baseuniq": {
             "version": "4.6.0",
             "inBundle": true,
@@ -28845,8 +28852,35 @@
                 "lodash._root": "~3.0.0"
             }
         },
+        "node_modules/npm/node_modules/lodash._bindcallback": {
+            "version": "3.0.1",
+            "extraneous": true,
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/lodash._cacheindexof": {
+            "version": "3.0.2",
+            "extraneous": true,
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/lodash._createcache": {
+            "version": "3.1.2",
+            "extraneous": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "lodash._getnative": "^3.0.0"
+            }
+        },
         "node_modules/npm/node_modules/lodash._createset": {
             "version": "4.0.3",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/lodash._getnative": {
+            "version": "3.9.1",
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT"
         },
@@ -28857,6 +28891,12 @@
         },
         "node_modules/npm/node_modules/lodash.clonedeep": {
             "version": "4.5.0",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/lodash.restparam": {
+            "version": "3.6.1",
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT"
         },
@@ -38422,6 +38462,14 @@
             },
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/ts-md5": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/ts-md5/-/ts-md5-1.3.1.tgz",
+            "integrity": "sha512-DiwiXfwvcTeZ5wCE0z+2A9EseZsztaiZtGrtSaY5JOD7ekPnR/GoIVD5gXZAlK9Na9Kvpo9Waz5rW64WKAWApg==",
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/ts-pnp": {
@@ -60604,6 +60652,11 @@
                         "signal-exit": "^3.0.2"
                     }
                 },
+                "lodash._baseindexof": {
+                    "version": "3.1.0",
+                    "bundled": true,
+                    "extraneous": true
+                },
                 "lodash._baseuniq": {
                     "version": "4.6.0",
                     "bundled": true,
@@ -60612,9 +60665,32 @@
                         "lodash._root": "~3.0.0"
                     }
                 },
+                "lodash._bindcallback": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "extraneous": true
+                },
+                "lodash._cacheindexof": {
+                    "version": "3.0.2",
+                    "bundled": true,
+                    "extraneous": true
+                },
+                "lodash._createcache": {
+                    "version": "3.1.2",
+                    "bundled": true,
+                    "extraneous": true,
+                    "requires": {
+                        "lodash._getnative": "^3.0.0"
+                    }
+                },
                 "lodash._createset": {
                     "version": "4.0.3",
                     "bundled": true
+                },
+                "lodash._getnative": {
+                    "version": "3.9.1",
+                    "bundled": true,
+                    "extraneous": true
                 },
                 "lodash._root": {
                     "version": "3.0.1",
@@ -60623,6 +60699,11 @@
                 "lodash.clonedeep": {
                     "version": "4.5.0",
                     "bundled": true
+                },
+                "lodash.restparam": {
+                    "version": "3.6.1",
+                    "bundled": true,
+                    "extraneous": true
                 },
                 "lodash.union": {
                     "version": "4.6.0",
@@ -67228,6 +67309,11 @@
                     }
                 }
             }
+        },
+        "ts-md5": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/ts-md5/-/ts-md5-1.3.1.tgz",
+            "integrity": "sha512-DiwiXfwvcTeZ5wCE0z+2A9EseZsztaiZtGrtSaY5JOD7ekPnR/GoIVD5gXZAlK9Na9Kvpo9Waz5rW64WKAWApg=="
         },
         "ts-pnp": {
             "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
         "react-syntax-highlighter": "^15.4.3",
         "react-transition-group": "^4.4.2",
         "recharts": "^2.1.8",
+        "ts-md5": "^1.3.1",
         "ts-treemap": "^1.1.0",
         "tsiclient": "^1.4.12",
         "use-deep-compare-effect": "^1.8.1",

--- a/src/Adapters/ADTAdapter.ts
+++ b/src/Adapters/ADTAdapter.ts
@@ -96,9 +96,7 @@ export default class ADTAdapter implements IADTAdapter {
         uniqueObjectId?: string,
         adtProxyServerPath = '/proxy/adt'
     ) {
-        this.adtHostUrl = adtHostUrl.startsWith('https://') // this should be the host name of the instace
-            ? adtHostUrl.replace('https://', '')
-            : adtHostUrl;
+        this.setAdtHostUrl(adtHostUrl); // this should be the host name of the instace
         this.adtProxyServerPath = adtProxyServerPath;
         this.authService = authService;
         this.tenantId = tenantId;
@@ -138,8 +136,9 @@ export default class ADTAdapter implements IADTAdapter {
     }
 
     setAdtHostUrl(hostName: string) {
-        if (hostName.startsWith('https://'))
+        if (hostName.startsWith('https://')) {
             hostName = hostName.replace('https://', '');
+        }
         this.adtHostUrl = hostName;
     }
 

--- a/src/Adapters/BlobAdapter.ts
+++ b/src/Adapters/BlobAdapter.ts
@@ -137,7 +137,7 @@ export default class BlobAdapter implements IBlobAdapter {
 
             try {
                 const configBlob = await getConfigBlob();
-                LogConfigFileTelemetry(configBlob.data);
+                LogConfigFileTelemetry(configBlob.data); // fire and forget the telemetry logging
                 return configBlob;
             } catch (err) {
                 if (

--- a/src/Adapters/BlobAdapter.ts
+++ b/src/Adapters/BlobAdapter.ts
@@ -26,6 +26,7 @@ import {
 import { I3DScenesConfig } from '../Models/Types/Generated/3DScenesConfiguration-v1.0.0';
 import defaultConfig from './__mockData__/3DScenesConfiguration.default.json';
 import { ComponentError } from '../Models/Classes';
+import { LogConfigFileTelemetry } from './BlobAdapterUtility';
 
 export default class BlobAdapter implements IBlobAdapter {
     protected storageAccountName: string;
@@ -141,6 +142,7 @@ export default class BlobAdapter implements IBlobAdapter {
 
             try {
                 const configBlob = await getConfigBlob();
+                LogConfigFileTelemetry(configBlob.data);
                 return configBlob;
             } catch (err) {
                 if (

--- a/src/Adapters/BlobAdapter.ts
+++ b/src/Adapters/BlobAdapter.ts
@@ -41,12 +41,7 @@ export default class BlobAdapter implements IBlobAdapter {
         authService: IAuthService,
         blobProxyServerPath = '/proxy/blob'
     ) {
-        if (blobContainerUrl) {
-            const containerURL = new URL(blobContainerUrl);
-            this.storageAccountHostName = containerURL.hostname;
-            this.storageAccountName = containerURL.hostname.split('.')[0];
-            this.containerName = containerURL.pathname.split('/')[1];
-        }
+        this.setBlobContainerPath(blobContainerUrl);
         this.blobAuthService = authService;
         this.blobAuthService.login();
         this.blobProxyServerPath = blobProxyServerPath;

--- a/src/Adapters/BlobAdapterUtility.ts
+++ b/src/Adapters/BlobAdapterUtility.ts
@@ -129,29 +129,25 @@ function sendBehaviorTelemetry(behavior: IBehavior, sceneHash: string) {
     });
 
     // capture the Behavior level metrics
-    const sceneEvent =
-        TelemetryEvents.Adapter.SceneLoad.SystemAction.ParseBehavior;
+    const event = TelemetryEvents.Adapter.SceneLoad.SystemAction.ParseBehavior;
     TelemetryService.sendEvent(
         new TelemetryEvent({
-            name: sceneEvent.eventName,
+            name: event.eventName,
             customProperties: {
-                [sceneEvent.properties.countAliases]: aliasCount,
-                [sceneEvent.properties.countDataSources]: dataSourceCount,
-                [sceneEvent.properties.countElements]: elementCount,
-                [sceneEvent.properties.countVisualBadgeType]:
-                    visualStats.badgeCount,
-                [sceneEvent.properties.countVisualColorType]:
-                    visualStats.colorCount,
-                [sceneEvent.properties.countVisuals]: visualStats.totalCount,
-                [sceneEvent.properties.countWidgetGaugeType]:
+                [event.properties.countAliases]: aliasCount,
+                [event.properties.countDataSources]: dataSourceCount,
+                [event.properties.countElements]: elementCount,
+                [event.properties.countVisualBadgeType]: visualStats.badgeCount,
+                [event.properties.countVisualColorType]: visualStats.colorCount,
+                [event.properties.countVisuals]: visualStats.totalCount,
+                [event.properties.countWidgetGaugeType]:
                     visualStats.widgets.gaugeCount,
-                [sceneEvent.properties.countWidgetLinkType]:
+                [event.properties.countWidgetLinkType]:
                     visualStats.widgets.linkCount,
-                [sceneEvent.properties.countWidgetPropertyType]:
+                [event.properties.countWidgetPropertyType]:
                     visualStats.widgets.propertyCount,
-                [sceneEvent.properties.countWidgets]:
-                    visualStats.widgets.totalCount,
-                [sceneEvent.properties.sceneHash]: sceneHash
+                [event.properties.countWidgets]: visualStats.widgets.totalCount,
+                [event.properties.parentSceneHash]: sceneHash
             },
             triggerType: TelemetryTrigger.SystemAction
         })
@@ -161,8 +157,8 @@ function sendBehaviorTelemetry(behavior: IBehavior, sceneHash: string) {
 /** send the KPI telemetry related to individual Elements */
 function sendElementTelemetry(element: IElement, sceneHash: string) {
     const type = element.type;
-    let meshCount = -1;
-    let aliasCount = -1;
+    let meshCount = 0;
+    let aliasCount = 0;
     // only capture the count when it's actually an 'element'
     if (ViewerConfigUtility.isTwinToObjectMappingElement(element)) {
         meshCount = element.objectIDs?.length;
@@ -172,16 +168,15 @@ function sendElementTelemetry(element: IElement, sceneHash: string) {
     }
 
     // capture the Element level metrics
-    const sceneEvent =
-        TelemetryEvents.Adapter.SceneLoad.SystemAction.ParseElement;
+    const event = TelemetryEvents.Adapter.SceneLoad.SystemAction.ParseElement;
     TelemetryService.sendEvent(
         new TelemetryEvent({
-            name: sceneEvent.eventName,
+            name: event.eventName,
             customProperties: {
-                [sceneEvent.properties.countAliases]: aliasCount,
-                [sceneEvent.properties.countMeshes]: meshCount,
-                [sceneEvent.properties.sceneHash]: sceneHash,
-                [sceneEvent.properties.type]: type
+                [event.properties.countAliases]: aliasCount,
+                [event.properties.countMeshes]: meshCount,
+                [event.properties.parentSceneHash]: sceneHash,
+                [event.properties.elementType]: type
             },
             triggerType: TelemetryTrigger.SystemAction
         })
@@ -200,19 +195,18 @@ function sendSceneTelemetry(scene: IScene, sceneHash: string) {
         scene.pollingConfiguration?.minimumPollingFrequency;
 
     // capture the Scene level metrics
-    const sceneEvent =
-        TelemetryEvents.Adapter.SceneLoad.SystemAction.ParseScene;
+    const event = TelemetryEvents.Adapter.SceneLoad.SystemAction.ParseScene;
     TelemetryService.sendEvent(
         new TelemetryEvent({
-            name: sceneEvent.eventName,
+            name: event.eventName,
             customProperties: {
-                [sceneEvent.properties.countAssets]: assetCount,
-                [sceneEvent.properties.countBehaviors]: behaviorsCount,
-                [sceneEvent.properties.countElements]: elementCount,
-                [sceneEvent.properties.hasCoordinates]: hasCoordinates,
-                [sceneEvent.properties.hasDescription]: hasDescription,
-                [sceneEvent.properties.pollingDelay]: scenePollingDelay,
-                [sceneEvent.properties.sceneHash]: sceneHash
+                [event.properties.countAssets]: assetCount,
+                [event.properties.countBehaviors]: behaviorsCount,
+                [event.properties.countElements]: elementCount,
+                [event.properties.hasCoordinates]: hasCoordinates,
+                [event.properties.hasDescription]: hasDescription,
+                [event.properties.pollingDelay]: scenePollingDelay,
+                [event.properties.sceneHash]: sceneHash
             },
             triggerType: TelemetryTrigger.SystemAction
         })
@@ -221,18 +215,18 @@ function sendSceneTelemetry(scene: IScene, sceneHash: string) {
 
 /** send the KPI telemetry related to the Config file as a whole */
 function sendConfigTelemetry(data: I3DScenesConfig) {
-    const configEvent =
+    const event =
         TelemetryEvents.Adapter.SceneLoad.SystemAction.ParseConfiguration;
     TelemetryService.sendEvent(
         new TelemetryEvent({
-            name: configEvent.eventName,
+            name: event.eventName,
             triggerType: TelemetryTrigger.SystemAction,
             customProperties: {
-                [configEvent.properties.countBehaviors]:
+                [event.properties.countBehaviors]:
                     data.configuration.behaviors?.length || 0,
-                [configEvent.properties.countLayers]:
+                [event.properties.countLayers]:
                     data.configuration.layers?.length || 0,
-                [configEvent.properties.countScenes]:
+                [event.properties.countScenes]:
                     data.configuration.scenes?.length || 0
             }
         })

--- a/src/Adapters/BlobAdapterUtility.ts
+++ b/src/Adapters/BlobAdapterUtility.ts
@@ -1,0 +1,239 @@
+import ViewerConfigUtility from '../Models/Classes/ViewerConfigUtility';
+import {
+    TelemetryEvents,
+    TelemetryTrigger
+} from '../Models/Constants/TelemetryConstants';
+import { TelemetryEvent } from '../Models/Services/TelemetryService/Telemetry';
+import TelemetryService from '../Models/Services/TelemetryService/TelemetryService';
+import { getDebugLogger, isDefined } from '../Models/Services/Utils';
+import {
+    I3DScenesConfig,
+    IBehavior,
+    IElement,
+    IScene
+} from '../Models/Types/Generated/3DScenesConfiguration-v1.0.0';
+
+const debugLogging = false;
+const logDebugConsole = getDebugLogger('BlobAdapterUtility', debugLogging);
+
+export const LogConfigFileTelemetry = async (
+    config: I3DScenesConfig
+): Promise<void> => {
+    const startTime = Date.now();
+
+    const data = config?.configuration;
+    if (!data) {
+        logDebugConsole('warn', 'No config found to process telemetry for');
+        return;
+    }
+
+    logDebugConsole(
+        'info',
+        '[START] Processing config telemetry. {config}',
+        data
+    );
+    // capture the config level metrics
+    sendConfigTelemetry(config);
+
+    // loop all the scenes
+    data.scenes.forEach((scene) => {
+        const sceneHash = scene.id; // TODO: hash this value
+        logDebugConsole(
+            'debug',
+            `[START] Processing scene ${scene.id} (hash: ${sceneHash})`
+        );
+
+        sendSceneTelemetry(scene, sceneHash);
+
+        // emit events for each element
+        scene.elements?.forEach((element) => {
+            logDebugConsole(
+                'debug',
+                `[START] Processing element ${element.displayName} (id: ${element.id})`
+            );
+            sendElementTelemetry(element, sceneHash);
+            logDebugConsole('debug', `[END] Processing element`);
+        });
+
+        const behaviors = ViewerConfigUtility.getBehaviorsInScene(
+            config,
+            scene.id
+        );
+        behaviors.forEach((behavior) => {
+            logDebugConsole(
+                'debug',
+                `[START] Processing behavior ${behavior.displayName} (id: ${behavior.id})`
+            );
+            sendBehaviorTelemetry(behavior, sceneHash);
+            logDebugConsole('debug', `[END] Processing behavior`);
+        });
+
+        logDebugConsole('debug', `[END] Processing scene`);
+    });
+
+    logDebugConsole(
+        'info',
+        `[END] Processing config telemetry. Elapsed time: ${
+            (Date.now() - startTime) / 1000
+        } seconds`
+    );
+};
+
+/** send the KPI telemetry related to individual Behaviors */
+function sendBehaviorTelemetry(behavior: IBehavior, sceneHash: string) {
+    // handle the primitive properties
+    const aliasCount = behavior.twinAliases?.length;
+    const dataSourceCount = behavior.datasources?.length || 0;
+    const elementDataSource = behavior.datasources.filter(
+        ViewerConfigUtility.isElementTwinToObjectMappingDataSource
+    )[0];
+    const elementCount = elementDataSource
+        ? elementDataSource.elementIDs?.length
+        : 0;
+
+    // loop the visuals
+    const visuals = behavior.visuals || [];
+    const visualStats = {
+        totalCount: visuals.length,
+        badgeCount: 0,
+        colorCount: 0,
+        widgets: {
+            totalCount: 0,
+            gaugeCount: 0,
+            linkCount: 0,
+            propertyCount: 0
+        }
+    };
+    visuals.forEach((visual) => {
+        if (ViewerConfigUtility.isPopoverVisual(visual)) {
+            visualStats.widgets.totalCount = visual.widgets?.length;
+            // loop through all the widgets in the popover
+            visual.widgets?.forEach((widget) => {
+                switch (widget.type) {
+                    case 'Gauge':
+                        visualStats.widgets.gaugeCount += 1;
+                        break;
+                    case 'Link':
+                        visualStats.widgets.linkCount += 1;
+                        break;
+                    case 'Value':
+                        visualStats.widgets.propertyCount += 1;
+                        break;
+                }
+            });
+        } else if (ViewerConfigUtility.isStatusColorVisual(visual)) {
+            visualStats.colorCount += 1;
+        } else if (ViewerConfigUtility.isAlertVisual(visual)) {
+            visualStats.badgeCount += 1;
+        }
+    });
+
+    // capture the Behavior level metrics
+    const sceneEvent =
+        TelemetryEvents.Adapter.SceneLoad.SystemAction.ParseBehavior;
+    TelemetryService.sendEvent(
+        new TelemetryEvent({
+            name: sceneEvent.eventName,
+            customProperties: {
+                [sceneEvent.properties.countAliases]: aliasCount,
+                [sceneEvent.properties.countDataSources]: dataSourceCount,
+                [sceneEvent.properties.countElements]: elementCount,
+                [sceneEvent.properties.countVisualBadgeType]:
+                    visualStats.badgeCount,
+                [sceneEvent.properties.countVisualColorType]:
+                    visualStats.colorCount,
+                [sceneEvent.properties.countVisuals]: visualStats.totalCount,
+                [sceneEvent.properties.countWidgetGaugeType]:
+                    visualStats.widgets.gaugeCount,
+                [sceneEvent.properties.countWidgetLinkType]:
+                    visualStats.widgets.linkCount,
+                [sceneEvent.properties.countWidgetPropertyType]:
+                    visualStats.widgets.propertyCount,
+                [sceneEvent.properties.countWidgets]:
+                    visualStats.widgets.totalCount,
+                [sceneEvent.properties.sceneHash]: sceneHash
+            },
+            triggerType: TelemetryTrigger.SystemAction
+        })
+    );
+}
+
+/** send the KPI telemetry related to individual Elements */
+function sendElementTelemetry(element: IElement, sceneHash: string) {
+    const type = element.type;
+    let meshCount = -1;
+    let aliasCount = -1;
+    // only capture the count when it's actually an 'element'
+    if (ViewerConfigUtility.isTwinToObjectMappingElement(element)) {
+        meshCount = element.objectIDs?.length;
+        if (element.twinAliases) {
+            aliasCount = Object.keys(element.twinAliases).length;
+        }
+    }
+
+    // capture the Element level metrics
+    const sceneEvent =
+        TelemetryEvents.Adapter.SceneLoad.SystemAction.ParseElement;
+    TelemetryService.sendEvent(
+        new TelemetryEvent({
+            name: sceneEvent.eventName,
+            customProperties: {
+                [sceneEvent.properties.countAliases]: aliasCount,
+                [sceneEvent.properties.countMeshes]: meshCount,
+                [sceneEvent.properties.sceneHash]: sceneHash,
+                [sceneEvent.properties.type]: type
+            },
+            triggerType: TelemetryTrigger.SystemAction
+        })
+    );
+}
+
+/** send the KPI telemetry related to individual Scenes */
+function sendSceneTelemetry(scene: IScene, sceneHash: string) {
+    const assetCount = scene.assets?.length || 0;
+    const behaviorsCount = scene.behaviorIDs?.length || 0;
+    const elementCount = scene.elements?.length || 0;
+    const hasCoordinates =
+        isDefined(scene.latitude) || isDefined(scene.longitude);
+    const hasDescription = false;
+    const scenePollingDelay = 0;
+
+    // capture the Scene level metrics
+    const sceneEvent =
+        TelemetryEvents.Adapter.SceneLoad.SystemAction.ParseScene;
+    TelemetryService.sendEvent(
+        new TelemetryEvent({
+            name: sceneEvent.eventName,
+            customProperties: {
+                [sceneEvent.properties.countAssets]: assetCount,
+                [sceneEvent.properties.countBehaviors]: behaviorsCount,
+                [sceneEvent.properties.countElements]: elementCount,
+                [sceneEvent.properties.hasCoordinates]: hasCoordinates,
+                [sceneEvent.properties.hasDescription]: hasDescription,
+                [sceneEvent.properties.pollingDelay]: scenePollingDelay,
+                [sceneEvent.properties.sceneHash]: sceneHash
+            },
+            triggerType: TelemetryTrigger.SystemAction
+        })
+    );
+}
+
+/** send the KPI telemetry related to the Config file as a whole */
+function sendConfigTelemetry(data: I3DScenesConfig) {
+    const configEvent =
+        TelemetryEvents.Adapter.SceneLoad.SystemAction.ParseConfiguration;
+    TelemetryService.sendEvent(
+        new TelemetryEvent({
+            name: configEvent.eventName,
+            triggerType: TelemetryTrigger.SystemAction,
+            customProperties: {
+                [configEvent.properties.countBehaviors]:
+                    data.configuration.behaviors?.length || 0,
+                [configEvent.properties.countLayers]:
+                    data.configuration.layers?.length || 0,
+                [configEvent.properties.countScenes]:
+                    data.configuration.scenes?.length || 0
+            }
+        })
+    );
+}

--- a/src/Adapters/BlobAdapterUtility.ts
+++ b/src/Adapters/BlobAdapterUtility.ts
@@ -194,9 +194,10 @@ function sendSceneTelemetry(scene: IScene, sceneHash: string) {
     const behaviorsCount = scene.behaviorIDs?.length || 0;
     const elementCount = scene.elements?.length || 0;
     const hasCoordinates =
-        isDefined(scene.latitude) || isDefined(scene.longitude);
-    const hasDescription = false;
-    const scenePollingDelay = 0;
+        isDefined(scene.latitude) || isDefined(scene.longitude) || false;
+    const hasDescription = scene.description?.trim()?.length > 0;
+    const scenePollingDelay =
+        scene.pollingConfiguration?.minimumPollingFrequency;
 
     // capture the Scene level metrics
     const sceneEvent =

--- a/src/Components/SceneList/SceneList.tsx
+++ b/src/Components/SceneList/SceneList.tsx
@@ -189,6 +189,15 @@ const SceneList: React.FC<SceneListProps> = ({
         <div
             onClick={() => {
                 if (typeof onSceneClick === 'function') {
+                    const telemetryEvent =
+                        TelemetryEvents.Builder.SceneList.UserAction
+                            .SelectScene;
+                    sendEventTelemetry({
+                        name: telemetryEvent.eventName,
+                        appRegion: AppRegion.SceneLobby,
+                        componentName: ComponentName.SceneList,
+                        triggerType: TelemetryTrigger.UserAction
+                    });
                     onSceneClick(props.item);
                 }
             }}

--- a/src/Components/SceneList/SceneList.tsx
+++ b/src/Components/SceneList/SceneList.tsx
@@ -185,26 +185,46 @@ const SceneList: React.FC<SceneListProps> = ({
         []
     );
 
-    const renderListRow: IDetailsListProps['onRenderRow'] = (props) => (
-        <div
-            onClick={() => {
-                if (typeof onSceneClick === 'function') {
-                    const telemetryEvent =
-                        TelemetryEvents.Builder.SceneList.UserAction
-                            .SelectScene;
-                    sendEventTelemetry({
-                        name: telemetryEvent.eventName,
-                        appRegion: AppRegion.SceneLobby,
-                        componentName: ComponentName.SceneList,
-                        triggerType: TelemetryTrigger.UserAction
-                    });
-                    onSceneClick(props.item);
-                }
-            }}
-        >
-            <DetailsRow className={'cb-scene-list-row'} {...props} />
-        </div>
-    );
+    const renderListRow: IDetailsListProps['onRenderRow'] = (props) => {
+        const clickHandler = () => {
+            if (typeof onSceneClick === 'function') {
+                const telemetryEvent =
+                    TelemetryEvents.Builder.SceneList.UserAction.SelectScene;
+                sendEventTelemetry({
+                    name: telemetryEvent.eventName,
+                    appRegion: AppRegion.SceneLobby,
+                    componentName: ComponentName.SceneList,
+                    triggerType: TelemetryTrigger.UserAction
+                });
+                onSceneClick(props.item);
+            }
+        };
+        return (
+            <DefaultButton
+                onClick={clickHandler}
+                onKeyPress={(event) => {
+                    console.log('clicked row', event);
+                    if (event.code === 'Enter' || event.code === 'Space') {
+                        clickHandler();
+                    }
+                }}
+                styles={{
+                    root: {
+                        alignItems: 'start',
+                        border: 0,
+                        height: 'auto',
+                        padding: 0,
+                        width: '100%'
+                    },
+                    flexContainer: {
+                        justifyContent: 'start'
+                    }
+                }}
+            >
+                <DetailsRow className={'cb-scene-list-row'} {...props} />
+            </DefaultButton>
+        );
+    };
 
     const renderItemColumn: IDetailsListProps['onRenderItemColumn'] = (
         item: any,

--- a/src/Components/SceneList/SceneList.tsx
+++ b/src/Components/SceneList/SceneList.tsx
@@ -42,6 +42,12 @@ import {
 import IllustrationMessage from '../IllustrationMessage/IllustrationMessage';
 import NoResults from '../../Resources/Static/noResults.svg';
 import useTelemetry from '../../Models/Hooks/useTelemetry';
+import {
+    AppRegion,
+    ComponentName,
+    TelemetryEvents,
+    TelemetryTrigger
+} from '../../Models/Constants/TelemetryConstants';
 
 const SceneList: React.FC<SceneListProps> = ({
     adapter,
@@ -193,7 +199,7 @@ const SceneList: React.FC<SceneListProps> = ({
 
     const renderItemColumn: IDetailsListProps['onRenderItemColumn'] = (
         item: any,
-        _itemIndex: number,
+        itemIndex: number,
         column: IColumn
     ) => {
         const fieldContent = item[column.fieldName] as string;
@@ -209,8 +215,18 @@ const SceneList: React.FC<SceneListProps> = ({
                                 event.stopPropagation();
                                 setSelectedScene(item);
                                 setIsSceneDialogOpen(true);
+                                const telemetryEvent =
+                                    TelemetryEvents.Builder.SceneList.UserAction
+                                        .EditScene.Initiate;
                                 sendEventTelemetry({
-                                    name: 'Edit scene - open'
+                                    name: telemetryEvent.eventName,
+                                    customProperties: {
+                                        [telemetryEvent.properties
+                                            .itemIndex]: itemIndex
+                                    },
+                                    appRegion: AppRegion.SceneLobby,
+                                    componentName: ComponentName.SceneList,
+                                    triggerType: TelemetryTrigger.UserAction
                                 });
                             }}
                             className={'cb-scenes-action-button'}
@@ -223,8 +239,18 @@ const SceneList: React.FC<SceneListProps> = ({
                                 event.stopPropagation();
                                 setSelectedScene(item);
                                 setIsConfirmDeleteDialogOpen(true);
+                                const telemetryEvent =
+                                    TelemetryEvents.Builder.SceneList.UserAction
+                                        .DeleteScene.Initiate;
                                 sendEventTelemetry({
-                                    name: 'Delete scene - open'
+                                    name: telemetryEvent.eventName,
+                                    customProperties: {
+                                        [telemetryEvent.properties
+                                            .itemIndex]: itemIndex
+                                    },
+                                    appRegion: AppRegion.SceneLobby,
+                                    componentName: ComponentName.SceneList,
+                                    triggerType: TelemetryTrigger.UserAction
                                 });
                             }}
                             className={'cb-scenes-action-button'}
@@ -332,8 +358,14 @@ const SceneList: React.FC<SceneListProps> = ({
                         <ActionButton
                             iconProps={{ iconName: 'Add' }}
                             onClick={() => {
+                                const telemetryEvent =
+                                    TelemetryEvents.Builder.SceneList.UserAction
+                                        .CreateScene.Initiate;
                                 sendEventTelemetry({
-                                    name: 'Create scene - open'
+                                    name: telemetryEvent.eventName,
+                                    appRegion: AppRegion.SceneLobby,
+                                    componentName: ComponentName.SceneList,
+                                    triggerType: TelemetryTrigger.UserAction
                                 });
                                 setIsSceneDialogOpen(true);
                             }}
@@ -386,8 +418,14 @@ const SceneList: React.FC<SceneListProps> = ({
                         <DialogFooter>
                             <DefaultButton
                                 onClick={() => {
+                                    const telemetryEvent =
+                                        TelemetryEvents.Builder.SceneList
+                                            .UserAction.DeleteScene.Cancel;
                                     sendEventTelemetry({
-                                        name: 'Delete scene - cancel'
+                                        name: telemetryEvent.eventName,
+                                        appRegion: AppRegion.SceneLobby,
+                                        componentName: ComponentName.SceneList,
+                                        triggerType: TelemetryTrigger.UserAction
                                     });
                                     setIsConfirmDeleteDialogOpen(false);
                                 }}
@@ -395,8 +433,14 @@ const SceneList: React.FC<SceneListProps> = ({
                             />
                             <PrimaryButton
                                 onClick={() => {
+                                    const telemetryEvent =
+                                        TelemetryEvents.Builder.SceneList
+                                            .UserAction.DeleteScene.Confirm;
                                     sendEventTelemetry({
-                                        name: 'Delete scene - confirm'
+                                        name: telemetryEvent.eventName,
+                                        appRegion: AppRegion.SceneLobby,
+                                        componentName: ComponentName.SceneList,
+                                        triggerType: TelemetryTrigger.UserAction
                                     });
                                     deleteScene.callAdapter({
                                         config: config,
@@ -445,8 +489,14 @@ const SceneList: React.FC<SceneListProps> = ({
                     }}
                     sceneToEdit={selectedScene}
                     onEditScene={(updatedScene) => {
+                        const telemetryEvent =
+                            TelemetryEvents.Builder.SceneList.UserAction
+                                .EditScene.Confirm;
                         sendEventTelemetry({
-                            name: 'Edit scene - confirm'
+                            name: telemetryEvent.eventName,
+                            appRegion: AppRegion.SceneLobby,
+                            componentName: ComponentName.SceneList,
+                            triggerType: TelemetryTrigger.UserAction
                         });
                         editScene.callAdapter({
                             config: config,
@@ -455,8 +505,14 @@ const SceneList: React.FC<SceneListProps> = ({
                         });
                     }}
                     onAddScene={(newScene) => {
+                        const telemetryEvent =
+                            TelemetryEvents.Builder.SceneList.UserAction
+                                .CreateScene.Confirm;
                         sendEventTelemetry({
-                            name: 'Create scene - confirm'
+                            name: telemetryEvent.eventName,
+                            appRegion: AppRegion.SceneLobby,
+                            componentName: ComponentName.SceneList,
+                            triggerType: TelemetryTrigger.UserAction
                         });
                         let newId = createGUID();
                         const existingIds = sceneList.map((s) => s.id);

--- a/src/Components/SceneList/SceneList.tsx
+++ b/src/Components/SceneList/SceneList.tsx
@@ -18,7 +18,8 @@ import {
     IDetailsListProps,
     DetailsRow,
     IButtonProps,
-    IModalStyles
+    IModalStyles,
+    IButtonStyles
 } from '@fluentui/react';
 import { withErrorBoundary } from '../../Models/Context/ErrorBoundary';
 import { createGUID } from '../../Models/Services/Utils';
@@ -48,6 +49,19 @@ import {
     TelemetryEvents,
     TelemetryTrigger
 } from '../../Models/Constants/TelemetryConstants';
+
+const ROW_BUTTON_STYLES: IButtonStyles = {
+    root: {
+        alignItems: 'start',
+        border: 0,
+        height: 'auto',
+        padding: 0,
+        width: '100%'
+    },
+    flexContainer: {
+        justifyContent: 'start'
+    }
+};
 
 const SceneList: React.FC<SceneListProps> = ({
     adapter,
@@ -203,23 +217,11 @@ const SceneList: React.FC<SceneListProps> = ({
             <DefaultButton
                 onClick={clickHandler}
                 onKeyPress={(event) => {
-                    console.log('clicked row', event);
                     if (event.code === 'Enter' || event.code === 'Space') {
                         clickHandler();
                     }
                 }}
-                styles={{
-                    root: {
-                        alignItems: 'start',
-                        border: 0,
-                        height: 'auto',
-                        padding: 0,
-                        width: '100%'
-                    },
-                    flexContainer: {
-                        justifyContent: 'start'
-                    }
-                }}
+                styles={ROW_BUTTON_STYLES}
             >
                 <DetailsRow className={'cb-scene-list-row'} {...props} />
             </DefaultButton>

--- a/src/Models/Constants/Constants.ts
+++ b/src/Models/Constants/Constants.ts
@@ -73,6 +73,14 @@ export const ONE_SECOND = 1000;
 export const ONE_MINUTE = 60 * ONE_SECOND;
 export const ONE_HOUR = 60 * ONE_MINUTE;
 
+export const LOCAL_STORAGE_KEYS = {
+    FeatureFlags: {
+        Telemetry: {
+            debugLogging: 'adt.debug.telemetryLogging' // enables debug logging for all emitted telemetry events
+        }
+    }
+};
+
 export const dtdlPrimitiveTypesList = [
     'boolean',
     'date',

--- a/src/Models/Constants/Constants.ts
+++ b/src/Models/Constants/Constants.ts
@@ -76,7 +76,7 @@ export const ONE_HOUR = 60 * ONE_MINUTE;
 export const LOCAL_STORAGE_KEYS = {
     FeatureFlags: {
         Telemetry: {
-            debugLogging: 'adt.debug.telemetryLogging' // enables debug logging for all emitted telemetry events
+            debugLogging: 'cardboard.debug.telemetryLogging' // enables debug logging for all emitted telemetry events
         }
     }
 };

--- a/src/Models/Constants/TelemetryConstants.ts
+++ b/src/Models/Constants/TelemetryConstants.ts
@@ -4,10 +4,14 @@ export const CUSTOM_PROPERTY_NAMES = {
     AppRegion: 'AppRegion',
     /** name of the emitting component */
     ComponentName: 'ComponentName',
+    /** hashed value for the environment */
+    EnvironmentHash: 'EnvironmentHash',
     /** type of action (user, system, etc.) */
     TriggerType: 'TriggerType',
     /** hashed id of the scene */
-    SceneHash: 'SceneHash'
+    SceneHash: 'SceneHash',
+    /** hashed id of the parent scene */
+    ParentSceneHash: 'ParentSceneHash'
 };
 
 /** Highest level sections of the app */
@@ -85,10 +89,10 @@ export const TelemetryEvents = {
                 ParseElement: {
                     eventName: 'ParseConfig.ElementKpis',
                     properties: {
-                        type: 'type',
+                        elementType: 'elementType',
                         countMeshes: 'countMeshes',
                         countAliases: 'countAliases',
-                        sceneHash: CUSTOM_PROPERTY_NAMES.SceneHash
+                        parentSceneHash: CUSTOM_PROPERTY_NAMES.ParentSceneHash
                     }
                 },
                 ParseBehavior: {
@@ -104,7 +108,7 @@ export const TelemetryEvents = {
                         countVisuals: 'countVisuals',
                         countVisualBadgeType: 'countVisualBadgeType',
                         countVisualColorType: 'countVisualColorType',
-                        sceneHash: CUSTOM_PROPERTY_NAMES.SceneHash
+                        parentSceneHash: CUSTOM_PROPERTY_NAMES.ParentSceneHash
                     }
                 }
             }

--- a/src/Models/Constants/TelemetryConstants.ts
+++ b/src/Models/Constants/TelemetryConstants.ts
@@ -1,17 +1,19 @@
 /** The property names for custom properties in the payload */
 export const CUSTOM_PROPERTY_NAMES = {
+    /** hashed value for the adt instance */
+    AdtInstanceHash: 'AdtInstanceHash',
     /** region of the app (builder/viewer/etc.) */
     AppRegion: 'AppRegion',
     /** name of the emitting component */
     ComponentName: 'ComponentName',
-    /** hashed value for the environment */
-    EnvironmentHash: 'EnvironmentHash',
-    /** type of action (user, system, etc.) */
-    TriggerType: 'TriggerType',
+    /** hashed id of the parent scene */
+    ParentSceneHash: 'ParentSceneHash',
     /** hashed id of the scene */
     SceneHash: 'SceneHash',
-    /** hashed id of the parent scene */
-    ParentSceneHash: 'ParentSceneHash'
+    /** hashed value for the adt instance */
+    StorageContainerHash: 'StorageContainerHash',
+    /** type of action (user, system, etc.) */
+    TriggerType: 'TriggerType'
 };
 
 /** Highest level sections of the app */

--- a/src/Models/Constants/TelemetryConstants.ts
+++ b/src/Models/Constants/TelemetryConstants.ts
@@ -30,7 +30,7 @@ export enum ComponentName {
 /**
  * The events the app can emit
  * Structure is like this:
- *  - App section (Builder/Viewer)
+ *  - App region (Builder/Viewer)
  *    - High level component (SceneList, ElementForm, etc)
  *      - User action/System action
  *        - Event/action

--- a/src/Models/Constants/TelemetryConstants.ts
+++ b/src/Models/Constants/TelemetryConstants.ts
@@ -65,6 +65,7 @@ export const TelemetryEvents = {
                 ParseConfiguration: {
                     eventName: 'ParseConfig.ConfigKpis',
                     properties: {
+                        countBehaviors: 'countBehaviors',
                         countScenes: 'countScenes',
                         countLayers: 'countLayers'
                     }
@@ -72,36 +73,38 @@ export const TelemetryEvents = {
                 ParseScene: {
                     eventName: 'ParseConfig.SceneKpis',
                     properties: {
-                        sceneHash: CUSTOM_PROPERTY_NAMES.SceneHash,
                         countBehaviors: 'countBehaviors',
                         countElements: 'countElements',
                         countAssets: 'countAssets',
                         hasCoordinates: 'hasCoordinates',
                         hasDescription: 'hasDescription',
-                        pollingDelay: 'pollingDelay'
+                        pollingDelay: 'pollingDelay',
+                        sceneHash: CUSTOM_PROPERTY_NAMES.SceneHash
                     }
                 },
                 ParseElement: {
                     eventName: 'ParseConfig.ElementKpis',
                     properties: {
-                        sceneHash: CUSTOM_PROPERTY_NAMES.SceneHash,
+                        type: 'type',
                         countMeshes: 'countMeshes',
-                        countAliases: 'countAliases'
+                        countAliases: 'countAliases',
+                        sceneHash: CUSTOM_PROPERTY_NAMES.SceneHash
                     }
                 },
                 ParseBehavior: {
                     eventName: 'ParseConfig.BehaviorKpis',
                     properties: {
-                        sceneHash: CUSTOM_PROPERTY_NAMES.SceneHash,
+                        countAliases: 'countAliases',
                         countElements: 'countElements',
                         countDataSources: 'countDataSources',
                         countWidgets: 'countWidgets',
                         countWidgetGaugeType: 'countWidgetGaugeType',
                         countWidgetLinkType: 'countWidgetLinkType',
-                        countWidgetPropertyType: '',
+                        countWidgetPropertyType: 'countWidgetPropertyType',
                         countVisuals: 'countVisuals',
                         countVisualBadgeType: 'countVisualBadgeType',
-                        countVisualColorType: 'countVisualColorType'
+                        countVisualColorType: 'countVisualColorType',
+                        sceneHash: CUSTOM_PROPERTY_NAMES.SceneHash
                     }
                 }
             }

--- a/src/Models/Constants/TelemetryConstants.ts
+++ b/src/Models/Constants/TelemetryConstants.ts
@@ -1,0 +1,96 @@
+/** Highest level sections of the app */
+export enum AppRegion {
+    Builder = 'Builder',
+    SceneLobby = 'SceneLobby',
+    Viewer = 'Viewer'
+}
+
+/** the source of the event, was it from a user or an automated event based off of some condition */
+export enum TelemetryTrigger {
+    /** user initiated action */
+    UserAction = 'UserAction',
+    /** user initiated view */
+    UserView = 'UserView',
+    /** System initiated action */
+    SystemAction = 'SystemAction'
+}
+
+/**
+ * The high level component emitting the event
+ * Keep it at the general level, no need to get overly specific.
+ * Ex: SceneList, ElementForm, etc
+ */
+export enum ComponentName {
+    BehaviorForm = 'BehaviorForm',
+    BehaviorList = 'BehaviorList',
+    ElementForm = 'ElementForm',
+    ElementList = 'ElementList',
+    SceneList = 'SceneList'
+}
+/**
+ * The events the app can emit
+ * Structure is like this:
+ *  - App section (Builder/Viewer)
+ *    - High level component (SceneList, ElementForm, etc)
+ *      - User action/System action
+ *        - Event/action
+ *           - variant (ex: initiate, confirm, cancel)
+ *           - eventName: the name of the beacon to emit
+ *           - properties: names of the custom properties that the event will have attached to it
+ */
+export const TelemetryEvents = {
+    /** builder section of the app */
+    Builder: {
+        /** scene list page */
+        SceneList: {
+            UserAction: {
+                /** creating a new scene */
+                CreateScene: {
+                    Cancel: {
+                        eventName: 'SceneList.CreateScene.Cancel'
+                    },
+                    Confirm: {
+                        eventName: 'SceneList.CreateScene.Confirm',
+                        properties: {
+                            hasCoordinates: 'hasCoordinates',
+                            hasDescription: 'hasDescription'
+                        }
+                    },
+                    Initiate: {
+                        eventName: 'SceneList.CreateScene.Initiate'
+                    }
+                },
+                /** delete an existing scene */
+                DeleteScene: {
+                    Cancel: {
+                        eventName: 'SceneList.DeleteScene.Cancel'
+                    },
+                    Confirm: {
+                        eventName: 'SceneList.DeleteScene.Confirm'
+                    },
+                    Initiate: {
+                        eventName: 'SceneList.DeleteScene.Initiate',
+                        properties: {
+                            itemIndex: 'itemIndex'
+                        }
+                    }
+                },
+                /** modify an existing scene */
+                EditScene: {
+                    Cancel: {
+                        eventName: 'SceneList.EditScene.Confirm'
+                    },
+                    Confirm: {
+                        eventName: 'SceneList.EditScene.Confirm'
+                    },
+                    Initiate: {
+                        eventName: 'SceneList.EditScene.Initiate',
+                        properties: {
+                            itemIndex: 'itemIndex'
+                        }
+                    }
+                }
+            }
+        }
+    }
+};

--- a/src/Models/Constants/TelemetryConstants.ts
+++ b/src/Models/Constants/TelemetryConstants.ts
@@ -89,6 +89,10 @@ export const TelemetryEvents = {
                             itemIndex: 'itemIndex'
                         }
                     }
+                },
+                /** Select a scene from the list */
+                SelectScene: {
+                    eventName: 'SceneList.SelectScene'
                 }
             }
         }

--- a/src/Models/Constants/TelemetryConstants.ts
+++ b/src/Models/Constants/TelemetryConstants.ts
@@ -1,8 +1,26 @@
+/** The property names for custom properties in the payload */
+export const CUSTOM_PROPERTY_NAMES = {
+    /** region of the app (builder/viewer/etc.) */
+    AppRegion: 'AppRegion',
+    /** name of the emitting component */
+    ComponentName: 'ComponentName',
+    /** type of action (user, system, etc.) */
+    TriggerType: 'TriggerType',
+    /** hashed id of the scene */
+    SceneHash: 'SceneHash'
+};
+
 /** Highest level sections of the app */
 export enum AppRegion {
     Builder = 'Builder',
     SceneLobby = 'SceneLobby',
     Viewer = 'Viewer'
+}
+
+/** The type of gesture the user used, (click, hover, etc.) */
+export enum Gesture {
+    Click = 'Click',
+    Hover = 'Hover'
 }
 
 /** the source of the event, was it from a user or an automated event based off of some condition */
@@ -27,6 +45,7 @@ export enum ComponentName {
     ElementList = 'ElementList',
     SceneList = 'SceneList'
 }
+
 /**
  * The events the app can emit
  * Structure is like this:
@@ -39,6 +58,55 @@ export enum ComponentName {
  *           - properties: names of the custom properties that the event will have attached to it
  */
 export const TelemetryEvents = {
+    Adapter: {
+        /** scene load */
+        SceneLoad: {
+            SystemAction: {
+                ParseConfiguration: {
+                    eventName: 'ParseConfig.ConfigKpis',
+                    properties: {
+                        countScenes: 'countScenes',
+                        countLayers: 'countLayers'
+                    }
+                },
+                ParseScene: {
+                    eventName: 'ParseConfig.SceneKpis',
+                    properties: {
+                        sceneHash: CUSTOM_PROPERTY_NAMES.SceneHash,
+                        countBehaviors: 'countBehaviors',
+                        countElements: 'countElements',
+                        countAssets: 'countAssets',
+                        hasCoordinates: 'hasCoordinates',
+                        hasDescription: 'hasDescription',
+                        pollingDelay: 'pollingDelay'
+                    }
+                },
+                ParseElement: {
+                    eventName: 'ParseConfig.ElementKpis',
+                    properties: {
+                        sceneHash: CUSTOM_PROPERTY_NAMES.SceneHash,
+                        countMeshes: 'countMeshes',
+                        countAliases: 'countAliases'
+                    }
+                },
+                ParseBehavior: {
+                    eventName: 'ParseConfig.BehaviorKpis',
+                    properties: {
+                        sceneHash: CUSTOM_PROPERTY_NAMES.SceneHash,
+                        countElements: 'countElements',
+                        countDataSources: 'countDataSources',
+                        countWidgets: 'countWidgets',
+                        countWidgetGaugeType: 'countWidgetGaugeType',
+                        countWidgetLinkType: 'countWidgetLinkType',
+                        countWidgetPropertyType: '',
+                        countVisuals: 'countVisuals',
+                        countVisualBadgeType: 'countVisualBadgeType',
+                        countVisualColorType: 'countVisualColorType'
+                    }
+                }
+            }
+        }
+    },
     /** builder section of the app */
     Builder: {
         /** scene list page */
@@ -96,5 +164,19 @@ export const TelemetryEvents = {
                 }
             }
         }
-    }
+    },
+    /** viewer section of the app */
+    Viewer: {}
 };
+
+/**
+ * The metrics the app can emit
+ * Structure is like this:
+ *  - App region (Builder/Viewer)
+ *    - High level component (SceneList, ElementForm, etc)
+ *      - User action/System metric
+ *        - Event/action
+ *           - eventName: the name of the beacon to emit
+ *           - properties: names of the custom properties that the event will have attached to it
+ */
+export const TelemetryMetrics = { Adapter: {}, Builder: {}, Viewer: {} };

--- a/src/Models/Context/DeeplinkContext/DeeplinkContext.tsx
+++ b/src/Models/Context/DeeplinkContext/DeeplinkContext.tsx
@@ -150,13 +150,14 @@ export const DeeplinkContextProvider: React.FC<IDeeplinkContextProviderProps> = 
         [deeplinkState, consumerDeeplinkContext?.onGenerateDeeplink]
     );
 
-    // notify telemetry service of changes to the environment
+    // notify telemetry service of changes to the adt instance
     useEffect(() => {
-        TelemetryService.setEnvironment(
-            deeplinkState.adtUrl,
-            deeplinkState.storageContainerUrl
-        );
-    }, [deeplinkState.adtUrl, deeplinkState.storageContainerUrl]);
+        TelemetryService.setAdtInstance(deeplinkState.adtUrl);
+    }, [deeplinkState.adtUrl]);
+    // notify telemetry service of changes to the blob storage
+    useEffect(() => {
+        TelemetryService.setStorageContainerUrl(deeplinkState.storageUrl);
+    }, [deeplinkState.storageUrl]);
     // notify telemetry service of changes to the scene id
     useEffect(() => {
         TelemetryService.setSceneId(deeplinkState.sceneId);

--- a/src/Models/Hooks/useTelemetry.ts
+++ b/src/Models/Hooks/useTelemetry.ts
@@ -16,7 +16,6 @@ import {
 
 const useTelemetry = () => {
     return {
-        sendTelemetry: TelemetryService.sendTelemetry,
         sendRequestTelemetry: (telemetryParams: IRequestTelemetryParams) =>
             TelemetryService.sendRequest(new TelemetryRequest(telemetryParams)),
         sendExceptionTelemetry: (telemetryParams: IExceptionTelemetryParams) =>

--- a/src/Models/Hooks/useTelemetry.ts
+++ b/src/Models/Hooks/useTelemetry.ts
@@ -7,7 +7,7 @@ import {
 } from '../Services/TelemetryService/Telemetry';
 import TelemetryService from '../Services/TelemetryService/TelemetryService';
 import {
-    IBaseTelemetryParams,
+    IEventTelemetryParams,
     IExceptionTelemetryParams,
     IMetricTelemetryParams,
     IRequestTelemetryParams,
@@ -27,7 +27,7 @@ const useTelemetry = () => {
             ),
         sendTraceTelemetry: (telemetryParams: ITraceTelemetryParams) =>
             TelemetryService.sendTelemetry(new TelemetryTrace(telemetryParams)),
-        sendEventTelemetry: (telemetryParams: IBaseTelemetryParams) =>
+        sendEventTelemetry: (telemetryParams: IEventTelemetryParams) =>
             TelemetryService.sendTelemetry(new TelemetryEvent(telemetryParams)),
         sendMetricTelemetry: (telemetryParams: IMetricTelemetryParams) =>
             TelemetryService.sendTelemetry(new TelemetryMetric(telemetryParams))

--- a/src/Models/Hooks/useTelemetry.ts
+++ b/src/Models/Hooks/useTelemetry.ts
@@ -18,19 +18,17 @@ const useTelemetry = () => {
     return {
         sendTelemetry: TelemetryService.sendTelemetry,
         sendRequestTelemetry: (telemetryParams: IRequestTelemetryParams) =>
-            TelemetryService.sendTelemetry(
-                new TelemetryRequest(telemetryParams)
-            ),
+            TelemetryService.sendRequest(new TelemetryRequest(telemetryParams)),
         sendExceptionTelemetry: (telemetryParams: IExceptionTelemetryParams) =>
-            TelemetryService.sendTelemetry(
+            TelemetryService.sendException(
                 new TelemetryException(telemetryParams)
             ),
         sendTraceTelemetry: (telemetryParams: ITraceTelemetryParams) =>
-            TelemetryService.sendTelemetry(new TelemetryTrace(telemetryParams)),
+            TelemetryService.sendTrace(new TelemetryTrace(telemetryParams)),
         sendEventTelemetry: (telemetryParams: IEventTelemetryParams) =>
-            TelemetryService.sendTelemetry(new TelemetryEvent(telemetryParams)),
+            TelemetryService.sendEvent(new TelemetryEvent(telemetryParams)),
         sendMetricTelemetry: (telemetryParams: IMetricTelemetryParams) =>
-            TelemetryService.sendTelemetry(new TelemetryMetric(telemetryParams))
+            TelemetryService.sendMetric(new TelemetryMetric(telemetryParams))
     };
 };
 

--- a/src/Models/Services/TelemetryService/Telemetry.ts
+++ b/src/Models/Services/TelemetryService/Telemetry.ts
@@ -1,3 +1,4 @@
+import { CUSTOM_PROPERTY_NAMES } from '../../Constants/TelemetryConstants';
 import {
     CustomProperties,
     IEventTelemetryParams,
@@ -9,11 +10,6 @@ import {
     TelemetryType
 } from './TelemetryService.types';
 
-const CUSTOM_PROPERTY_NAMES = {
-    AppRegion: 'AppRegion',
-    ComponentName: 'ComponentName',
-    TriggerType: 'TriggerType'
-};
 export type TelemetryItem =
     | TelemetryEvent
     | TelemetryException
@@ -33,7 +29,7 @@ export abstract class Telemetry {
     ) {
         this.name = name;
         this.type = type;
-        this.customProperties = customProperties;
+        this.customProperties = customProperties || {};
         this.timestamp = new Date().toUTCString();
     }
 }
@@ -122,17 +118,17 @@ export class TelemetryEvent extends Telemetry {
     type: TelemetryType.event;
     constructor({
         appRegion,
-        name,
         componentName,
         customProperties,
+        name,
         triggerType
     }: IEventTelemetryParams) {
         super(name, TelemetryType.event, customProperties);
         this.customProperties = {
             ...this.customProperties,
-            [CUSTOM_PROPERTY_NAMES.AppRegion]: appRegion,
-            [CUSTOM_PROPERTY_NAMES.ComponentName]: componentName,
-            [CUSTOM_PROPERTY_NAMES.TriggerType]: triggerType
+            [CUSTOM_PROPERTY_NAMES.AppRegion]: appRegion || 'Unset',
+            [CUSTOM_PROPERTY_NAMES.ComponentName]: componentName || 'Unset',
+            [CUSTOM_PROPERTY_NAMES.TriggerType]: triggerType || 'Unset'
         };
     }
 }

--- a/src/Models/Services/TelemetryService/Telemetry.ts
+++ b/src/Models/Services/TelemetryService/Telemetry.ts
@@ -20,6 +20,7 @@ export type TelemetryItem =
 export abstract class Telemetry {
     name: string;
     type: TelemetryType;
+    telemetryType: TelemetryType;
     customProperties: CustomProperties;
     timestamp: string;
     constructor(
@@ -28,7 +29,7 @@ export abstract class Telemetry {
         customProperties: CustomProperties
     ) {
         this.name = name;
-        this.type = type;
+        this.telemetryType = type;
         this.customProperties = customProperties || {};
         this.timestamp = new Date().toUTCString();
     }
@@ -56,6 +57,7 @@ export class TelemetryRequest extends Telemetry {
         customProperties
     }: IRequestTelemetryParams) {
         super(name, TelemetryType.request, customProperties);
+        this.telemetryType = TelemetryType.request;
         this.url = url;
         this.success = success;
         this.responseCode = responseCode;
@@ -150,7 +152,7 @@ export class TelemetryMetric extends Telemetry {
         sampleSize,
         customProperties
     }: IMetricTelemetryParams) {
-        super(name, TelemetryType.event, customProperties);
+        super(name, TelemetryType.metric, customProperties);
         this.average = average;
         this.min = min;
         this.max = max;

--- a/src/Models/Services/TelemetryService/Telemetry.ts
+++ b/src/Models/Services/TelemetryService/Telemetry.ts
@@ -1,6 +1,6 @@
 import {
     CustomProperties,
-    IBaseTelemetryParams,
+    IEventTelemetryParams,
     IExceptionTelemetryParams,
     IMetricTelemetryParams,
     IRequestTelemetryParams,
@@ -9,6 +9,11 @@ import {
     TelemetryType
 } from './TelemetryService.types';
 
+const CUSTOM_PROPERTY_NAMES = {
+    AppRegion: 'AppRegion',
+    ComponentName: 'ComponentName',
+    TriggerType: 'TriggerType'
+};
 export type TelemetryItem =
     | TelemetryEvent
     | TelemetryException
@@ -115,8 +120,20 @@ export class TelemetryTrace extends Telemetry {
  */
 export class TelemetryEvent extends Telemetry {
     type: TelemetryType.event;
-    constructor({ name, customProperties }: IBaseTelemetryParams) {
+    constructor({
+        appRegion,
+        name,
+        componentName,
+        customProperties,
+        triggerType
+    }: IEventTelemetryParams) {
         super(name, TelemetryType.event, customProperties);
+        this.customProperties = {
+            ...this.customProperties,
+            [CUSTOM_PROPERTY_NAMES.AppRegion]: appRegion,
+            [CUSTOM_PROPERTY_NAMES.ComponentName]: componentName,
+            [CUSTOM_PROPERTY_NAMES.TriggerType]: triggerType
+        };
     }
 }
 

--- a/src/Models/Services/TelemetryService/Telemetry.ts
+++ b/src/Models/Services/TelemetryService/Telemetry.ts
@@ -20,16 +20,10 @@ export type TelemetryItem =
 export abstract class Telemetry {
     name: string;
     type: TelemetryType;
-    telemetryType: TelemetryType;
     customProperties: CustomProperties;
     timestamp: string;
-    constructor(
-        name: string,
-        type: TelemetryType,
-        customProperties: CustomProperties
-    ) {
+    constructor(name: string, customProperties: CustomProperties) {
         this.name = name;
-        this.telemetryType = type;
         this.customProperties = customProperties || {};
         this.timestamp = new Date().toUTCString();
     }
@@ -56,8 +50,8 @@ export class TelemetryRequest extends Telemetry {
         success,
         customProperties
     }: IRequestTelemetryParams) {
-        super(name, TelemetryType.request, customProperties);
-        this.telemetryType = TelemetryType.request;
+        super(name, customProperties);
+        this.type = TelemetryType.request;
         this.url = url;
         this.success = success;
         this.responseCode = responseCode;
@@ -85,7 +79,8 @@ export class TelemetryException extends Telemetry {
         customProperties,
         severityLevel
     }: IExceptionTelemetryParams) {
-        super(name, TelemetryType.exception, customProperties);
+        super(name, customProperties);
+        this.type = TelemetryType.exception;
         this.exceptionId = exceptionId;
         this.severityLevel = severityLevel;
         this.message = message;
@@ -107,7 +102,8 @@ export class TelemetryTrace extends Telemetry {
         severityLevel,
         customProperties
     }: ITraceTelemetryParams) {
-        super(name, TelemetryType.trace, customProperties);
+        super(name, customProperties);
+        this.type = TelemetryType.trace;
         this.message = message;
         this.severityLevel = severityLevel;
     }
@@ -125,7 +121,8 @@ export class TelemetryEvent extends Telemetry {
         name,
         triggerType
     }: IEventTelemetryParams) {
-        super(name, TelemetryType.event, customProperties);
+        super(name, customProperties);
+        this.type = TelemetryType.event;
         this.customProperties = {
             ...this.customProperties,
             [CUSTOM_PROPERTY_NAMES.AppRegion]: appRegion || 'Unset',
@@ -152,7 +149,8 @@ export class TelemetryMetric extends Telemetry {
         sampleSize,
         customProperties
     }: IMetricTelemetryParams) {
-        super(name, TelemetryType.metric, customProperties);
+        super(name, customProperties);
+        this.type = TelemetryType.metric;
         this.average = average;
         this.min = min;
         this.max = max;

--- a/src/Models/Services/TelemetryService/TelemetryService.ts
+++ b/src/Models/Services/TelemetryService/TelemetryService.ts
@@ -1,5 +1,12 @@
 import { getDebugLogger } from '../Utils';
-import { TelemetryItem } from './Telemetry';
+import {
+    TelemetryEvent,
+    TelemetryException,
+    TelemetryItem,
+    TelemetryMetric,
+    TelemetryRequest,
+    TelemetryTrace
+} from './Telemetry';
 
 const debugLogging = true;
 const logDebugConsole = getDebugLogger('TelemetryService', debugLogging);
@@ -23,6 +30,26 @@ class TelemetryService {
         );
         if (TelemetryService.telemetryCallback)
             TelemetryService.telemetryCallback(telemetry);
+    }
+
+    static sendEvent(telemetry: TelemetryEvent) {
+        this.sendTelemetry(telemetry);
+    }
+
+    static sendMetric(telemetry: TelemetryMetric) {
+        this.sendTelemetry(telemetry);
+    }
+
+    static sendException(telemetry: TelemetryException) {
+        this.sendTelemetry(telemetry);
+    }
+
+    static sendTrace(telemetry: TelemetryTrace) {
+        this.sendTelemetry(telemetry);
+    }
+
+    static sendRequest(telemetry: TelemetryRequest) {
+        this.sendTelemetry(telemetry);
     }
 }
 

--- a/src/Models/Services/TelemetryService/TelemetryService.ts
+++ b/src/Models/Services/TelemetryService/TelemetryService.ts
@@ -1,4 +1,6 @@
+import { Md5 } from 'ts-md5';
 import { LOCAL_STORAGE_KEYS } from '../../Constants/Constants';
+import { CUSTOM_PROPERTY_NAMES } from '../../Constants/TelemetryConstants';
 import { getDebugLogger } from '../Utils';
 import {
     TelemetryEvent,
@@ -17,6 +19,8 @@ const logDebugConsole = getDebugLogger('TelemetryService', debugLogging);
 
 class TelemetryService {
     static telemetryCallback: (telemetry: TelemetryItem) => Promise<void>;
+    private static environmentHash: string; // the hashed value of the environment
+    private static sceneHash: string; // the hash of the scene id
 
     // Attach telemetry processing callback from consuming application
     static registerTelemetryCallback(
@@ -25,16 +29,7 @@ class TelemetryService {
         TelemetryService.telemetryCallback = telemetryCallback;
     }
 
-    // Report telemetry to telemetry processing callback (if present)
-    static sendTelemetry(telemetry: TelemetryItem) {
-        logDebugConsole(
-            'debug',
-            `[Telemetry] [${telemetry.type}] ${telemetry.name}`,
-            telemetry
-        );
-        if (TelemetryService.telemetryCallback)
-            TelemetryService.telemetryCallback(telemetry);
-    }
+    // #region public telemetry emitters
 
     static sendEvent(telemetry: TelemetryEvent) {
         this.sendTelemetry(telemetry);
@@ -55,6 +50,72 @@ class TelemetryService {
     static sendRequest(telemetry: TelemetryRequest) {
         this.sendTelemetry(telemetry);
     }
+
+    // #endregion
+
+    // #region public setters
+
+    /** store the current environment parameters */
+    static setEnvironment(
+        adtInstanceUrl: string,
+        storageBlobUrl: string
+    ): void {
+        this.environmentHash = Md5.hashStr(adtInstanceUrl + storageBlobUrl);
+        logDebugConsole(
+            'debug',
+            `Updating environment hash to ${this.environmentHash}. {storageUrl, adtInstance}`,
+            storageBlobUrl,
+            adtInstanceUrl
+        );
+    }
+
+    /** store the scene id for the current scene */
+    static setSceneId(sceneId: string): void {
+        this.sceneHash = Md5.hashStr(sceneId);
+        logDebugConsole(
+            'debug',
+            `Updating scene hash to ${this.sceneHash}. {sceneId}`,
+            sceneId
+        );
+    }
+
+    // #endregion
+
+    // #region private methods
+
+    // Report telemetry to telemetry processing callback (if present)
+    private static sendTelemetry(telemetry: TelemetryItem) {
+        // add the common properties for all events
+        TelemetryService._addCommonTelemetryProperties(telemetry);
+
+        logDebugConsole(
+            'debug',
+            `[Telemetry] [${telemetry.type}] ${telemetry.name}`,
+            telemetry
+        );
+        if (TelemetryService.telemetryCallback)
+            TelemetryService.telemetryCallback(telemetry);
+    }
+
+    private static _addCommonTelemetryProperties(telemetry: TelemetryItem) {
+        if (!telemetry.customProperties) {
+            telemetry.customProperties = {};
+        }
+        // add the scene hash
+        if (this.sceneHash) {
+            telemetry.customProperties[
+                CUSTOM_PROPERTY_NAMES.SceneHash
+            ] = this.sceneHash;
+        }
+        // add the Environment hash
+        if (this.environmentHash) {
+            telemetry.customProperties[
+                CUSTOM_PROPERTY_NAMES.EnvironmentHash
+            ] = this.environmentHash;
+        }
+    }
+
+    // #endregion
 }
 
 export default TelemetryService;

--- a/src/Models/Services/TelemetryService/TelemetryService.ts
+++ b/src/Models/Services/TelemetryService/TelemetryService.ts
@@ -1,7 +1,7 @@
 import { getDebugLogger } from '../Utils';
 import { TelemetryItem } from './Telemetry';
 
-const debugLogging = false;
+const debugLogging = true;
 const logDebugConsole = getDebugLogger('TelemetryService', debugLogging);
 
 class TelemetryService {

--- a/src/Models/Services/TelemetryService/TelemetryService.ts
+++ b/src/Models/Services/TelemetryService/TelemetryService.ts
@@ -1,3 +1,4 @@
+import { LOCAL_STORAGE_KEYS } from '../../Constants/Constants';
 import { getDebugLogger } from '../Utils';
 import {
     TelemetryEvent,
@@ -8,7 +9,10 @@ import {
     TelemetryTrace
 } from './Telemetry';
 
-const debugLogging = false;
+const debugLogging =
+    localStorage.getItem(
+        LOCAL_STORAGE_KEYS.FeatureFlags.Telemetry.debugLogging
+    ) === 'true' || false;
 const logDebugConsole = getDebugLogger('TelemetryService', debugLogging);
 
 class TelemetryService {
@@ -25,7 +29,7 @@ class TelemetryService {
     static sendTelemetry(telemetry: TelemetryItem) {
         logDebugConsole(
             'debug',
-            `[Telemetry] [${telemetry.telemetryType}] ${telemetry.name}`,
+            `[Telemetry] [${telemetry.type}] ${telemetry.name}`,
             telemetry
         );
         if (TelemetryService.telemetryCallback)

--- a/src/Models/Services/TelemetryService/TelemetryService.ts
+++ b/src/Models/Services/TelemetryService/TelemetryService.ts
@@ -19,7 +19,8 @@ const logDebugConsole = getDebugLogger('TelemetryService', debugLogging);
 
 class TelemetryService {
     static telemetryCallback: (telemetry: TelemetryItem) => Promise<void>;
-    private static environmentHash: string; // the hashed value of the environment
+    private static adtInstanceHash: string; // the hashed value of the adt instance URL
+    private static storageContainerHash: string; // the hashed value of the storage container url
     private static sceneHash: string; // the hash of the scene id
 
     // Attach telemetry processing callback from consuming application
@@ -55,17 +56,29 @@ class TelemetryService {
 
     // #region public setters
 
-    /** store the current environment parameters */
-    static setEnvironment(
-        adtInstanceUrl: string,
-        storageBlobUrl: string
-    ): void {
-        this.environmentHash = Md5.hashStr(adtInstanceUrl + storageBlobUrl);
+    /**
+     * store the current adt instance
+     * @param adtInstanceUrl
+     */
+    static setAdtInstance(adtInstanceUrl: string): void {
+        this.adtInstanceHash = Md5.hashStr(adtInstanceUrl);
         logDebugConsole(
             'debug',
-            `Updating environment hash to ${this.environmentHash}. {storageUrl, adtInstance}`,
-            storageBlobUrl,
+            `Updating adt instance hash to ${this.adtInstanceHash}. {adtInstance}`,
             adtInstanceUrl
+        );
+    }
+
+    /**
+     * store the current blob storage container url
+     * @param blobStorageContainerUrl the url for the storage container
+     */
+    static setStorageContainerUrl(blobStorageContainerUrl: string): void {
+        this.storageContainerHash = Md5.hashStr(blobStorageContainerUrl);
+        logDebugConsole(
+            'debug',
+            `Updating storage URL to ${this.storageContainerHash}. {storageUrl}`,
+            blobStorageContainerUrl
         );
     }
 
@@ -107,11 +120,17 @@ class TelemetryService {
                 CUSTOM_PROPERTY_NAMES.SceneHash
             ] = this.sceneHash;
         }
-        // add the Environment hash
-        if (this.environmentHash) {
+        // add the adt instance hash
+        if (this.adtInstanceHash) {
             telemetry.customProperties[
-                CUSTOM_PROPERTY_NAMES.EnvironmentHash
-            ] = this.environmentHash;
+                CUSTOM_PROPERTY_NAMES.AdtInstanceHash
+            ] = this.adtInstanceHash;
+        }
+        // add the storage container hash
+        if (this.storageContainerHash) {
+            telemetry.customProperties[
+                CUSTOM_PROPERTY_NAMES.StorageContainerHash
+            ] = this.storageContainerHash;
         }
     }
 

--- a/src/Models/Services/TelemetryService/TelemetryService.ts
+++ b/src/Models/Services/TelemetryService/TelemetryService.ts
@@ -8,15 +8,15 @@ import {
     TelemetryTrace
 } from './Telemetry';
 
-const debugLogging = true;
+const debugLogging = false;
 const logDebugConsole = getDebugLogger('TelemetryService', debugLogging);
 
 class TelemetryService {
-    static telemetryCallback: (telemetry: TelemetryItem) => void;
+    static telemetryCallback: (telemetry: TelemetryItem) => Promise<void>;
 
     // Attach telemetry processing callback from consuming application
     static registerTelemetryCallback(
-        telemetryCallback: (telemetry: TelemetryItem) => void
+        telemetryCallback: (telemetry: TelemetryItem) => Promise<void>
     ) {
         TelemetryService.telemetryCallback = telemetryCallback;
     }
@@ -25,7 +25,7 @@ class TelemetryService {
     static sendTelemetry(telemetry: TelemetryItem) {
         logDebugConsole(
             'debug',
-            `[Telemetry] [${telemetry.type}] ${telemetry.name}`,
+            `[Telemetry] [${telemetry.telemetryType}] ${telemetry.name}`,
             telemetry
         );
         if (TelemetryService.telemetryCallback)

--- a/src/Models/Services/TelemetryService/TelemetryService.ts
+++ b/src/Models/Services/TelemetryService/TelemetryService.ts
@@ -36,19 +36,19 @@ class TelemetryService {
         this.sendTelemetry(telemetry);
     }
 
-    static sendMetric(telemetry: TelemetryMetric) {
-        this.sendTelemetry(telemetry);
-    }
-
     static sendException(telemetry: TelemetryException) {
         this.sendTelemetry(telemetry);
     }
 
-    static sendTrace(telemetry: TelemetryTrace) {
+    static sendMetric(telemetry: TelemetryMetric) {
         this.sendTelemetry(telemetry);
     }
 
     static sendRequest(telemetry: TelemetryRequest) {
+        this.sendTelemetry(telemetry);
+    }
+
+    static sendTrace(telemetry: TelemetryTrace) {
         this.sendTelemetry(telemetry);
     }
 

--- a/src/Models/Services/TelemetryService/TelemetryService.types.ts
+++ b/src/Models/Services/TelemetryService/TelemetryService.types.ts
@@ -1,3 +1,9 @@
+import {
+    AppRegion,
+    ComponentName,
+    TelemetryTrigger
+} from '../../Constants/TelemetryConstants';
+
 /** Loosely based on the Application insights telemetry data model
  * https://docs.microsoft.com/en-us/azure/azure-monitor/app/data-model
  */
@@ -22,8 +28,8 @@ export type SeverityLevel =
     | 'Critical';
 
 export interface IBaseTelemetryParams {
-    name: string;
     customProperties?: CustomProperties;
+    name: string;
 }
 
 export interface IRequestTelemetryParams extends IBaseTelemetryParams {
@@ -50,6 +56,12 @@ export interface ITraceTelemetryParams extends IBaseTelemetryParams {
     message: string;
     /** Trace severity level */
     severityLevel?: SeverityLevel;
+}
+
+export interface IEventTelemetryParams extends IBaseTelemetryParams {
+    componentName: ComponentName;
+    triggerType: TelemetryTrigger;
+    appRegion: AppRegion;
 }
 
 export interface IMetricTelemetryParams extends IBaseTelemetryParams {

--- a/src/Models/Services/TelemetryService/TelemetryService.types.ts
+++ b/src/Models/Services/TelemetryService/TelemetryService.types.ts
@@ -58,11 +58,29 @@ export interface ITraceTelemetryParams extends IBaseTelemetryParams {
     severityLevel?: SeverityLevel;
 }
 
-export interface IEventTelemetryParams extends IBaseTelemetryParams {
-    componentName: ComponentName;
+export type IEventTelemetryParams =
+    | IEventTelemetryForComponentAction
+    | IEventTelemetryForComponentView
+    | IEventTelemetryForService;
+
+interface IEventTelemetryParamsBase extends IBaseTelemetryParams {
     triggerType: TelemetryTrigger;
-    appRegion: AppRegion;
 }
+type IEventTelemetryForComponentAction = IEventTelemetryParamsBase & {
+    triggerType: TelemetryTrigger.UserAction;
+    componentName: ComponentName;
+    appRegion: AppRegion;
+};
+type IEventTelemetryForComponentView = IEventTelemetryParamsBase & {
+    triggerType: TelemetryTrigger.UserView;
+    componentName: ComponentName;
+    appRegion: AppRegion;
+};
+type IEventTelemetryForService = IEventTelemetryParamsBase & {
+    triggerType: TelemetryTrigger.SystemAction;
+    componentName?: ComponentName;
+    appRegion?: AppRegion;
+};
 
 export interface IMetricTelemetryParams extends IBaseTelemetryParams {
     average: number;

--- a/src/Models/Services/TelemetryService/__tests__/TelemetryService.test.ts
+++ b/src/Models/Services/TelemetryService/__tests__/TelemetryService.test.ts
@@ -146,11 +146,11 @@ describe('Telemetry service tests', () => {
             expect(message).toBeInstanceOf(TelemetryEvent);
             expect(
                 message.customProperties[CUSTOM_PROPERTY_NAMES.AdtInstanceHash]
-            ).toBe('testEvent.name');
+            ).toBe('eb9328444a41243802d59d4b64b9d4be');
         });
         test('setting blob storage url gets included on messages', () => {
             // ARRANGE
-            const blobStorage = 'https://myadtinstance.com';
+            const blobStorage = 'https://mystorage.blob.com';
 
             // ACT
             TelemetryService.setStorageContainerUrl(blobStorage);
@@ -164,11 +164,11 @@ describe('Telemetry service tests', () => {
                 message.customProperties[
                     CUSTOM_PROPERTY_NAMES.StorageContainerHash
                 ]
-            ).toBe('testEvent.name');
+            ).toBe('0d3974c1e930cadab16cfbe833587bef');
         });
         test('setting scene id gets included on messages', () => {
             // ARRANGE
-            const sceneId = 'https://myadtinstance.com';
+            const sceneId = '125-23523-23523-23523';
 
             // ACT
             TelemetryService.setSceneId(sceneId);
@@ -180,7 +180,7 @@ describe('Telemetry service tests', () => {
             expect(message).toBeInstanceOf(TelemetryEvent);
             expect(
                 message.customProperties[CUSTOM_PROPERTY_NAMES.SceneHash]
-            ).toBe('testEvent.name');
+            ).toBe('9c2507e0369cc2b90fc38a27e02746d4');
         });
     });
 });

--- a/src/Models/Services/Utils.test.ts
+++ b/src/Models/Services/Utils.test.ts
@@ -1,6 +1,6 @@
 import { cleanup } from '@testing-library/react-hooks';
 import { DurationUnits } from '../Constants';
-import { formatTimeInRelevantUnits } from './Utils';
+import { formatTimeInRelevantUnits, isDefined } from './Utils';
 
 afterEach(cleanup);
 
@@ -241,6 +241,24 @@ describe('Utils', () => {
             expect(result).toBeDefined();
             expect(result.value).toEqual(1);
             expect(result.displayStringKey).toEqual('duration.year');
+        });
+    });
+
+    describe('isDefined', () => {
+        test('null returns false', () => {
+            expect(isDefined(null)).toBeFalsy();
+        });
+        test('undefined returns false', () => {
+            expect(isDefined(undefined)).toBeFalsy();
+        });
+        test('0 returns true', () => {
+            expect(isDefined(0)).toBeTruthy();
+        });
+        test('empty string returns true', () => {
+            expect(isDefined('')).toBeTruthy();
+        });
+        test('a string returns true', () => {
+            expect(isDefined('test')).toBeTruthy();
         });
     });
 });

--- a/src/Models/Services/Utils.ts
+++ b/src/Models/Services/Utils.ts
@@ -668,3 +668,8 @@ export function getDebugLogger(
         }
     };
 }
+
+/** checks if a value is null or undefined and returns true if it's not one of those values */
+export function isDefined(value: unknown) {
+    return value != null || value != undefined;
+}

--- a/src/Models/Services/Utils.ts
+++ b/src/Models/Services/Utils.ts
@@ -671,5 +671,5 @@ export function getDebugLogger(
 
 /** checks if a value is null or undefined and returns true if it's not one of those values */
 export function isDefined(value: unknown) {
-    return value != null || value != undefined;
+    return value != null && value != undefined;
 }


### PR DESCRIPTION
### Summary of changes 🔍 
Creating the initial infrastructure and events to emit KPI telemetry of the user's config file. The core of the changes are in the `BlobAdapterUtility` file. This is where we iterate through the entire config and emit events for every scene, behavior and element in the file.
The data will not actually get emitted to any telemetry service as part of Cardboard. That will be up to the hosting app to send it to a telemetry service. 
In our case, we have added that connection in the Flights app to emit the data to application insights and show it in a [PowerBI report](https://msit.powerbi.com/links/hBV4U-Y5QF?ctid=72f988bf-86f1-41af-91ab-2d7cd011db47&pbi_source=linkShare).

#### Event names and properties
You can see that all of the event names and the properties attached to each event are denoted in the `TelemetryConstants` file. This will help us to have a single place to look for the property names & event names. 
Note that there is a `TelemetryEvents` object as well as a `TelemetryMetrics` object. Right now we don't have any metrics but we likely will in the future. 
Each of those objects is broken down into the following structure to help group events together.

> - App region (Builder/Viewer/Adapter)
>    - High level component (SceneList, ElementForm, etc)
>       - User action/System action
>          - Event/action
>             - variant (ex: initiate, confirm, cancel)
>             - eventName: the name of the beacon to emit
>             - properties: names of the custom properties that the event will have attached to it

#### Metadata
There are a few properties that will be attached to every telemetry event:
- Current Environment id (hash)
- Current Scene id (hash)

These are updated anytime the deeplink context is has a value change so they will always reflect the current state of the app. We use the `md5` library for generating the hashes. The EnvironmentId is based on a combination of storageUrl and the ADT instance URL. The scene id is simply a hash of the GUID stored in the config file.

#### System action telemetry
Some events will be emitted by the system without user interaction. I'm defining these as "SystemAction" events. These will be most commonly sent from Adapters or services where we want to send a KPI type metric so we can identify patterns in the configs or usage of the app rather than specific user actions.
An example of these can be found in the `BlobAdapterUtility.ts` where we parse the config and emit events for every scene, behavior and element. These will be sent when the config is fetched and does not get triggered by a particular user action.

#### User action telemetry
Most events from the app will eventually by "UserAction" events which are prompted by a user taking some action in the app.
User actions will have a few extra properties attached to them which are not required for system actions coming from events in adapters. We want to capture a few extra points such as the ComponentName, AppRegion and the Gesture (hover, click) that triggered that event. Those will be required in addition to the event name when utilizing the `useTelemetry` hook and calling the `sendEventTelemetry` method. This will help us to slice and dice the data in the cases where the same event name is emitted by multiple different places in the app. Rather that proliferating the event names and using different names in multiple places, we can use the same event and simply slice by the "source"

An example of this kind of event can be seen in the `SceneList.tsx` file where we capture events when the user clicks on a list item or chooses to create/edit/delete a scene.

#### Debugging telemetry
If you run the following command in your browser console, you can enable telemetry logging (running locally or in production) to see all telemetry events that are being fired. NOTE: This does not mean it was sent to the server. This just means the hosting app was notified, it's up to that app to determine whether to send it to a telemetry service.

```ts
localStorage.setItem('cardboard.debug.telemetryLogging', true);
```

### Testing 🧪
first, set the local storage key for logging & then reload the page to see the events get fired

- [ ] click the edit button on a scene in the scene list --> see a telemetry event fire
- [ ] click 'create scene' on the scene list page --> see the telemetry event fire
- [ ] launch the app and see the KPI events fire for your scenes

### Checklist ✔️
- [ ] Linked associated issue (if present)
- [ ] Added relevant labels
- [ ] Requested developer reviews
- [ ] Request UI review from design / PM
- [ ] Verify all code checks are passing