### PR TITLE
Creating a generic modal component

### DIFF
--- a/src/Components/AdvancedSearch/AdvancedSearch.styles.ts
+++ b/src/Components/AdvancedSearch/AdvancedSearch.styles.ts
@@ -1,58 +1,14 @@
-import { FontSizes, FontWeights } from '@fluentui/react';
+import { FontSizes } from '@fluentui/react';
 import {
     IAdvancedSearchStyleProps,
     IAdvancedSearchStyles
 } from './AdvancedSearch.types';
 
-export const classPrefix = 'cb-advancedsearch';
-const classNames = {
-    content: `${classPrefix}-content`,
-    footer: `${classPrefix}-footer`,
-    headerContainer: `${classPrefix}-headerContainer`,
-    subtitle: `${classPrefix}-subtitle`,
-    title: `${classPrefix}-title`,
-    titleContainer: `${classPrefix}-titleContainer`
-};
-
 export const getStyles = (
     _props: IAdvancedSearchStyleProps
 ): IAdvancedSearchStyles => {
     return {
-        content: [
-            classNames.content,
-            {
-                height: '100%'
-            }
-        ],
-        footer: [classNames.footer],
-        headerContainer: [classNames.headerContainer],
-        title: [
-            classNames.title,
-            {
-                margin: 0,
-                fontSize: FontSizes.size24,
-                fontWeight: FontWeights.semibold
-            }
-        ],
-        titleContainer: [
-            classNames.titleContainer,
-            {
-                display: 'flex',
-                paddingBottom: 8
-            }
-        ],
-        subtitle: [classNames.subtitle],
         subComponentStyles: {
-            modal: {
-                main: {
-                    height: 690,
-                    width: 940,
-                    padding: 20
-                },
-                scrollableContent: {
-                    height: '100%'
-                }
-            },
             icon: {
                 root: {
                     textAlign: 'center',

--- a/src/Components/AdvancedSearch/AdvancedSearch.tsx
+++ b/src/Components/AdvancedSearch/AdvancedSearch.tsx
@@ -144,12 +144,12 @@ const AdvancedSearch: React.FC<IAdvancedSearchProps> = (props) => {
                         horizontal={true}
                         horizontalAlign={'end'}
                     >
+                        <DefaultButton text={t('cancel')} onClick={onDismiss} />
                         <PrimaryButton
                             text={t('select')}
                             disabled={!selectedTwinId.length}
                             onClick={onConfirmSelection}
                         />
-                        <DefaultButton text={t('cancel')} onClick={onDismiss} />
                     </Stack>
                 </div>
             </Stack>

--- a/src/Components/AdvancedSearch/AdvancedSearch.tsx
+++ b/src/Components/AdvancedSearch/AdvancedSearch.tsx
@@ -9,14 +9,8 @@ import {
     classNamesFunction,
     useTheme,
     styled,
-    Modal,
-    Icon,
-    Stack,
-    IStackTokens,
-    PrimaryButton,
-    DefaultButton
+    IStackTokens
 } from '@fluentui/react';
-import { useId } from '@fluentui/react-hooks';
 import QueryBuilder from './Internal/QueryBuilder/QueryBuilder';
 import AdvancedSearchResultDetailsList from './Internal/AdvancedSearchResultDetailsList/AdvancedSearchResultDetailsList';
 import {
@@ -25,6 +19,7 @@ import {
 } from '../../Models/Constants';
 import { useTranslation } from 'react-i18next';
 import { useAdapter } from '../../Models/Hooks';
+import CardboardModal from '../CardboardModal/CardboardModal';
 
 const getClassNames = classNamesFunction<
     IAdvancedSearchStyleProps,
@@ -32,11 +27,9 @@ const getClassNames = classNamesFunction<
 >();
 
 const CONTENT_MAX_HEIGHT = 515;
-const containerStackTokens: IStackTokens = { childrenGap: 8 };
 const contentStackTokens: IStackTokens = {
     maxHeight: CONTENT_MAX_HEIGHT
 };
-const footerStackTokens: IStackTokens = { childrenGap: 8 };
 
 const AdvancedSearch: React.FC<IAdvancedSearchProps> = (props) => {
     const {
@@ -51,7 +44,6 @@ const AdvancedSearch: React.FC<IAdvancedSearchProps> = (props) => {
         theme: useTheme()
     });
     const { t } = useTranslation();
-    const titleId = useId('advanced-search-modal-title');
     const filteredTwins = useRef<IADTTwin[]>([]);
     const additionalProperties = useRef(new Set<string>());
     const searchForTwinAdapterData = useAdapter({
@@ -90,70 +82,43 @@ const AdvancedSearch: React.FC<IAdvancedSearchProps> = (props) => {
     }, [selectedTwinId]);
 
     return (
-        <Modal
-            isOpen={isOpen}
-            onDismiss={onDismiss}
-            titleAriaId={titleId}
-            styles={classNames.subComponentStyles.modal}
-            layerProps={{ eventBubblingEnabled: true }}
-        >
-            <Stack tokens={containerStackTokens} style={{ height: '100%' }}>
-                <div className={classNames.headerContainer}>
-                    <div className={classNames.titleContainer}>
-                        <Icon
-                            iconName={'search'}
-                            styles={classNames.subComponentStyles.icon}
-                        />
-                        <h3 id={titleId} className={classNames.title}>
-                            {t('advancedSearch.modalTitle')}
-                        </h3>
-                    </div>
-                    <p className={classNames.subtitle}>
-                        {t('advancedSearch.modalSubtitle')}
-                    </p>
-                </div>
-                <div className={classNames.content}>
-                    <Stack tokens={contentStackTokens}>
-                        <QueryBuilder
-                            adapter={adapter}
-                            allowedPropertyValueTypes={
-                                allowedPropertyValueTypes
-                            }
-                            executeQuery={executeQuery}
-                            updateColumns={updateColumns}
-                        />
-                        <AdvancedSearchResultDetailsList
-                            adapter={adapter}
-                            isLoading={searchForTwinAdapterData.isLoading}
-                            containsError={searchForTwinAdapterData.adapterResult.hasError()}
-                            onTwinIdSelect={updateSelectedTwinId}
-                            searchedProperties={Array.from(
-                                additionalProperties.current
-                            )}
-                            twins={filteredTwins.current}
-                            styles={
-                                classNames.subComponentStyles
-                                    .advancedSearchDetailsList
-                            }
-                        />
-                    </Stack>
-                </div>
-                <div className={classNames.footer}>
-                    <Stack
-                        tokens={footerStackTokens}
-                        horizontal={true}
-                        horizontalAlign={'end'}
-                    >
-                        <DefaultButton text={t('cancel')} onClick={onDismiss} />
-                        <PrimaryButton
-                            text={t('select')}
-                            disabled={!selectedTwinId.length}
-                            onClick={onConfirmSelection}
-                        />
-                    </Stack>
-                </div>
-            </Stack>
-        </Modal>
+        <>
+            <CardboardModal
+                isOpen={isOpen}
+                contentStackProps={{ tokens: contentStackTokens }}
+                onDismiss={onDismiss}
+                title={t('advancedSearch.modalTitle')}
+                titleIconName={'Search'}
+                subTitle={t('advancedSearch.modalSubtitle')}
+                modalProps={{ layerProps: { eventBubblingEnabled: true } }}
+                primaryButtonProps={{
+                    text: t('select'),
+                    disabled: !selectedTwinId.length,
+                    onClick: onConfirmSelection
+                }}
+                styles={classNames.subComponentStyles.modal}
+            >
+                <QueryBuilder
+                    adapter={adapter}
+                    allowedPropertyValueTypes={allowedPropertyValueTypes}
+                    executeQuery={executeQuery}
+                    updateColumns={updateColumns}
+                />
+                <AdvancedSearchResultDetailsList
+                    adapter={adapter}
+                    isLoading={searchForTwinAdapterData.isLoading}
+                    containsError={searchForTwinAdapterData.adapterResult.hasError()}
+                    onTwinIdSelect={updateSelectedTwinId}
+                    searchedProperties={Array.from(
+                        additionalProperties.current
+                    )}
+                    twins={filteredTwins.current}
+                    styles={
+                        classNames.subComponentStyles.advancedSearchDetailsList
+                    }
+                />
+            </CardboardModal>
+        </>
     );
 };
 

--- a/src/Components/AdvancedSearch/AdvancedSearch.tsx
+++ b/src/Components/AdvancedSearch/AdvancedSearch.tsx
@@ -84,19 +84,19 @@ const AdvancedSearch: React.FC<IAdvancedSearchProps> = (props) => {
     return (
         <>
             <CardboardModal
-                isOpen={isOpen}
                 contentStackProps={{ tokens: contentStackTokens }}
-                onDismiss={onDismiss}
-                title={t('advancedSearch.modalTitle')}
-                titleIconName={'Search'}
-                subTitle={t('advancedSearch.modalSubtitle')}
+                isOpen={isOpen}
                 modalProps={{ layerProps: { eventBubblingEnabled: true } }}
+                onDismiss={onDismiss}
                 primaryButtonProps={{
                     text: t('select'),
                     disabled: !selectedTwinId.length,
                     onClick: onConfirmSelection
                 }}
+                subTitle={t('advancedSearch.modalSubtitle')}
                 styles={classNames.subComponentStyles.modal}
+                title={t('advancedSearch.modalTitle')}
+                titleIconName={'Search'}
             >
                 <QueryBuilder
                     adapter={adapter}

--- a/src/Components/AdvancedSearch/AdvancedSearch.tsx
+++ b/src/Components/AdvancedSearch/AdvancedSearch.tsx
@@ -88,7 +88,7 @@ const AdvancedSearch: React.FC<IAdvancedSearchProps> = (props) => {
                 isOpen={isOpen}
                 modalProps={{ layerProps: { eventBubblingEnabled: true } }}
                 onDismiss={onDismiss}
-                primaryButtonProps={{
+                footerPrimaryButtonProps={{
                     text: t('select'),
                     disabled: !selectedTwinId.length,
                     onClick: onConfirmSelection

--- a/src/Components/AdvancedSearch/AdvancedSearch.types.ts
+++ b/src/Components/AdvancedSearch/AdvancedSearch.types.ts
@@ -1,12 +1,12 @@
 import {
     IIconStyles,
-    IModalStyles,
     IStyle,
     IStyleFunctionOrObject,
     ITheme
 } from '@fluentui/react';
 import { ADTAdapter, MockAdapter } from '../../Adapters';
 import { PropertyValueType } from '../../Models/Constants';
+import { ICardboardModalStyles } from '../CardboardModal/CardboardModal.types';
 import { IAdvancedSearchResultDetailsListStyles } from './Internal/AdvancedSearchResultDetailsList/AdvancedSearchResultDetailsList.types';
 
 export const QUERY_RESULT_LIMIT = 1000;
@@ -44,7 +44,7 @@ export interface IAdvancedSearchStyles {
 }
 
 export interface IAdvancedSearchSubComponentStyles {
-    modal?: Partial<IModalStyles>;
+    modal?: ICardboardModalStyles;
     icon?: IIconStyles;
     advancedSearchDetailsList?: Partial<IAdvancedSearchResultDetailsListStyles>;
 }

--- a/src/Components/AdvancedSearch/AdvancedSearch.types.ts
+++ b/src/Components/AdvancedSearch/AdvancedSearch.types.ts
@@ -1,9 +1,4 @@
-import {
-    IIconStyles,
-    IStyle,
-    IStyleFunctionOrObject,
-    ITheme
-} from '@fluentui/react';
+import { IIconStyles, IStyleFunctionOrObject, ITheme } from '@fluentui/react';
 import { ADTAdapter, MockAdapter } from '../../Adapters';
 import { PropertyValueType } from '../../Models/Constants';
 import { ICardboardModalStyles } from '../CardboardModal/CardboardModal.types';
@@ -31,12 +26,6 @@ export interface IAdvancedSearchStyleProps {
     theme: ITheme;
 }
 export interface IAdvancedSearchStyles {
-    content: IStyle;
-    footer: IStyle;
-    headerContainer: IStyle;
-    title: IStyle;
-    titleContainer: IStyle;
-    subtitle: IStyle;
     /**
      * SubComponent styles.
      */

--- a/src/Components/CardboardModal/CardboardModal.stories.tsx
+++ b/src/Components/CardboardModal/CardboardModal.stories.tsx
@@ -43,7 +43,7 @@ export const Base = Template.bind({}) as CardboardModalStory;
 Base.args = {
     isOpen: true,
     onDismiss: () => alert('closed'),
-    primaryButtonProps: {
+    footerPrimaryButtonProps: {
         text: 'Submit',
         onClick: () => alert('clicked')
     },
@@ -55,7 +55,7 @@ export const WithIcon = Template.bind({}) as CardboardModalStory;
 WithIcon.args = {
     isOpen: true,
     onDismiss: () => alert('closed'),
-    primaryButtonProps: {
+    footerPrimaryButtonProps: {
         text: 'Submit',
         onClick: () => alert('clicked')
     },
@@ -66,7 +66,7 @@ WithIcon.args = {
 
 export const WithDestructive = Template.bind({}) as CardboardModalStory;
 WithDestructive.args = {
-    dangerButtonProps: {
+    footerDangerButtonProps: {
         text: 'Destroy',
         onClick: () => {
             'destroy';
@@ -74,7 +74,23 @@ WithDestructive.args = {
     },
     isOpen: true,
     onDismiss: () => alert('closed'),
-    primaryButtonProps: {
+    footerPrimaryButtonProps: {
+        text: 'Submit',
+        onClick: () => alert('clicked')
+    },
+    title: 'Header',
+    subTitle: 'Sub title'
+} as ICardboardModalProps;
+
+export const WithFooterLink = Template.bind({}) as CardboardModalStory;
+WithFooterLink.args = {
+    footerLinkProps: {
+        text: 'Documentation',
+        url: 'https://developer.microsoft.com/en-us/fluentui#/controls/web'
+    },
+    isOpen: true,
+    onDismiss: () => alert('closed'),
+    footerPrimaryButtonProps: {
         text: 'Submit',
         onClick: () => alert('clicked')
     },
@@ -86,7 +102,7 @@ export const WithCustomElements = Template.bind({}) as CardboardModalStory;
 WithCustomElements.args = {
     isOpen: true,
     onDismiss: () => alert('closed'),
-    primaryButtonProps: {
+    footerPrimaryButtonProps: {
         text: 'Submit',
         onClick: () => alert('clicked')
     },

--- a/src/Components/CardboardModal/CardboardModal.stories.tsx
+++ b/src/Components/CardboardModal/CardboardModal.stories.tsx
@@ -66,7 +66,7 @@ WithIcon.args = {
 
 export const WithDestructive = Template.bind({}) as CardboardModalStory;
 WithDestructive.args = {
-    destructiveButtonProps: {
+    dangerButtonProps: {
         text: 'Destroy',
         onClick: () => {
             'destroy';

--- a/src/Components/CardboardModal/CardboardModal.stories.tsx
+++ b/src/Components/CardboardModal/CardboardModal.stories.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { ComponentStory } from '@storybook/react';
+import { getDefaultStoryDecorator } from '../../Models/Services/StoryUtilities';
+import CardboardModal from './CardboardModal';
+import { ICardboardModalProps } from './CardboardModal.types';
+import { TextField } from '@fluentui/react';
+
+const wrapperStyle = { width: '100%', height: '600px', padding: 8 };
+
+export default {
+    title: 'Components/CardboardModal',
+    component: CardboardModal,
+    decorators: [getDefaultStoryDecorator<ICardboardModalProps>(wrapperStyle)]
+};
+
+type CardboardModalStory = ComponentStory<typeof CardboardModal>;
+
+const Template: CardboardModalStory = (args) => {
+    return (
+        <CardboardModal {...args}>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+            eiusmod tempor incididunt ut labore et dolore magna aliqua. Mauris
+            cursus mattis molestie a iaculis at erat pellentesque adipiscing.
+            Urna nec tincidunt praesent semper feugiat nibh sed. Viverra nibh
+            cras pulvinar mattis nunc sed blandit. Nullam non nisi est sit amet.
+            Dis parturient montes nascetur ridiculus mus mauris vitae ultricies.
+            Pretium lectus quam id leo in vitae. Dictum varius duis at
+            consectetur lorem donec. Amet massa vitae tortor condimentum lacinia
+            quis vel eros. Risus at ultrices mi tempus imperdiet nulla
+            malesuada.
+            <TextField label={'Field 1'} placeholder={'Field 1'} />
+            <TextField label={'Field 2'} placeholder={'Field 2'} />
+            <TextField label={'Field 3'} placeholder={'Field 3'} />
+            <TextField label={'Field 4'} placeholder={'Field 4'} />
+            <TextField label={'Field 5'} placeholder={'Field 5'} />
+            <TextField label={'Field 6'} placeholder={'Field 6'} />
+            <TextField label={'Field 7'} placeholder={'Field 7'} />
+        </CardboardModal>
+    );
+};
+
+export const Base = Template.bind({}) as CardboardModalStory;
+Base.args = {
+    isOpen: true,
+    onDismiss: () => alert('closed'),
+    primaryButtonProps: {
+        text: 'Submit',
+        onClick: () => alert('clicked')
+    },
+    title: 'Header',
+    subTitle: 'Sub title'
+} as ICardboardModalProps;
+
+export const WithIcon = Template.bind({}) as CardboardModalStory;
+WithIcon.args = {
+    isOpen: true,
+    onDismiss: () => alert('closed'),
+    primaryButtonProps: {
+        text: 'Submit',
+        onClick: () => alert('clicked')
+    },
+    title: 'Header',
+    titleIconName: 'CubeShape',
+    subTitle: 'Sub title'
+} as ICardboardModalProps;
+
+export const WithDestructive = Template.bind({}) as CardboardModalStory;
+WithDestructive.args = {
+    destructiveButtonProps: {
+        text: 'Destroy',
+        onClick: () => {
+            'destroy';
+        }
+    },
+    isOpen: true,
+    onDismiss: () => alert('closed'),
+    primaryButtonProps: {
+        text: 'Submit',
+        onClick: () => alert('clicked')
+    },
+    title: 'Header',
+    subTitle: 'Sub title'
+} as ICardboardModalProps;
+
+export const WithCustomElements = Template.bind({}) as CardboardModalStory;
+WithCustomElements.args = {
+    isOpen: true,
+    onDismiss: () => alert('closed'),
+    primaryButtonProps: {
+        text: 'Submit',
+        onClick: () => alert('clicked')
+    },
+    title: () => <div style={{ color: 'red' }}>Custom title</div>,
+    subTitle: () => <div style={{ color: 'blue' }}>custom styled sub title</div>
+} as ICardboardModalProps;

--- a/src/Components/CardboardModal/CardboardModal.styles.ts
+++ b/src/Components/CardboardModal/CardboardModal.styles.ts
@@ -1,0 +1,67 @@
+import { FontSizes, FontWeights } from '@fluentui/react';
+import {
+    ICardboardModalStyleProps,
+    ICardboardModalStyles
+} from './CardboardModal.types';
+
+export const classPrefix = 'cb-oat-modal';
+const classNames = {
+    content: `${classPrefix}-content`,
+    footer: `${classPrefix}-footer`,
+    headerContainer: `${classPrefix}-headerContainer`,
+    subtitle: `${classPrefix}-subtitle`,
+    title: `${classPrefix}-title`,
+    titleContainer: `${classPrefix}-titleContainer`
+};
+export const getStyles = (
+    _props: ICardboardModalStyleProps
+): ICardboardModalStyles => {
+    return {
+        content: [
+            classNames.content,
+            {
+                height: '100%',
+                overflow: 'auto'
+            }
+        ],
+        footer: [classNames.footer],
+        headerContainer: [classNames.headerContainer],
+        title: [
+            classNames.title,
+            {
+                margin: 0,
+                fontSize: FontSizes.size24,
+                fontWeight: FontWeights.semibold
+            }
+        ],
+        titleContainer: [
+            classNames.titleContainer,
+            {
+                display: 'flex',
+                paddingBottom: 8
+            }
+        ],
+        subtitle: [classNames.subtitle],
+        subComponentStyles: {
+            modal: {
+                main: {
+                    height: 690,
+                    width: 940,
+                    padding: 20
+                },
+                scrollableContent: {
+                    height: '100%'
+                }
+            },
+            icon: {
+                root: {
+                    textAlign: 'center',
+                    alignSelf: 'center',
+                    paddingRight: 12,
+                    paddingTop: 8,
+                    fontSize: FontSizes.size20
+                }
+            }
+        }
+    };
+};

--- a/src/Components/CardboardModal/CardboardModal.styles.ts
+++ b/src/Components/CardboardModal/CardboardModal.styles.ts
@@ -16,7 +16,7 @@ const classNames = {
 export const getStyles = (
     props: ICardboardModalStyleProps
 ): ICardboardModalStyles => {
-    const { isDestructiveFooterActionVisible, theme } = props;
+    const { splitFooter, theme } = props;
     return {
         content: [
             classNames.content,
@@ -68,7 +68,7 @@ export const getStyles = (
             },
             footerStack: {
                 root: {
-                    justifyContent: isDestructiveFooterActionVisible
+                    justifyContent: splitFooter
                         ? 'space-between !important'
                         : 'end'
                 }

--- a/src/Components/CardboardModal/CardboardModal.styles.ts
+++ b/src/Components/CardboardModal/CardboardModal.styles.ts
@@ -14,8 +14,10 @@ const classNames = {
     titleContainer: `${classPrefix}-titleContainer`
 };
 export const getStyles = (
-    _props: ICardboardModalStyleProps
+    props: ICardboardModalStyleProps
 ): ICardboardModalStyles => {
+    const { isDestructiveFooterActionVisible, theme } = props;
+    console.log('***Is destructive', isDestructiveFooterActionVisible);
     return {
         content: [
             classNames.content,
@@ -43,6 +45,35 @@ export const getStyles = (
         ],
         subtitle: [classNames.subtitle],
         subComponentStyles: {
+            destructiveButton: {
+                root: {
+                    backgroundColor: 'transparent',
+                    borderColor: 'var(--cb-color-text-danger)',
+                    color: 'var(--cb-color-text-danger)'
+                },
+                rootHovered: {
+                    backgroundColor: 'var(--cb-color-text-danger)',
+                    borderColor: theme.palette.white,
+                    color: theme.palette.white
+                },
+                rootFocused: {
+                    backgroundColor: 'var(--cb-color-text-danger)',
+                    borderColor: theme.palette.white,
+                    color: theme.palette.white
+                },
+                rootPressed: {
+                    backgroundColor: 'var(--cb-color-text-danger)',
+                    borderColor: theme.palette.white,
+                    color: theme.palette.white
+                }
+            },
+            footerStack: {
+                root: {
+                    justifyContent: isDestructiveFooterActionVisible
+                        ? 'space-between !important'
+                        : 'end'
+                }
+            },
             modal: {
                 main: {
                     height: 690,

--- a/src/Components/CardboardModal/CardboardModal.styles.ts
+++ b/src/Components/CardboardModal/CardboardModal.styles.ts
@@ -17,7 +17,6 @@ export const getStyles = (
     props: ICardboardModalStyleProps
 ): ICardboardModalStyles => {
     const { isDestructiveFooterActionVisible, theme } = props;
-    console.log('***Is destructive', isDestructiveFooterActionVisible);
     return {
         content: [
             classNames.content,

--- a/src/Components/CardboardModal/CardboardModal.tsx
+++ b/src/Components/CardboardModal/CardboardModal.tsx
@@ -30,7 +30,7 @@ const CardboardModal: React.FC<ICardboardModalProps> = (props) => {
     const {
         contentStackProps,
         children,
-        destructiveButtonProps,
+        dangerButtonProps,
         isOpen,
         modalProps,
         onDismiss,
@@ -48,7 +48,7 @@ const CardboardModal: React.FC<ICardboardModalProps> = (props) => {
     // styles
     const classNames = getClassNames(styles, {
         theme: useTheme(),
-        isDestructiveFooterActionVisible: !!destructiveButtonProps
+        isDestructiveFooterActionVisible: !!dangerButtonProps
     });
 
     return (
@@ -93,9 +93,9 @@ const CardboardModal: React.FC<ICardboardModalProps> = (props) => {
                         tokens={stackTokens}
                         styles={classNames.subComponentStyles.footerStack}
                     >
-                        {destructiveButtonProps && (
+                        {dangerButtonProps && (
                             <PrimaryButton
-                                {...destructiveButtonProps}
+                                {...dangerButtonProps}
                                 styles={classNames.subComponentStyles.destructiveButton()}
                             />
                         )}

--- a/src/Components/CardboardModal/CardboardModal.tsx
+++ b/src/Components/CardboardModal/CardboardModal.tsx
@@ -8,7 +8,8 @@ import {
     Modal,
     PrimaryButton,
     Stack,
-    IStackTokens
+    IStackTokens,
+    Link
 } from '@fluentui/react';
 import { useId } from '@fluentui/react-hooks';
 import {
@@ -28,13 +29,14 @@ const getClassNames = classNamesFunction<
 
 const CardboardModal: React.FC<ICardboardModalProps> = (props) => {
     const {
-        contentStackProps,
         children,
-        dangerButtonProps,
+        contentStackProps,
+        footerDangerButtonProps,
+        footerLinkProps,
+        footerPrimaryButtonProps,
         isOpen,
         modalProps,
         onDismiss,
-        primaryButtonProps,
         styles,
         subTitle,
         title,
@@ -48,7 +50,7 @@ const CardboardModal: React.FC<ICardboardModalProps> = (props) => {
     // styles
     const classNames = getClassNames(styles, {
         theme: useTheme(),
-        isDestructiveFooterActionVisible: !!dangerButtonProps
+        splitFooter: !!footerDangerButtonProps || !!footerLinkProps
     });
 
     return (
@@ -61,8 +63,8 @@ const CardboardModal: React.FC<ICardboardModalProps> = (props) => {
         >
             <Stack
                 {...contentStackProps}
-                tokens={{ ...stackTokens, ...contentStackProps.tokens }}
-                style={{ height: '100%', ...contentStackProps.style }}
+                tokens={{ ...stackTokens, ...contentStackProps?.tokens }}
+                style={{ height: '100%', ...contentStackProps?.style }}
             >
                 <div className={classNames.headerContainer}>
                     <div className={classNames.titleContainer}>
@@ -93,9 +95,18 @@ const CardboardModal: React.FC<ICardboardModalProps> = (props) => {
                         tokens={stackTokens}
                         styles={classNames.subComponentStyles.footerStack}
                     >
-                        {dangerButtonProps && (
+                        {footerLinkProps && (
+                            <Link
+                                target="_blank"
+                                href={footerLinkProps.url}
+                                {...footerLinkProps.linkProps}
+                            >
+                                {footerLinkProps.text}
+                            </Link>
+                        )}
+                        {footerDangerButtonProps && (
                             <PrimaryButton
-                                {...dangerButtonProps}
+                                {...footerDangerButtonProps}
                                 styles={classNames.subComponentStyles.destructiveButton()}
                             />
                         )}
@@ -110,7 +121,7 @@ const CardboardModal: React.FC<ICardboardModalProps> = (props) => {
                                 styles={classNames.subComponentStyles.cancelButton?.()}
                             />
                             <PrimaryButton
-                                {...primaryButtonProps}
+                                {...footerPrimaryButtonProps}
                                 styles={classNames.subComponentStyles.primaryButton?.()}
                             />
                         </Stack>

--- a/src/Components/CardboardModal/CardboardModal.tsx
+++ b/src/Components/CardboardModal/CardboardModal.tsx
@@ -28,14 +28,16 @@ const getClassNames = classNamesFunction<
 
 const CardboardModal: React.FC<ICardboardModalProps> = (props) => {
     const {
-        isOpen,
-        onDismiss,
-        primaryButtonProps,
-        title,
+        contentStackProps,
         children,
         destructiveButtonProps,
+        isOpen,
+        modalProps,
+        onDismiss,
+        primaryButtonProps,
         styles,
         subTitle,
+        title,
         titleIconName
     } = props;
 
@@ -51,12 +53,17 @@ const CardboardModal: React.FC<ICardboardModalProps> = (props) => {
 
     return (
         <Modal
+            {...modalProps}
             isOpen={isOpen}
             titleAriaId={titleId}
             onDismiss={onDismiss}
             styles={classNames.subComponentStyles.modal}
         >
-            <Stack tokens={stackTokens} style={{ height: '100%' }}>
+            <Stack
+                {...contentStackProps}
+                tokens={{ ...stackTokens, ...contentStackProps.tokens }}
+                style={{ height: '100%', ...contentStackProps.style }}
+            >
                 <div className={classNames.headerContainer}>
                     <div className={classNames.titleContainer}>
                         {titleIconName && (
@@ -89,7 +96,7 @@ const CardboardModal: React.FC<ICardboardModalProps> = (props) => {
                         {destructiveButtonProps && (
                             <PrimaryButton
                                 {...destructiveButtonProps}
-                                styles={classNames.subComponentStyles.destructiveButton?.()}
+                                styles={classNames.subComponentStyles.destructiveButton()}
                             />
                         )}
                         <Stack

--- a/src/Components/CardboardModal/CardboardModal.tsx
+++ b/src/Components/CardboardModal/CardboardModal.tsx
@@ -39,17 +39,9 @@ const CardboardModal: React.FC<ICardboardModalProps> = (props) => {
         titleIconName
     } = props;
 
-    // contexts
-
-    // state
-
     // hooks
     const { t } = useTranslation();
     const titleId = useId('modal-title');
-
-    // callbacks
-
-    // side effects
 
     // styles
     const classNames = getClassNames(styles, {
@@ -105,14 +97,14 @@ const CardboardModal: React.FC<ICardboardModalProps> = (props) => {
                             horizontal
                             horizontalAlign={'end'}
                         >
-                            <PrimaryButton
-                                {...primaryButtonProps}
-                                styles={classNames.subComponentStyles.primaryButton?.()}
-                            />
                             <DefaultButton
                                 text={t('cancel')}
                                 onClick={onDismiss}
                                 styles={classNames.subComponentStyles.cancelButton?.()}
+                            />
+                            <PrimaryButton
+                                {...primaryButtonProps}
+                                styles={classNames.subComponentStyles.primaryButton?.()}
                             />
                         </Stack>
                     </Stack>

--- a/src/Components/CardboardModal/CardboardModal.tsx
+++ b/src/Components/CardboardModal/CardboardModal.tsx
@@ -53,7 +53,8 @@ const CardboardModal: React.FC<ICardboardModalProps> = (props) => {
 
     // styles
     const classNames = getClassNames(styles, {
-        theme: useTheme()
+        theme: useTheme(),
+        isDestructiveFooterActionVisible: !!destructiveButtonProps
     });
 
     return (
@@ -88,16 +89,32 @@ const CardboardModal: React.FC<ICardboardModalProps> = (props) => {
                     <Stack tokens={stackTokens}>{children}</Stack>
                 </div>
                 <div className={classNames.footer}>
-                    {destructiveButtonProps && (
-                        <PrimaryButton {...destructiveButtonProps} />
-                    )}
                     <Stack
+                        horizontal
                         tokens={stackTokens}
-                        horizontal={true}
-                        horizontalAlign={'end'}
+                        styles={classNames.subComponentStyles.footerStack}
                     >
-                        <PrimaryButton {...primaryButtonProps} />
-                        <DefaultButton text={t('cancel')} onClick={onDismiss} />
+                        {destructiveButtonProps && (
+                            <PrimaryButton
+                                {...destructiveButtonProps}
+                                styles={classNames.subComponentStyles.destructiveButton?.()}
+                            />
+                        )}
+                        <Stack
+                            tokens={stackTokens}
+                            horizontal
+                            horizontalAlign={'end'}
+                        >
+                            <PrimaryButton
+                                {...primaryButtonProps}
+                                styles={classNames.subComponentStyles.primaryButton?.()}
+                            />
+                            <DefaultButton
+                                text={t('cancel')}
+                                onClick={onDismiss}
+                                styles={classNames.subComponentStyles.cancelButton?.()}
+                            />
+                        </Stack>
                     </Stack>
                 </div>
             </Stack>

--- a/src/Components/CardboardModal/CardboardModal.tsx
+++ b/src/Components/CardboardModal/CardboardModal.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import {
+    classNamesFunction,
+    useTheme,
+    styled,
+    DefaultButton,
+    Icon,
+    Modal,
+    PrimaryButton,
+    Stack,
+    IStackTokens
+} from '@fluentui/react';
+import { useId } from '@fluentui/react-hooks';
+import {
+    ICardboardModalProps,
+    ICardboardModalStyleProps,
+    ICardboardModalStyles
+} from './CardboardModal.types';
+import { getStyles } from './CardboardModal.styles';
+import { useTranslation } from 'react-i18next';
+
+const stackTokens: IStackTokens = { childrenGap: 8 };
+
+const getClassNames = classNamesFunction<
+    ICardboardModalStyleProps,
+    ICardboardModalStyles
+>();
+
+const CardboardModal: React.FC<ICardboardModalProps> = (props) => {
+    const {
+        isOpen,
+        onDismiss,
+        primaryButtonProps,
+        title,
+        children,
+        destructiveButtonProps,
+        styles,
+        subTitle,
+        titleIconName
+    } = props;
+
+    // contexts
+
+    // state
+
+    // hooks
+    const { t } = useTranslation();
+    const titleId = useId('modal-title');
+
+    // callbacks
+
+    // side effects
+
+    // styles
+    const classNames = getClassNames(styles, {
+        theme: useTheme()
+    });
+
+    return (
+        <Modal
+            isOpen={isOpen}
+            titleAriaId={titleId}
+            onDismiss={onDismiss}
+            styles={classNames.subComponentStyles.modal}
+        >
+            <Stack tokens={stackTokens} style={{ height: '100%' }}>
+                <div className={classNames.headerContainer}>
+                    <div className={classNames.titleContainer}>
+                        {titleIconName && (
+                            <Icon
+                                iconName={titleIconName}
+                                styles={classNames.subComponentStyles.icon}
+                            />
+                        )}
+                        <h3 id={titleId} className={classNames.title}>
+                            {typeof title === 'function' ? title() : title}
+                        </h3>
+                    </div>
+                    {subTitle && (
+                        <p className={classNames.subtitle}>
+                            {typeof subTitle === 'function'
+                                ? subTitle()
+                                : subTitle}
+                        </p>
+                    )}
+                </div>
+                <div className={classNames.content}>
+                    <Stack tokens={stackTokens}>{children}</Stack>
+                </div>
+                <div className={classNames.footer}>
+                    {destructiveButtonProps && (
+                        <PrimaryButton {...destructiveButtonProps} />
+                    )}
+                    <Stack
+                        tokens={stackTokens}
+                        horizontal={true}
+                        horizontalAlign={'end'}
+                    >
+                        <PrimaryButton {...primaryButtonProps} />
+                        <DefaultButton text={t('cancel')} onClick={onDismiss} />
+                    </Stack>
+                </div>
+            </Stack>
+        </Modal>
+    );
+};
+
+export default styled<
+    ICardboardModalProps,
+    ICardboardModalStyleProps,
+    ICardboardModalStyles
+>(CardboardModal, getStyles);

--- a/src/Components/CardboardModal/CardboardModal.types.ts
+++ b/src/Components/CardboardModal/CardboardModal.types.ts
@@ -15,7 +15,7 @@ import { CardboardIconNames } from '../../Models/Constants';
 export interface ICardboardModalProps {
     /** overrides for stack props for the main content body */
     contentStackProps?: IStackProps;
-    /** on click of the destructive action. If not provided, button is hidden */
+    /** props for the danger action in the footer. If not provided, button is hidden */
     dangerButtonProps?: IButtonProps;
     /** is the modal open */
     isOpen: boolean;

--- a/src/Components/CardboardModal/CardboardModal.types.ts
+++ b/src/Components/CardboardModal/CardboardModal.types.ts
@@ -2,6 +2,7 @@ import {
     IButtonProps,
     IButtonStyles,
     IIconStyles,
+    ILinkProps,
     IModalProps,
     IModalStyles,
     IStackProps,
@@ -16,7 +17,14 @@ export interface ICardboardModalProps {
     /** overrides for stack props for the main content body */
     contentStackProps?: IStackProps;
     /** props for the danger action in the footer. If not provided, button is hidden */
-    dangerButtonProps?: IButtonProps;
+    footerDangerButtonProps?: IButtonProps;
+    footerLinkProps?: {
+        text: string;
+        url: string;
+        linkProps?: ILinkProps;
+    };
+    /** click handle for the primary footer button */
+    footerPrimaryButtonProps: IButtonProps;
     /** is the modal open */
     isOpen: boolean;
     /** additional props to pass to the modal for customization */
@@ -26,8 +34,6 @@ export interface ICardboardModalProps {
     >;
     /** on dismiss of the dialog (either close or cancel) */
     onDismiss: () => void;
-    /** click handle for the primary footer button */
-    primaryButtonProps: IButtonProps;
     /** sub title text */
     subTitle?: string | (() => React.ReactNode);
     /** title text */
@@ -48,7 +54,7 @@ export interface ICardboardModalProps {
 
 export interface ICardboardModalStyleProps {
     theme: ITheme;
-    isDestructiveFooterActionVisible: boolean;
+    splitFooter: boolean;
 }
 export interface ICardboardModalStyles {
     content: IStyle;

--- a/src/Components/CardboardModal/CardboardModal.types.ts
+++ b/src/Components/CardboardModal/CardboardModal.types.ts
@@ -1,7 +1,9 @@
 import {
     IButtonProps,
+    IButtonStyles,
     IIconStyles,
     IModalStyles,
+    IStackStyles,
     IStyle,
     IStyleFunctionOrObject,
     ITheme
@@ -37,6 +39,7 @@ export interface ICardboardModalProps {
 
 export interface ICardboardModalStyleProps {
     theme: ITheme;
+    isDestructiveFooterActionVisible: boolean;
 }
 export interface ICardboardModalStyles {
     content: IStyle;
@@ -53,6 +56,10 @@ export interface ICardboardModalStyles {
 }
 
 export interface ICardboardModalSubComponentStyles {
-    modal?: Partial<IModalStyles>;
+    cancelButton?: Partial<IButtonStyles>;
+    destructiveButton?: Partial<IButtonStyles>;
+    footerStack?: IStackStyles;
     icon?: IIconStyles;
+    modal?: Partial<IModalStyles>;
+    primaryButton?: Partial<IButtonStyles>;
 }

--- a/src/Components/CardboardModal/CardboardModal.types.ts
+++ b/src/Components/CardboardModal/CardboardModal.types.ts
@@ -16,7 +16,7 @@ export interface ICardboardModalProps {
     /** overrides for stack props for the main content body */
     contentStackProps?: IStackProps;
     /** on click of the destructive action. If not provided, button is hidden */
-    destructiveButtonProps?: IButtonProps;
+    dangerButtonProps?: IButtonProps;
     /** is the modal open */
     isOpen: boolean;
     /** additional props to pass to the modal for customization */

--- a/src/Components/CardboardModal/CardboardModal.types.ts
+++ b/src/Components/CardboardModal/CardboardModal.types.ts
@@ -1,0 +1,58 @@
+import {
+    IButtonProps,
+    IIconStyles,
+    IModalStyles,
+    IStyle,
+    IStyleFunctionOrObject,
+    ITheme
+} from '@fluentui/react';
+import { CardboardIconNames } from '../../Models/Constants';
+
+export interface ICardboardModalProps {
+    /** on click of the destructive action. If not provided, button is hidden */
+    destructiveButtonProps?: IButtonProps;
+    /** is the modal open */
+    isOpen: boolean;
+    /** on dismiss of the dialog (either close or cancel) */
+    onDismiss: () => void;
+    /** click handle for the primary footer button */
+    primaryButtonProps: IButtonProps;
+    /** sub title text */
+    subTitle?: string | (() => React.ReactNode);
+    /** title text */
+    title: string | (() => React.ReactNode);
+    /**
+     * icon next to the title
+     */
+    titleIconName?: CardboardIconNames;
+
+    /**
+     * Call to provide customized styling that will layer on top of the variant rules.
+     */
+    styles?: IStyleFunctionOrObject<
+        ICardboardModalStyleProps,
+        ICardboardModalStyles
+    >;
+}
+
+export interface ICardboardModalStyleProps {
+    theme: ITheme;
+}
+export interface ICardboardModalStyles {
+    content: IStyle;
+    footer: IStyle;
+    headerContainer: IStyle;
+    subtitle: IStyle;
+    title: IStyle;
+    titleContainer: IStyle;
+
+    /**
+     * SubComponent styles.
+     */
+    subComponentStyles?: ICardboardModalSubComponentStyles;
+}
+
+export interface ICardboardModalSubComponentStyles {
+    modal?: Partial<IModalStyles>;
+    icon?: IIconStyles;
+}

--- a/src/Components/CardboardModal/CardboardModal.types.ts
+++ b/src/Components/CardboardModal/CardboardModal.types.ts
@@ -2,7 +2,9 @@ import {
     IButtonProps,
     IButtonStyles,
     IIconStyles,
+    IModalProps,
     IModalStyles,
+    IStackProps,
     IStackStyles,
     IStyle,
     IStyleFunctionOrObject,
@@ -11,10 +13,17 @@ import {
 import { CardboardIconNames } from '../../Models/Constants';
 
 export interface ICardboardModalProps {
+    /** overrides for stack props for the main content body */
+    contentStackProps?: IStackProps;
     /** on click of the destructive action. If not provided, button is hidden */
     destructiveButtonProps?: IButtonProps;
     /** is the modal open */
     isOpen: boolean;
+    /** additional props to pass to the modal for customization */
+    modalProps?: Omit<
+        Partial<IModalProps>,
+        'isOpen' | 'titleAriaId' | 'onDismiss' | 'styles'
+    >;
     /** on dismiss of the dialog (either close or cancel) */
     onDismiss: () => void;
     /** click handle for the primary footer button */
@@ -57,7 +66,7 @@ export interface ICardboardModalStyles {
 
 export interface ICardboardModalSubComponentStyles {
     cancelButton?: Partial<IButtonStyles>;
-    destructiveButton?: Partial<IButtonStyles>;
+    destructiveButton: Partial<IButtonStyles>;
     footerStack?: IStackStyles;
     icon?: IIconStyles;
     modal?: Partial<IModalStyles>;

--- a/src/Models/Constants/Types.ts
+++ b/src/Models/Constants/Types.ts
@@ -179,6 +179,7 @@ export type CardboardIconNames =
     | 'Org'
     | 'ProductVariant'
     | 'Ringer'
+    | 'Search'
     | 'Shapes'
     | 'SpeedHigh'
     | 'View';


### PR DESCRIPTION
### Summary of changes 🔍 
We have a lot of modals and it seemed logical that we should standardize some of that styling and components when possible so this is a generic control that conforms to most of our default styles and patterns.

This is heavily lifted from the work @pasanchMSFT did on the AdvancedSearch modal so props there! It was super easy to extract and convert to a generic implementation.


Generic modal that has title, subtitle
![image](https://user-images.githubusercontent.com/57726991/193314688-69ef4de1-e2cb-4336-b94d-3f9d5fea5933.png)

Generic with destructive action
![image](https://user-images.githubusercontent.com/57726991/193322150-aaac64e1-0d3e-4ede-8355-d8153e6add4e.png)

Customizable title and sub title
![image](https://user-images.githubusercontent.com/57726991/193314550-1c06d1c3-0cce-4ba2-ab85-04b12efac0fc.png)

I migrated AdvancedSearch to the generic control as an example
![image](https://user-images.githubusercontent.com/57726991/193329681-9fe66d87-3c01-4860-abae-f9af50b56f4b.png)


### Testing 🧪
- Check out the `CardboardModal` stories.
![image](https://user-images.githubusercontent.com/57726991/193314988-4ec2635b-aa11-4d37-b3d8-b37550a42c92.png)


### Checklist ✔️
- [x] Linked associated issue (if present)
- [x] Added relevant labels
- [x] Requested developer reviews
- [x] Request UI review from design / PM
- [x] Verify all code checks are passing