### PR TITLE
Integrating Advanced search to Element form

### DIFF
--- a/src/Components/ADT3DSceneBuilder/Internal/Elements/ElementForm.tsx
+++ b/src/Components/ADT3DSceneBuilder/Internal/Elements/ElementForm.tsx
@@ -239,7 +239,7 @@ const SceneElementForm: React.FC<IADT3DSceneBuilderElementFormProps> = ({
 
     const handleSearchSelectTwinId = (selectedTwinId: string) => {
         if (propertyDropdownRef.current && selectedTwinId.length) {
-            propertyDropdownRef.current.updateValue(selectedTwinId);
+            propertyDropdownRef.current.setValue(selectedTwinId);
             handleSelectTwinId(selectedTwinId);
         }
     };
@@ -302,6 +302,13 @@ const SceneElementForm: React.FC<IADT3DSceneBuilderElementFormProps> = ({
     const theme = useTheme();
     const commonPanelStyles = getLeftPanelStyles(theme);
     const commonFormStyles = getPanelFormStyles(theme, 170);
+    const iconButtonStyles = {
+        root: {
+            marginTop: '34px', // Needed to align button to dropdown
+            color: theme.semanticColors.buttonText,
+            border: `1px solid ${theme.semanticColors.inputBorder}`
+        }
+    };
     return (
         <div className={commonFormStyles.root}>
             <LeftPanelBuilderHeader
@@ -356,15 +363,7 @@ const SceneElementForm: React.FC<IADT3DSceneBuilderElementFormProps> = ({
                                         }
                                         styles={{
                                             subComponentStyles: {
-                                                button: {
-                                                    root: {
-                                                        marginTop: '34px', // Needed to align button to dropdown
-                                                        color:
-                                                            theme.semanticColors
-                                                                .buttonText,
-                                                        border: `1px solid ${theme.semanticColors.buttonBorder}`
-                                                    }
-                                                }
+                                                button: iconButtonStyles
                                             }
                                         }}
                                     />
@@ -373,15 +372,7 @@ const SceneElementForm: React.FC<IADT3DSceneBuilderElementFormProps> = ({
                                             iconName: 'QueryList'
                                         }}
                                         onClick={ToggleAdvancedSearchOpen}
-                                        styles={{
-                                            root: {
-                                                marginTop: '34px', // Needed to align button to dropdown
-                                                color:
-                                                    theme.semanticColors
-                                                        .buttonText,
-                                                border: `1px solid ${theme.semanticColors.buttonBorder}`
-                                            }
-                                        }}
+                                        styles={iconButtonStyles}
                                     />
                                 </Stack>
                                 <TextField

--- a/src/Components/ADT3DSceneBuilder/Internal/Elements/ElementForm.tsx
+++ b/src/Components/ADT3DSceneBuilder/Internal/Elements/ElementForm.tsx
@@ -8,6 +8,7 @@ import React, {
 import { useTranslation } from 'react-i18next';
 import {
     DefaultButton,
+    IconButton,
     Pivot,
     PivotItem,
     PrimaryButton,
@@ -16,6 +17,7 @@ import {
     TextField,
     useTheme
 } from '@fluentui/react';
+import { useBoolean } from '@fluentui/react-hooks';
 import {
     IADT3DSceneBuilderElementFormProps,
     SET_ADT_SCENE_BUILDER_FORM_DIRTY_MAP_ENTRY
@@ -46,6 +48,10 @@ import {
 import { ElementFormContextActionType } from '../../../../Models/Context/ElementsFormContext/ElementFormContext.types';
 import { setPivotToRequired } from '../../../../Theming/FluentComponentStyles/Pivot.styles';
 import { DTID_PROPERTY_NAME } from '../../../../Models/Constants/Constants';
+import PropertyInspectorCallout from '../../../PropertyInspector/PropertyInspectorCallout/PropertyInspectorCallout';
+import AdvancedSearch from '../../../AdvancedSearch/AdvancedSearch';
+import { queryAllowedPropertyValueTypes } from '../../../AdvancedSearch/Internal/QueryBuilder/QueryBuilder.types';
+import { PropertyValueHandle } from '../../../TwinPropertySearchDropdown/TwinPropertySearchDropdown.types';
 
 const debugLogging = false;
 const logDebugConsole = getDebugLogger('ElementsForm', debugLogging);
@@ -75,12 +81,17 @@ const SceneElementForm: React.FC<IADT3DSceneBuilderElementFormProps> = ({
     const { elementFormDispatch, elementFormState } = useElementFormContext();
 
     // state
+    const [
+        isAdvancedSearchOpen,
+        { toggle: ToggleAdvancedSearchOpen }
+    ] = useBoolean(false);
     const existingElementsRef = useRef(
         ViewerConfigUtility.getSceneById(config, sceneId)?.elements?.filter(
             ViewerConfigUtility.isTwinToObjectMappingElement
         ) || []
     );
     const newElementsRef = useRef(null);
+    const propertyDropdownRef = useRef<PropertyValueHandle>(null);
 
     const isCreateElementDisabled = !(
         elementFormState.elementToEdit?.displayName &&
@@ -226,6 +237,13 @@ const SceneElementForm: React.FC<IADT3DSceneBuilderElementFormProps> = ({
         });
     };
 
+    const handleSearchSelectTwinId = (selectedTwinId: string) => {
+        if (propertyDropdownRef.current && selectedTwinId.length) {
+            propertyDropdownRef.current.updateValue(selectedTwinId);
+            handleSelectTwinId(selectedTwinId);
+        }
+    };
+
     // effects
 
     // mirror the form state up to the scene context (for navigation confirmation)
@@ -298,27 +316,74 @@ const SceneElementForm: React.FC<IADT3DSceneBuilderElementFormProps> = ({
                     <div className={commonFormStyles.content}>
                         <div className={commonFormStyles.header}>
                             <Stack tokens={{ childrenGap: 8 }}>
-                                <TwinPropertySearchDropdown
-                                    adapter={adapter}
-                                    descriptionText={t(
-                                        '3dSceneBuilder.elementForm.twinNameDescription'
-                                    )}
-                                    label={t('3dSceneBuilder.primaryTwin')}
-                                    labelTooltip={{
-                                        buttonAriaLabel: t(
-                                            '3dSceneBuilder.elementForm.twinNameTooltip'
-                                        ),
-                                        calloutContent: t(
-                                            '3dSceneBuilder.elementForm.twinNameTooltip'
-                                        )
-                                    }}
-                                    initialSelectedValue={
-                                        elementFormState.elementToEdit
-                                            ?.primaryTwinID
-                                    }
-                                    searchPropertyName={DTID_PROPERTY_NAME}
-                                    onChange={handleSelectTwinId}
-                                />
+                                <Stack
+                                    horizontal={true}
+                                    tokens={{ childrenGap: 4 }}
+                                >
+                                    <TwinPropertySearchDropdown
+                                        ref={propertyDropdownRef}
+                                        adapter={adapter}
+                                        descriptionText={t(
+                                            '3dSceneBuilder.elementForm.twinNameDescription'
+                                        )}
+                                        label={t('3dSceneBuilder.primaryTwin')}
+                                        labelTooltip={{
+                                            buttonAriaLabel: t(
+                                                '3dSceneBuilder.elementForm.twinNameTooltip'
+                                            ),
+                                            calloutContent: t(
+                                                '3dSceneBuilder.elementForm.twinNameTooltip'
+                                            )
+                                        }}
+                                        initialSelectedValue={
+                                            elementFormState.elementToEdit
+                                                ?.primaryTwinID
+                                        }
+                                        searchPropertyName={DTID_PROPERTY_NAME}
+                                        onChange={handleSelectTwinId}
+                                    />
+                                    <PropertyInspectorCallout
+                                        adapter={adapter}
+                                        twinId={
+                                            elementFormState.elementToEdit
+                                                ?.primaryTwinID
+                                        }
+                                        disabled={
+                                            !(
+                                                elementFormState.elementToEdit
+                                                    ?.primaryTwinID?.length > 0
+                                            )
+                                        }
+                                        styles={{
+                                            subComponentStyles: {
+                                                button: {
+                                                    root: {
+                                                        marginTop: '34px', // Needed to align button to dropdown
+                                                        color:
+                                                            theme.semanticColors
+                                                                .buttonText,
+                                                        border: `1px solid ${theme.semanticColors.buttonBorder}`
+                                                    }
+                                                }
+                                            }
+                                        }}
+                                    />
+                                    <IconButton
+                                        iconProps={{
+                                            iconName: 'QueryList'
+                                        }}
+                                        onClick={ToggleAdvancedSearchOpen}
+                                        styles={{
+                                            root: {
+                                                marginTop: '34px', // Needed to align button to dropdown
+                                                color:
+                                                    theme.semanticColors
+                                                        .buttonText,
+                                                border: `1px solid ${theme.semanticColors.buttonBorder}`
+                                            }
+                                        }}
+                                    />
+                                </Stack>
                                 <TextField
                                     label={t('name')}
                                     value={
@@ -417,6 +482,18 @@ const SceneElementForm: React.FC<IADT3DSceneBuilderElementFormProps> = ({
                             onClick={onCancelClick}
                         />
                     </PanelFooter>
+                    {/* Modal */}
+                    {isAdvancedSearchOpen && (
+                        <AdvancedSearch
+                            adapter={adapter}
+                            allowedPropertyValueTypes={
+                                queryAllowedPropertyValueTypes
+                            }
+                            isOpen={isAdvancedSearchOpen}
+                            onDismiss={ToggleAdvancedSearchOpen}
+                            onTwinIdSelect={handleSearchSelectTwinId}
+                        />
+                    )}
                 </>
             )}
         </div>

--- a/src/Components/AdvancedSearch/AdvancedSearch.stories.local.tsx
+++ b/src/Components/AdvancedSearch/AdvancedSearch.stories.local.tsx
@@ -34,6 +34,9 @@ const Template: AdvancedSearchStory = (_args) => {
                     authenticationParameters.storage.blobContainerUrl
                 )
             }
+            onTwinIdSelect={(selectedTwin: string) => {
+                alert(`Selected twin: ${selectedTwin}`);
+            }}
             allowedPropertyValueTypes={queryAllowedPropertyValueTypes}
             isOpen={true}
             onDismiss={() => ({})}

--- a/src/Components/AdvancedSearch/AdvancedSearch.stories.tsx
+++ b/src/Components/AdvancedSearch/AdvancedSearch.stories.tsx
@@ -29,6 +29,9 @@ Base.args = {
     onDismiss: () => {
         return;
     },
+    onTwinIdSelect: (selectedTwin: string) => {
+        alert(`Selected twin: ${selectedTwin}`);
+    },
     adapter: new MockAdapter(),
     allowedPropertyValueTypes: queryAllowedPropertyValueTypes,
     theme: null
@@ -39,6 +42,9 @@ const sharedArgs = {
     isOpen: true,
     onDismiss: () => {
         return;
+    },
+    onTwinIdSelect: (selectedTwin: string) => {
+        alert(`Selected twin: ${selectedTwin}`);
     },
     adapter: new MockAdapter(),
     allowedPropertyValueTypes: queryAllowedPropertyValueTypes,

--- a/src/Components/AdvancedSearch/AdvancedSearch.stories.tsx
+++ b/src/Components/AdvancedSearch/AdvancedSearch.stories.tsx
@@ -55,7 +55,7 @@ export const NumericalDropdown = Template.bind({});
 NumericalDropdown.args = sharedArgs;
 NumericalDropdown.play = async () => {
     // Click on a numerical option
-    selectReactSelectOption('AdvancedSearch-propertySelectInput', 0);
+    await selectReactSelectOption('AdvancedSearch-propertySelectInput', 0);
 };
 NumericalDropdown.storyName = 'Mock Numerical dropdown';
 
@@ -63,7 +63,7 @@ export const BooleanDropdown = Template.bind({});
 BooleanDropdown.args = sharedArgs;
 BooleanDropdown.play = async () => {
     // Click on a boolean typed option
-    selectReactSelectOption('AdvancedSearch-propertySelectInput', 4);
+    await selectReactSelectOption('AdvancedSearch-propertySelectInput', 4);
 };
 BooleanDropdown.storyName = 'Mock Boolean dropdown';
 
@@ -71,6 +71,6 @@ export const StringDropdown = Template.bind({});
 StringDropdown.args = sharedArgs;
 StringDropdown.play = async () => {
     // Click on a string typed option
-    selectReactSelectOption('AdvancedSearch-propertySelectInput', 9);
+    await selectReactSelectOption('AdvancedSearch-propertySelectInput', 9);
 };
 StringDropdown.storyName = 'Mock String dropdown';

--- a/src/Components/AdvancedSearch/AdvancedSearch.styles.ts
+++ b/src/Components/AdvancedSearch/AdvancedSearch.styles.ts
@@ -7,6 +7,7 @@ import {
 export const classPrefix = 'cb-advancedsearch';
 const classNames = {
     content: `${classPrefix}-content`,
+    footer: `${classPrefix}-footer`,
     headerContainer: `${classPrefix}-headerContainer`,
     subtitle: `${classPrefix}-subtitle`,
     title: `${classPrefix}-title`,
@@ -17,7 +18,13 @@ export const getStyles = (
     _props: IAdvancedSearchStyleProps
 ): IAdvancedSearchStyles => {
     return {
-        content: [classNames.content],
+        content: [
+            classNames.content,
+            {
+                height: '100%'
+            }
+        ],
+        footer: [classNames.footer],
         headerContainer: [classNames.headerContainer],
         title: [
             classNames.title,
@@ -41,6 +48,9 @@ export const getStyles = (
                     height: 690,
                     width: 940,
                     padding: 20
+                },
+                scrollableContent: {
+                    height: '100%'
                 }
             },
             icon: {
@@ -50,6 +60,11 @@ export const getStyles = (
                     paddingRight: 12,
                     paddingTop: 8,
                     fontSize: FontSizes.size20
+                }
+            },
+            advancedSearchDetailsList: {
+                root: {
+                    overflow: 'auto'
                 }
             }
         }

--- a/src/Components/AdvancedSearch/AdvancedSearch.tsx
+++ b/src/Components/AdvancedSearch/AdvancedSearch.tsx
@@ -31,9 +31,12 @@ const getClassNames = classNamesFunction<
     IAdvancedSearchStyles
 >();
 
-const stackTokens: IStackTokens = {
-    maxHeight: 550
+const CONTENT_MAX_HEIGHT = 515;
+const containerStackTokens: IStackTokens = { childrenGap: 8 };
+const contentStackTokens: IStackTokens = {
+    maxHeight: CONTENT_MAX_HEIGHT
 };
+const footerStackTokens: IStackTokens = { childrenGap: 8 };
 
 const AdvancedSearch: React.FC<IAdvancedSearchProps> = (props) => {
     const {
@@ -94,63 +97,62 @@ const AdvancedSearch: React.FC<IAdvancedSearchProps> = (props) => {
             styles={classNames.subComponentStyles.modal}
             layerProps={{ eventBubblingEnabled: true }}
         >
-            <div className={classNames.headerContainer}>
-                <div className={classNames.titleContainer}>
-                    <Icon
-                        iconName={'search'}
-                        styles={classNames.subComponentStyles.icon}
-                    />
-                    <h3 id={titleId} className={classNames.title}>
-                        {t('advancedSearch.modalTitle')}
-                    </h3>
-                </div>
-                <p className={classNames.subtitle}>
-                    {t('advancedSearch.modalSubtitle')}
-                </p>
-            </div>
-            <div className={classNames.content}>
-                <Stack tokens={stackTokens}>
-                    <QueryBuilder
-                        adapter={adapter}
-                        allowedPropertyValueTypes={allowedPropertyValueTypes}
-                        executeQuery={executeQuery}
-                        updateColumns={updateColumns}
-                    />
-                    <AdvancedSearchResultDetailsList
-                        adapter={adapter}
-                        isLoading={searchForTwinAdapterData.isLoading}
-                        containsError={searchForTwinAdapterData.adapterResult.hasError()}
-                        onTwinIdSelect={updateSelectedTwinId}
-                        searchedProperties={Array.from(
-                            additionalProperties.current
-                        )}
-                        twins={filteredTwins.current}
-                        styles={{
-                            root: {
-                                maxHeight: 380,
-                                overflow: 'auto'
-                            }
-                        }}
-                    />
-                    <div>
-                        <Stack
-                            tokens={{ childrenGap: 8 }}
-                            horizontal={true}
-                            horizontalAlign={'end'}
-                        >
-                            <PrimaryButton
-                                text={t('select')}
-                                disabled={!selectedTwinId.length}
-                                onClick={onConfirmSelection}
-                            />
-                            <DefaultButton
-                                text={t('cancel')}
-                                onClick={onDismiss}
-                            />
-                        </Stack>
+            <Stack tokens={containerStackTokens} style={{ height: '100%' }}>
+                <div className={classNames.headerContainer}>
+                    <div className={classNames.titleContainer}>
+                        <Icon
+                            iconName={'search'}
+                            styles={classNames.subComponentStyles.icon}
+                        />
+                        <h3 id={titleId} className={classNames.title}>
+                            {t('advancedSearch.modalTitle')}
+                        </h3>
                     </div>
-                </Stack>
-            </div>
+                    <p className={classNames.subtitle}>
+                        {t('advancedSearch.modalSubtitle')}
+                    </p>
+                </div>
+                <div className={classNames.content}>
+                    <Stack tokens={contentStackTokens}>
+                        <QueryBuilder
+                            adapter={adapter}
+                            allowedPropertyValueTypes={
+                                allowedPropertyValueTypes
+                            }
+                            executeQuery={executeQuery}
+                            updateColumns={updateColumns}
+                        />
+                        <AdvancedSearchResultDetailsList
+                            adapter={adapter}
+                            isLoading={searchForTwinAdapterData.isLoading}
+                            containsError={searchForTwinAdapterData.adapterResult.hasError()}
+                            onTwinIdSelect={updateSelectedTwinId}
+                            searchedProperties={Array.from(
+                                additionalProperties.current
+                            )}
+                            twins={filteredTwins.current}
+                            styles={
+                                classNames.subComponentStyles
+                                    .advancedSearchDetailsList
+                            }
+                        />
+                    </Stack>
+                </div>
+                <div className={classNames.footer}>
+                    <Stack
+                        tokens={footerStackTokens}
+                        horizontal={true}
+                        horizontalAlign={'end'}
+                    >
+                        <PrimaryButton
+                            text={t('select')}
+                            disabled={!selectedTwinId.length}
+                            onClick={onConfirmSelection}
+                        />
+                        <DefaultButton text={t('cancel')} onClick={onDismiss} />
+                    </Stack>
+                </div>
+            </Stack>
         </Modal>
     );
 };

--- a/src/Components/AdvancedSearch/AdvancedSearch.tsx
+++ b/src/Components/AdvancedSearch/AdvancedSearch.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
     IAdvancedSearchProps,
     IAdvancedSearchStyleProps,
@@ -12,7 +12,9 @@ import {
     Modal,
     Icon,
     Stack,
-    IStackTokens
+    IStackTokens,
+    PrimaryButton,
+    DefaultButton
 } from '@fluentui/react';
 import { useId } from '@fluentui/react-hooks';
 import QueryBuilder from './Internal/QueryBuilder/QueryBuilder';
@@ -39,6 +41,7 @@ const AdvancedSearch: React.FC<IAdvancedSearchProps> = (props) => {
         allowedPropertyValueTypes,
         isOpen,
         onDismiss,
+        onTwinIdSelect,
         styles
     } = props;
     const classNames = getClassNames(styles, {
@@ -54,6 +57,7 @@ const AdvancedSearch: React.FC<IAdvancedSearchProps> = (props) => {
         refetchDependencies: [adapter],
         isAdapterCalledOnMount: false
     });
+    const [selectedTwinId, updateSelectedTwinId] = useState<string>('');
 
     const executeQuery = (query: string) => {
         searchForTwinAdapterData.callAdapter({
@@ -76,6 +80,11 @@ const AdvancedSearch: React.FC<IAdvancedSearchProps> = (props) => {
     const updateColumns = (properties: Set<string>) => {
         additionalProperties.current = properties;
     };
+
+    const onConfirmSelection = useCallback(() => {
+        onTwinIdSelect(selectedTwinId);
+        onDismiss();
+    }, [selectedTwinId]);
 
     return (
         <Modal
@@ -111,7 +120,7 @@ const AdvancedSearch: React.FC<IAdvancedSearchProps> = (props) => {
                         adapter={adapter}
                         isLoading={searchForTwinAdapterData.isLoading}
                         containsError={searchForTwinAdapterData.adapterResult.hasError()}
-                        onTwinSelection={null}
+                        onTwinIdSelect={updateSelectedTwinId}
                         searchedProperties={Array.from(
                             additionalProperties.current
                         )}
@@ -123,6 +132,23 @@ const AdvancedSearch: React.FC<IAdvancedSearchProps> = (props) => {
                             }
                         }}
                     />
+                    <div>
+                        <Stack
+                            tokens={{ childrenGap: 8 }}
+                            horizontal={true}
+                            horizontalAlign={'end'}
+                        >
+                            <PrimaryButton
+                                text={t('select')}
+                                disabled={!selectedTwinId.length}
+                                onClick={onConfirmSelection}
+                            />
+                            <DefaultButton
+                                text={t('cancel')}
+                                onClick={onDismiss}
+                            />
+                        </Stack>
+                    </div>
                 </Stack>
             </div>
         </Modal>

--- a/src/Components/AdvancedSearch/AdvancedSearch.types.ts
+++ b/src/Components/AdvancedSearch/AdvancedSearch.types.ts
@@ -16,6 +16,7 @@ export interface IAdvancedSearchProps {
     allowedPropertyValueTypes: PropertyValueType[];
     isOpen: boolean;
     onDismiss: () => void;
+    onTwinIdSelect: (selectedTwin: string) => void;
     /**
      * Call to provide customized styling that will layer on top of the variant rules.
      */

--- a/src/Components/AdvancedSearch/AdvancedSearch.types.ts
+++ b/src/Components/AdvancedSearch/AdvancedSearch.types.ts
@@ -7,6 +7,7 @@ import {
 } from '@fluentui/react';
 import { ADTAdapter, MockAdapter } from '../../Adapters';
 import { PropertyValueType } from '../../Models/Constants';
+import { IAdvancedSearchResultDetailsListStyles } from './Internal/AdvancedSearchResultDetailsList/AdvancedSearchResultDetailsList.types';
 
 export const QUERY_RESULT_LIMIT = 1000;
 
@@ -31,6 +32,7 @@ export interface IAdvancedSearchStyleProps {
 }
 export interface IAdvancedSearchStyles {
     content: IStyle;
+    footer: IStyle;
     headerContainer: IStyle;
     title: IStyle;
     titleContainer: IStyle;
@@ -44,29 +46,5 @@ export interface IAdvancedSearchStyles {
 export interface IAdvancedSearchSubComponentStyles {
     modal?: Partial<IModalStyles>;
     icon?: IIconStyles;
+    advancedSearchDetailsList?: Partial<IAdvancedSearchResultDetailsListStyles>;
 }
-
-/** Search results types */
-export interface IAdvancedSearchResultsProps {
-    /**
-     * Call to provide customized styling that will layer on top of the variant rules.
-     */
-    styles?: IStyleFunctionOrObject<
-        IAdvancedSearchResultsStyleProps,
-        IAdvancedSearchResultsStyles
-    >;
-}
-
-export interface IAdvancedSearchResultsStyleProps {
-    theme: ITheme;
-}
-export interface IAdvancedSearchResultsStyles {
-    root: IStyle;
-    /**
-     * SubComponent styles.
-     */
-    subComponentStyles?: IAdvancedSearchResultsSubComponentStyles;
-}
-
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface IAdvancedSearchResultsSubComponentStyles {}

--- a/src/Components/AdvancedSearch/Internal/AdvancedSearchResultDetailsList/AdvancedSearchResultDetailsList.stories.tsx
+++ b/src/Components/AdvancedSearch/Internal/AdvancedSearchResultDetailsList/AdvancedSearchResultDetailsList.stories.tsx
@@ -42,5 +42,5 @@ export const Base = Template.bind({}) as AdvancedSearchResultDetailsListStory;
 Base.args = {
     twins: filteredTwins,
     searchedProperties: cols,
-    onTwinSelection: null
+    onTwinIdSelect: null
 } as IAdvancedSearchResultDetailsListProps;

--- a/src/Components/AdvancedSearch/Internal/AdvancedSearchResultDetailsList/AdvancedSearchResultDetailsList.tsx
+++ b/src/Components/AdvancedSearch/Internal/AdvancedSearchResultDetailsList/AdvancedSearchResultDetailsList.tsx
@@ -36,7 +36,7 @@ const getClassNames = classNamesFunction<
 const AdvancedSearchResultDetailsList: React.FC<IAdvancedSearchResultDetailsListProps> = ({
     adapter,
     containsError,
-    onTwinSelection,
+    onTwinIdSelect,
     isLoading,
     searchedProperties,
     styles,
@@ -129,7 +129,9 @@ const AdvancedSearchResultDetailsList: React.FC<IAdvancedSearchResultDetailsList
             return item['$dtId'];
         },
         onSelectionChanged: () => {
-            onTwinSelection?.(selection.getSelection());
+            // getSelection returns an array of selected elements, since this is single select first one is always going to be the correct one
+            const selectionValue = selection.getSelection()[0];
+            onTwinIdSelect(selectionValue ? selectionValue['$dtId'] : '');
         }
     });
 

--- a/src/Components/AdvancedSearch/Internal/AdvancedSearchResultDetailsList/AdvancedSearchResultDetailsList.types.ts
+++ b/src/Components/AdvancedSearch/Internal/AdvancedSearchResultDetailsList/AdvancedSearchResultDetailsList.types.ts
@@ -16,7 +16,7 @@ export interface IAdvancedSearchResultDetailsListProps {
     containsError: boolean;
     isLoading: boolean;
     /* Callback function from parent on what to do once the user selects or deselects a twin. */
-    onTwinSelection: (IADTTwin) => void;
+    onTwinIdSelect: (twinId: string) => void;
     /* String of fieldnames, for specific properties that were used in the search. */
     searchedProperties: string[];
     /* Call to provide customized styling that will layer on top of the variant rules. */

--- a/src/Components/AdvancedSearch/Internal/QueryBuilder/QueryBuilder.styles.ts
+++ b/src/Components/AdvancedSearch/Internal/QueryBuilder/QueryBuilder.styles.ts
@@ -1,4 +1,4 @@
-import { FontSizes, ITheme } from '@fluentui/react';
+import { FontSizes } from '@fluentui/react';
 import {
     IQueryBuilderStyleProps,
     IQueryBuilderStyles,

--- a/src/Components/AdvancedSearch/Internal/QueryBuilder/QueryBuilderRow.tsx
+++ b/src/Components/AdvancedSearch/Internal/QueryBuilder/QueryBuilderRow.tsx
@@ -333,7 +333,9 @@ const QueryBuilderRow: React.FC<IQueryBuilderRowProps> = (props) => {
             <div className={classNames.inputColumn}>
                 {/* Property */}
                 <Select
+                    // Both className and prefix are required for testing
                     className={'AdvancedSearch-propertySelectInput'}
+                    classNamePrefix={'AdvancedSearch-propertySelectInput'}
                     id={propertySelectorId}
                     options={isLoading ? [] : propertyOptions}
                     noOptionsMessage={() =>

--- a/src/Components/AdvancedSearch/Internal/QueryBuilder/QueryBuilderRow.tsx
+++ b/src/Components/AdvancedSearch/Internal/QueryBuilder/QueryBuilderRow.tsx
@@ -332,7 +332,7 @@ const QueryBuilderRow: React.FC<IQueryBuilderRowProps> = (props) => {
             )}
             <div className={classNames.inputColumn}>
                 {/* Property */}
-                <Select<PropertyOption>
+                <Select
                     className={'AdvancedSearch-propertySelectInput'}
                     id={propertySelectorId}
                     options={isLoading ? [] : propertyOptions}

--- a/src/Components/PropertyInspector/PropertyInspectorCallout/PropertyInspectorCallout.tsx
+++ b/src/Components/PropertyInspector/PropertyInspectorCallout/PropertyInspectorCallout.tsx
@@ -25,7 +25,7 @@ const getClassNames = classNamesFunction<
 const PropertyInspectorCallout: React.FC<IPropertyInspectorCalloutProps> = (
     props
 ) => {
-    const { adapter, twinId, styles } = props;
+    const { adapter, disabled = false, twinId, styles } = props;
 
     // state
     const [isVisible, { toggle: setIsVisible }] = useBoolean(false);
@@ -51,6 +51,7 @@ const PropertyInspectorCallout: React.FC<IPropertyInspectorCalloutProps> = (
                 }}
                 id={buttonId}
                 styles={classNames.subComponentStyles.button?.()}
+                disabled={disabled}
             />
             {isVisible && (
                 <Callout

--- a/src/Components/PropertyInspector/PropertyInspectorCallout/PropertyInspectorCallout.types.ts
+++ b/src/Components/PropertyInspector/PropertyInspectorCallout/PropertyInspectorCallout.types.ts
@@ -10,6 +10,7 @@ import { IPropertyInspectorAdapter } from '../../../Models/Constants';
 export interface IPropertyInspectorCalloutProps {
     adapter: IPropertyInspectorAdapter;
     twinId: string;
+    disabled?: boolean;
     /**
      * Call to provide customized styling that will layer on top of the variant rules.
      */

--- a/src/Components/TwinPropertySearchDropdown/TwinPropertySearchDropdown.tsx
+++ b/src/Components/TwinPropertySearchDropdown/TwinPropertySearchDropdown.tsx
@@ -335,7 +335,8 @@ const TwinPropertySearchDropdown = (
                         }
                     }}
                     placeholder={
-                        placeholderText || t('3dSceneBuilder.searchTwinId')
+                        placeholderText ||
+                        t('3dSceneBuilder.searchTwinIdPlaceholder')
                     }
                     noOptionsMessage={() =>
                         noOptionsText || t('3dSceneBuilder.noTwinsFound')

--- a/src/Components/TwinPropertySearchDropdown/TwinPropertySearchDropdown.tsx
+++ b/src/Components/TwinPropertySearchDropdown/TwinPropertySearchDropdown.tsx
@@ -57,7 +57,10 @@ const SuggestionListScrollThresholdFactor = 40;
  * @returns a component
  */
 const TwinPropertySearchDropdown = (
-    {
+    props: ITwinPropertySearchDropdownProps,
+    ref: Ref<PropertyValueHandle>
+) => {
+    const {
         adapter,
         descriptionText,
         initialSelectedValue,
@@ -72,9 +75,7 @@ const TwinPropertySearchDropdown = (
         resetInputOnBlur = true,
         searchPropertyName,
         styles
-    },
-    ref: Ref<PropertyValueHandle>
-) => {
+    } = props;
     const { t } = useTranslation();
     const selectId = useId('twin-property-search-dropdown');
     const [searchValue, setSearchValue] = useState(initialSelectedValue ?? '');
@@ -211,8 +212,9 @@ const TwinPropertySearchDropdown = (
 
     // imperative handle to expose modifying the state
     useImperativeHandle(ref, () => ({
-        updateValue: (newValue: string) => {
+        setValue: (newValue: string) => {
             setSearchValue(newValue);
+            setSelectedOption(createOption(newValue));
         }
     }));
 

--- a/src/Components/TwinPropertySearchDropdown/TwinPropertySearchDropdown.tsx
+++ b/src/Components/TwinPropertySearchDropdown/TwinPropertySearchDropdown.tsx
@@ -1,4 +1,12 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, {
+    forwardRef,
+    Ref,
+    useEffect,
+    useImperativeHandle,
+    useMemo,
+    useRef,
+    useState
+} from 'react';
 import { useTranslation } from 'react-i18next';
 import {
     Callout,
@@ -28,7 +36,8 @@ import {
     IReactSelectOption,
     ITwinPropertySearchDropdownProps,
     ITwinPropertySearchDropdownStyleProps,
-    ITwinPropertySearchDropdownStyles
+    ITwinPropertySearchDropdownStyles,
+    PropertyValueHandle
 } from './TwinPropertySearchDropdown.types';
 
 const debugLogging = false;
@@ -47,22 +56,25 @@ const SuggestionListScrollThresholdFactor = 40;
  * @param param0 props
  * @returns a component
  */
-const TwinPropertySearchDropdown: React.FC<ITwinPropertySearchDropdownProps> = ({
-    adapter,
-    descriptionText,
-    initialSelectedValue,
-    inputStyles,
-    isLabelHidden = false,
-    label,
-    labelIconName,
-    labelTooltip,
-    onChange,
-    noOptionsText,
-    placeholderText,
-    resetInputOnBlur = true,
-    searchPropertyName,
-    styles
-}) => {
+const TwinPropertySearchDropdown = (
+    {
+        adapter,
+        descriptionText,
+        initialSelectedValue,
+        inputStyles,
+        isLabelHidden = false,
+        label,
+        labelIconName,
+        labelTooltip,
+        onChange,
+        noOptionsText,
+        placeholderText,
+        resetInputOnBlur = true,
+        searchPropertyName,
+        styles
+    },
+    ref: Ref<PropertyValueHandle>
+) => {
     const { t } = useTranslation();
     const selectId = useId('twin-property-search-dropdown');
     const [searchValue, setSearchValue] = useState(initialSelectedValue ?? '');
@@ -196,6 +208,13 @@ const TwinPropertySearchDropdown: React.FC<ITwinPropertySearchDropdownProps> = (
             </Callout>
         );
     };
+
+    // imperative handle to expose modifying the state
+    useImperativeHandle(ref, () => ({
+        updateValue: (newValue: string) => {
+            setSearchValue(newValue);
+        }
+    }));
 
     logDebugConsole(
         'debug',
@@ -343,7 +362,7 @@ const TwinPropertySearchDropdown: React.FC<ITwinPropertySearchDropdownProps> = (
 };
 
 export default styled<
-    ITwinPropertySearchDropdownProps,
+    ITwinPropertySearchDropdownProps & React.RefAttributes<PropertyValueHandle>,
     ITwinPropertySearchDropdownStyleProps,
     ITwinPropertySearchDropdownStyles
->(TwinPropertySearchDropdown, getStyles);
+>(forwardRef(TwinPropertySearchDropdown), getStyles);

--- a/src/Components/TwinPropertySearchDropdown/TwinPropertySearchDropdown.types.ts
+++ b/src/Components/TwinPropertySearchDropdown/TwinPropertySearchDropdown.types.ts
@@ -11,7 +11,7 @@ import MockAdapter from '../../Adapters/MockAdapter';
 import { ITooltipCalloutContent } from '../TooltipCallout/TooltipCallout.types';
 
 export type PropertyValueHandle = {
-    updateValue: (newValue: string) => void;
+    setValue: (newValue: string) => void;
 };
 
 export interface IReactSelectOption {

--- a/src/Components/TwinPropertySearchDropdown/TwinPropertySearchDropdown.types.ts
+++ b/src/Components/TwinPropertySearchDropdown/TwinPropertySearchDropdown.types.ts
@@ -10,6 +10,10 @@ import ADTAdapter from '../../Adapters/ADTAdapter';
 import MockAdapter from '../../Adapters/MockAdapter';
 import { ITooltipCalloutContent } from '../TooltipCallout/TooltipCallout.types';
 
+export type PropertyValueHandle = {
+    updateValue: (newValue: string) => void;
+};
+
 export interface IReactSelectOption {
     value: string;
     label: string;

--- a/src/Models/Services/StoryUtilities.tsx
+++ b/src/Models/Services/StoryUtilities.tsx
@@ -132,7 +132,14 @@ export const selectReactSelectOption = (
     fireEvent.mouseDown(
         document.getElementsByClassName(`${className}__control`)[0]
     );
-    fireEvent.click(
-        document.getElementsByClassName(`${className}__option`)[optionIndex]
+    // Wait for callout to pop-up
+    setTimeout(
+        () =>
+            fireEvent.click(
+                document.getElementsByClassName(`${className}__option`)[
+                    optionIndex
+                ]
+            ),
+        1000
     );
 };

--- a/src/Models/Services/StoryUtilities.tsx
+++ b/src/Models/Services/StoryUtilities.tsx
@@ -124,7 +124,7 @@ export const clickOverFlowMenuItem = async (element: HTMLElement) => {
  * @param optionIndex index of the option we are selecting.
  * @returns
  */
-export const selectReactSelectOption = (
+export const selectReactSelectOption = async (
     className: string,
     optionIndex: number
 ) => {
@@ -133,13 +133,8 @@ export const selectReactSelectOption = (
         document.getElementsByClassName(`${className}__control`)[0]
     );
     // Wait for callout to pop-up
-    setTimeout(
-        () =>
-            fireEvent.click(
-                document.getElementsByClassName(`${className}__option`)[
-                    optionIndex
-                ]
-            ),
-        1000
+    await sleep(1);
+    fireEvent.click(
+        document.getElementsByClassName(`${className}__option`)[optionIndex]
     );
 };

--- a/src/Resources/Locales/cs.json
+++ b/src/Resources/Locales/cs.json
@@ -412,7 +412,6 @@
     "Done": "Hotový",
     "edit": "Upravit {{elementDisplayName}}",
     "editBehavior": "Chování úprav",
-    "searchTwinId": "Hledat ID dvojčete ($dtId)...",
     "noTwinsFound": "Nebyla nalezena žádná dvojčata (při hledání se rozlišují malá a velká písmena)",
     "useNonExistingTwinId": "Žádná přesná shoda, použijte",
     "addBehaviorToScene": "Přidání chování do scény",
@@ -545,7 +544,8 @@
     "transform": {
       "position": "Postavení",
       "rotation": "Rotace"
-    }
+    },
+    "searchTwinIdPlaceholder": "Hledat ID dvojčete ($dtId)"
   },
   "widgets": {
     "trend": {

--- a/src/Resources/Locales/de.json
+++ b/src/Resources/Locales/de.json
@@ -412,7 +412,6 @@
     "Done": "Fertig",
     "edit": "{{elementDisplayName}} bearbeiten",
     "editBehavior": "Verhalten bearbeiten",
-    "searchTwinId": "Twin ID ($dtId) suchen...",
     "noTwinsFound": "Keine Zwillinge gefunden (bei der Suche wird zwischen Groß- und Kleinschreibung unterschieden)",
     "useNonExistingTwinId": "Keine exakte Übereinstimmung, Verwendung",
     "addBehaviorToScene": "Verhalten zur Szene hinzufügen",
@@ -545,7 +544,8 @@
     "transform": {
       "position": "Position",
       "rotation": "Drehung"
-    }
+    },
+    "searchTwinIdPlaceholder": "Twin ID ($dtId) suchen"
   },
   "widgets": {
     "trend": {

--- a/src/Resources/Locales/en.json
+++ b/src/Resources/Locales/en.json
@@ -417,7 +417,7 @@
         "Done": "Done",
         "edit": "Edit {{elementDisplayName}}",
         "editBehavior": "Edit behavior",
-        "searchTwinId": "Search Twin ID ($dtId)...",
+        "searchTwinIdPlaceholder": "Search Twin ID ($dtId)",
         "noTwinsFound": "No twins found (search is case sensitive)",
         "useNonExistingTwinId": "No exact match, use",
         "addBehaviorToScene": "Add behavior to scene",

--- a/src/Resources/Locales/es.json
+++ b/src/Resources/Locales/es.json
@@ -412,7 +412,6 @@
     "Done": "Hecho",
     "edit": "Editar {{elementDisplayName}}",
     "editBehavior": "Editar comportamiento",
-    "searchTwinId": "Buscar Twin ID ($dtId)...",
     "noTwinsFound": "No se han encontrado gemelos (la búsqueda distingue entre mayúsculas y minúsculas)",
     "useNonExistingTwinId": "No hay coincidencia exacta, use",
     "addBehaviorToScene": "Agregar comportamiento a la escena",
@@ -545,7 +544,8 @@
     "transform": {
       "position": "Posición",
       "rotation": "Rotación"
-    }
+    },
+    "searchTwinIdPlaceholder": "Buscar Twin ID ($dtId)"
   },
   "widgets": {
     "trend": {

--- a/src/Resources/Locales/fr.json
+++ b/src/Resources/Locales/fr.json
@@ -412,7 +412,6 @@
     "Done": "Fait",
     "edit": "Modifier {{elementDisplayName}}",
     "editBehavior": "Modifier le comportement",
-    "searchTwinId": "Rechercher Twin ID ($dtId)...",
     "noTwinsFound": "Aucun jumeau trouvé (la recherche est sensible à la casse)",
     "useNonExistingTwinId": "Pas de correspondance exacte, utilisez",
     "addBehaviorToScene": "Ajouter un comportement à la scène",
@@ -545,7 +544,8 @@
     "transform": {
       "position": "Position",
       "rotation": "Rotation"
-    }
+    },
+    "searchTwinIdPlaceholder": "Rechercher Twin ID ($dtId)"
   },
   "widgets": {
     "trend": {

--- a/src/Resources/Locales/hu.json
+++ b/src/Resources/Locales/hu.json
@@ -412,7 +412,6 @@
     "Done": "Kész",
     "edit": "{{elementDisplayName}} szerkesztése",
     "editBehavior": "Viselkedés szerkesztése",
-    "searchTwinId": "Keresés Twin ID ($dtId)...",
     "noTwinsFound": "Nem található ikerpár (a keresés megkülönbözteti a kis- és nagybetűket)",
     "useNonExistingTwinId": "Nincs pontos egyezés, használat",
     "addBehaviorToScene": "Viselkedés hozzáadása a jelenethez",
@@ -545,7 +544,8 @@
     "transform": {
       "position": "Pozíció",
       "rotation": "Forgás"
-    }
+    },
+    "searchTwinIdPlaceholder": "Keresés ikerazonosítóban ($dtId)"
   },
   "widgets": {
     "trend": {

--- a/src/Resources/Locales/it.json
+++ b/src/Resources/Locales/it.json
@@ -412,7 +412,6 @@
     "Done": "Fatto",
     "edit": "Modifica {{elementDisplayName}}",
     "editBehavior": "Modificare il comportamento",
-    "searchTwinId": "Cerca Twin ID ($dtId)...",
     "noTwinsFound": "Nessun gemello trovato (la ricerca fa distinzione tra maiuscole e minuscole)",
     "useNonExistingTwinId": "Nessuna corrispondenza esatta, uso",
     "addBehaviorToScene": "Aggiungere un comportamento alla scena",
@@ -545,7 +544,8 @@
     "transform": {
       "position": "Posizione",
       "rotation": "Rotazione"
-    }
+    },
+    "searchTwinIdPlaceholder": "Cerca Twin ID ($dtId)"
   },
   "widgets": {
     "trend": {

--- a/src/Resources/Locales/ja.json
+++ b/src/Resources/Locales/ja.json
@@ -412,7 +412,6 @@
     "Done": "完成です",
     "edit": "{{elementDisplayName}} を編集",
     "editBehavior": "動作の編集",
-    "searchTwinId": "検索ツイン ID ($dtId)...",
     "noTwinsFound": "双子が見つかりません (検索では大文字と小文字が区別されます)",
     "useNonExistingTwinId": "完全に一致しない、使用",
     "addBehaviorToScene": "シーンにビヘイビアを追加する",
@@ -545,7 +544,8 @@
     "transform": {
       "position": "立場",
       "rotation": "自転"
-    }
+    },
+    "searchTwinIdPlaceholder": "検索ツイン ID ($dtId)"
   },
   "widgets": {
     "trend": {

--- a/src/Resources/Locales/ko.json
+++ b/src/Resources/Locales/ko.json
@@ -412,7 +412,6 @@
     "Done": "수행",
     "edit": "편집 {{elementDisplayName}}",
     "editBehavior": "동작 편집",
-    "searchTwinId": "트윈 ID ($dtId)를 검색 ...",
     "noTwinsFound": "쌍둥이를 찾을 수 없음(검색은 대/소문자를 구분함)",
     "useNonExistingTwinId": "정확한 일치가 없으므로 사용하십시오.",
     "addBehaviorToScene": "장면에 동작 추가",
@@ -545,7 +544,8 @@
     "transform": {
       "position": "위치",
       "rotation": "회전"
-    }
+    },
+    "searchTwinIdPlaceholder": "트윈 ID ($dtId) 검색"
   },
   "widgets": {
     "trend": {

--- a/src/Resources/Locales/nl.json
+++ b/src/Resources/Locales/nl.json
@@ -412,7 +412,6 @@
     "Done": "Klaar",
     "edit": "Bewerken {{elementDisplayName}}",
     "editBehavior": "Gedrag bewerken",
-    "searchTwinId": "Zoek Twin ID ($dtId)...",
     "noTwinsFound": "Geen tweeling gevonden (zoeken is hoofdlettergevoelig)",
     "useNonExistingTwinId": "Geen exacte overeenkomst, gebruik",
     "addBehaviorToScene": "Gedrag toevoegen aan scène",
@@ -545,7 +544,8 @@
     "transform": {
       "position": "Positie",
       "rotation": "Rotatie"
-    }
+    },
+    "searchTwinIdPlaceholder": "Twin ID zoeken ($dtId)"
   },
   "widgets": {
     "trend": {

--- a/src/Resources/Locales/pl.json
+++ b/src/Resources/Locales/pl.json
@@ -412,7 +412,6 @@
     "Done": "Gotowy",
     "edit": "Edytuj {{elementDisplayName}}",
     "editBehavior": "Edytuj zachowanie",
-    "searchTwinId": "Szukaj Twin ID ($dtId)...",
     "noTwinsFound": "Nie znaleziono bliźniąt (w wyszukiwaniu rozróżniana jest wielkość liter)",
     "useNonExistingTwinId": "Brak dokładnego dopasowania, użyj",
     "addBehaviorToScene": "Dodawanie zachowania do sceny",
@@ -545,7 +544,8 @@
     "transform": {
       "position": "Pozycja",
       "rotation": "Obrót"
-    }
+    },
+    "searchTwinIdPlaceholder": "Szukaj Twin ID ($dtId)"
   },
   "widgets": {
     "trend": {

--- a/src/Resources/Locales/pt-pt.json
+++ b/src/Resources/Locales/pt-pt.json
@@ -412,7 +412,6 @@
     "Done": "Feito",
     "edit": "Editar {{elementDisplayName}}",
     "editBehavior": "Editar comportamento",
-    "searchTwinId": "Pesquisar Twin ID ($dtId)...",
     "noTwinsFound": "Não foram encontrados gémeos (a procura é sensível ao caso)",
     "useNonExistingTwinId": "Sem correspondência exata, use",
     "addBehaviorToScene": "Adicionar comportamento à cena",
@@ -545,7 +544,8 @@
     "transform": {
       "position": "Posição",
       "rotation": "Rotação"
-    }
+    },
+    "searchTwinIdPlaceholder": "Pesquisar Twin ID ($dtId)"
   },
   "widgets": {
     "trend": {

--- a/src/Resources/Locales/pt.json
+++ b/src/Resources/Locales/pt.json
@@ -412,7 +412,6 @@
     "Done": "Terminado",
     "edit": "Editar {{elementDisplayName}}",
     "editBehavior": "Editar comportamento",
-    "searchTwinId": "Pesquisar twin id ($dtId)...",
     "noTwinsFound": "Nenhum gêmeo encontrado (a busca é sensível ao caso)",
     "useNonExistingTwinId": "Sem correspondência exata, use",
     "addBehaviorToScene": "Adicionar comportamento à cena",
@@ -545,7 +544,8 @@
     "transform": {
       "position": "Posição",
       "rotation": "Rotação"
-    }
+    },
+    "searchTwinIdPlaceholder": "Pesquisar iD duplo ($dtId)"
   },
   "widgets": {
     "trend": {

--- a/src/Resources/Locales/ru.json
+++ b/src/Resources/Locales/ru.json
@@ -412,7 +412,6 @@
     "Done": "Договорились",
     "edit": "Редактировать {{elementDisplayName}}",
     "editBehavior": "Редактирование поведения",
-    "searchTwinId": "Поиск Twin ID ($dtId)...",
     "noTwinsFound": "Близнецы не найдены (поиск чувствителен к регистру)",
     "useNonExistingTwinId": "Нет точного соответствия, используйте",
     "addBehaviorToScene": "Добавление поведения в сцену",
@@ -545,7 +544,8 @@
     "transform": {
       "position": "Позиция",
       "rotation": "Вращение"
-    }
+    },
+    "searchTwinIdPlaceholder": "Поиск Твин ID ($dtId)"
   },
   "widgets": {
     "trend": {

--- a/src/Resources/Locales/sv.json
+++ b/src/Resources/Locales/sv.json
@@ -412,7 +412,6 @@
     "Done": "Färdig",
     "edit": "Redigera {{elementDisplayName}}",
     "editBehavior": "Redigera beteende",
-    "searchTwinId": "Sök efter tvilling-ID ($dtId)...",
     "noTwinsFound": "Inga tvillingar hittades (sökningen är skiftlägeskänslig)",
     "useNonExistingTwinId": "Ingen exakt matchning, använd",
     "addBehaviorToScene": "Lägg till beteende i scenen",
@@ -545,7 +544,8 @@
     "transform": {
       "position": "Position",
       "rotation": "Rotation"
-    }
+    },
+    "searchTwinIdPlaceholder": "Sök tvilling-ID ($dtId)"
   },
   "widgets": {
     "trend": {

--- a/src/Resources/Locales/tr.json
+++ b/src/Resources/Locales/tr.json
@@ -412,7 +412,6 @@
     "Done": "Yapılmış",
     "edit": "Düzenle {{elementDisplayName}}",
     "editBehavior": "Düzenleme davranışı",
-    "searchTwinId": "Arama İkiz Kimlik ($dtId)...",
     "noTwinsFound": "İkiz bulunamadı (arama büyük/küçük harfe duyarlıdır)",
     "useNonExistingTwinId": "Tam eşleşme yok, kullanın",
     "addBehaviorToScene": "Sahneye davranış ekleme",
@@ -545,7 +544,8 @@
     "transform": {
       "position": "Konum",
       "rotation": "Rotasyon"
-    }
+    },
+    "searchTwinIdPlaceholder": "Arama İkiz Kimliği ($dtId)"
   },
   "widgets": {
     "trend": {

--- a/src/Resources/Locales/zh-Hans.json
+++ b/src/Resources/Locales/zh-Hans.json
@@ -412,7 +412,6 @@
     "Done": "做",
     "edit": "Edit {{elementDisplayName}}",
     "editBehavior": "编辑行为",
-    "searchTwinId": "正在搜索孪生 ID （$dtId）...",
     "noTwinsFound": "未找到双胞胎（搜索区分大小写）",
     "useNonExistingTwinId": "不完全匹配，使用",
     "addBehaviorToScene": "向场景添加行为",
@@ -545,7 +544,8 @@
     "transform": {
       "position": "位置",
       "rotation": "旋转"
-    }
+    },
+    "searchTwinIdPlaceholder": "搜索双胞胎 ID （$dtId）"
   },
   "widgets": {
     "trend": {


### PR DESCRIPTION
### Summary of changes 🔍 
This PR integrates Advanced Search functionality with the Element form. This new feature allows the users to select a Primary twin after building a query to search for it. Previously the Element form only allowed users to select a Twin by searching for its `$dtId`, now both `$dtId` and advanced search are enabled.

Also included in this PR a button was added to the Element form to show a callout containing the `PropertyInspector`. The `PropertyInspector` component here will allow users to know which properties are part of the selected Twin in case they want to search for another Twin of the same model. 

### Testing 🧪
PropertyInspector:
- Navigate to Element form
- If a Twin is selected: (else select Twin from list)
  - Click the first icon besides the Primary Twin dropdown.
  - Make sure properties are correct for the selected Twin model

Advanced search:
- Navigate to Element form
- Click the second icon besides the Primary Twin dropdown
- Create a query to search for Twins, in Mock data any Operator other than Equals will return all available data
  - An example of an Equals operation that will yield some filtered values is: 
![image](https://user-images.githubusercontent.com/55852250/189770490-d7899dbf-720c-40f4-b272-2172d39cd248.png)

- Select a twin from the list
- Click on the `Select` button in the modal
- Review:
  - If dropdown changed to selected twin
  - If Property inspector shows correct twin data
  - If saving the form persists data


### Checklist ✔️
- [x] Linked associated issue (if present)
- [x] Added relevant labels
- [x] Requested developer reviews
- [ ] Request UI review from design / PM
- [ ] Verify all code checks are passing