### PR TITLE
Bug Fix: Overflow tabs cause react error

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,7 +21,7 @@
         "@typescript-eslint/no-var-requires": 0,
         "@typescript-eslint/no-explicit-any": 0,
         "@typescript-eslint/no-unused-vars": [
-            "warn",
+            "error",
             {
                 "argsIgnorePattern": "^_"
             }

--- a/src/Components/ADT3DSceneBuilder/Internal/Behaviors/BehaviorsForm.tsx
+++ b/src/Components/ADT3DSceneBuilder/Internal/Behaviors/BehaviorsForm.tsx
@@ -467,6 +467,7 @@ const SceneBehaviorsForm: React.FC<IADT3DSceneBuilderBehaviorFormProps> = ({
                                         behaviorState.validityMap?.get(
                                             'Elements'
                                         )?.isValid,
+                                        t,
                                         props,
                                         defaultRenderer
                                     )
@@ -492,6 +493,7 @@ const SceneBehaviorsForm: React.FC<IADT3DSceneBuilderBehaviorFormProps> = ({
                                     setPivotToRequired(
                                         behaviorState.validityMap?.get('Twins')
                                             ?.isValid,
+                                        t,
                                         props,
                                         defaultRenderer
                                     )
@@ -511,6 +513,7 @@ const SceneBehaviorsForm: React.FC<IADT3DSceneBuilderBehaviorFormProps> = ({
                                     setPivotToRequired(
                                         behaviorState.validityMap?.get('Status')
                                             ?.isValid,
+                                        t,
                                         props,
                                         defaultRenderer
                                     )
@@ -528,6 +531,7 @@ const SceneBehaviorsForm: React.FC<IADT3DSceneBuilderBehaviorFormProps> = ({
                                     setPivotToRequired(
                                         behaviorState.validityMap?.get('Alerts')
                                             ?.isValid,
+                                        t,
                                         props,
                                         defaultRenderer
                                     )
@@ -544,6 +548,7 @@ const SceneBehaviorsForm: React.FC<IADT3DSceneBuilderBehaviorFormProps> = ({
                                         behaviorState.validityMap?.get(
                                             'Widgets'
                                         )?.isValid,
+                                        t,
                                         props,
                                         defaultRenderer
                                     )

--- a/src/Components/ADT3DSceneBuilder/Internal/Elements/ElementForm.tsx
+++ b/src/Components/ADT3DSceneBuilder/Internal/Elements/ElementForm.tsx
@@ -408,6 +408,7 @@ const SceneElementForm: React.FC<IADT3DSceneBuilderElementFormProps> = ({
                                 onRenderItemLink={(props, defaultRenderer) =>
                                     setPivotToRequired(
                                         coloredMeshItems.length > 0,
+                                        t,
                                         props,
                                         defaultRenderer
                                     )

--- a/src/Components/OATHeader/internal/FormOpen.tsx
+++ b/src/Components/OATHeader/internal/FormOpen.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useEffect } from 'react';
+import React, { useState, useMemo } from 'react';
 import {
     Text,
     ActionButton,

--- a/src/Theming/FluentComponentStyles/Pivot.styles.tsx
+++ b/src/Theming/FluentComponentStyles/Pivot.styles.tsx
@@ -3,7 +3,7 @@ import { Theme } from '../../Models/Constants/Enums';
 import { IStyle, mergeStyleSets } from '@fluentui/react';
 import { IPivotItemProps } from '@fluentui/react';
 import React from 'react';
-import { useTranslation } from 'react-i18next';
+import { TFunction } from 'react-i18next';
 
 export const getPivotStyles = (
     _themeSetting: Theme,
@@ -49,10 +49,10 @@ export const customPivotItemStyles = mergeStyleSets({
 
 export function setPivotToRequired(
     isValid: boolean | undefined,
+    t: TFunction<string>,
     link?: IPivotItemProps,
     defaultRenderer?: (link?: IPivotItemProps) => JSX.Element | null
 ): JSX.Element | null {
-    const { t } = useTranslation();
     if (!link || !defaultRenderer) {
         return null;
     }


### PR DESCRIPTION
### Summary of changes 🔍 
The tabs overflow menu was throwing a react error anytime it was opened. This only showed up in other languages so it wasn't caught internally. 
The issue was that the custom rendering function on each tab item was calling a hook and since it got pushed inside the overflow set it changed the hook execution and broke the React rules for hooks always executing in the same order.

Original bug
![react error](https://user-images.githubusercontent.com/57726991/191850312-e5f516be-2ae1-4f1e-ba83-f0455ec88a9e.gif)

Fixed
![fixed](https://user-images.githubusercontent.com/57726991/191851240-ad010f87-519e-4908-95a7-c4cef1c40f0a.gif)

### Testing 🧪
- [x] Switch your language to something that causes the behavior form tabs to overflow. Then go to the behavior form. Click the overflow set and use the app as normal. It used to crash

### Checklist ✔️
- [ ] Linked associated issue (if present)
- [ ] Added relevant labels
- [ ] Requested developer reviews
- [ ] Request UI review from design / PM
- [ ] Verify all code checks are passing