### PR TITLE
Fix null reference in environment picker

### DIFF
--- a/src/Components/EnvironmentPicker/EnvironmentPicker.tsx
+++ b/src/Components/EnvironmentPicker/EnvironmentPicker.tsx
@@ -133,7 +133,7 @@ const EnvironmentPicker = ({
 
     // set initial values based on props and local storage
     useEffect(() => {
-        let environmentUrls = [];
+        let environmentUrls: string[] = [];
         if (environmentUrl) {
             // passed environmentUrl has precedence over the selected environment in localstorage, if enabled
             environmentUrls = [environmentUrl];
@@ -166,7 +166,7 @@ const EnvironmentPicker = ({
             }
         });
 
-        let containerUrls: Array<string>;
+        let containerUrls: Array<string> = [];
         if (storage?.containerUrl) {
             containerUrls = [storage.containerUrl];
         }


### PR DESCRIPTION
### Summary of changes 🔍 
Fixing a null reference when a new user comes to the site and the environment URL is not in storage already.

![image](https://user-images.githubusercontent.com/57726991/189993971-0fcf70ac-c311-4197-b138-bf7590893a79.png)

![image](https://user-images.githubusercontent.com/57726991/189994027-6b8d20c5-020d-45a6-817a-825a27c351af.png)


### Testing 🧪
 > [ Add any special instructions needed to test or view your changes such as environment URLs or other config details. ]

### Checklist ✔️
- [ ] Linked associated issue (if present)
- [ ] Added relevant labels
- [ ] Requested developer reviews
- [ ] Request UI review from design / PM
- [ ] Verify all code checks are passing