### PR TITLE
CardboardList: Add custom icon support to cardboard list

### DIFF
--- a/src/Components/CardboardList/CardboardList.types.ts
+++ b/src/Components/CardboardList/CardboardList.types.ts
@@ -27,14 +27,18 @@ type IListItemBaseProps<T> = {
         customStyles?: IButtonStyles;
     };
     /** icon to render on the right side of the list item */
-    iconEnd?: {
-        name: IIconNames;
-        onClick?: (item: T) => void;
-    };
+    iconEnd?:
+        | {
+              name: IIconNames;
+              onClick?: (item: T) => void;
+          }
+        | ((item: T) => React.ReactElement);
     /** icon or JSX element to render at the left side of the list item */
-    iconStart?: {
-        name: IIconNames | JSX.Element;
-    };
+    iconStart?:
+        | {
+              name: IIconNames | JSX.Element;
+          }
+        | ((item: T) => React.ReactElement);
     /** if provided false will result in rendering the red dot at the very left of the element. If not provided, will assume it is valid and not render any dot */
     isValid?: boolean;
     /** if provided will result in rendering the checkbox in either checked or unchecked state. If not provided, will not render a checkbox */

--- a/src/Components/CardboardList/CardboardList.types.ts
+++ b/src/Components/CardboardList/CardboardList.types.ts
@@ -36,7 +36,7 @@ type IListItemBaseProps<T> = {
     /** icon or JSX element to render at the left side of the list item */
     iconStart?:
         | {
-              name: IIconNames | JSX.Element;
+              name: IIconNames;
           }
         | ((item: T) => React.ReactElement);
     /** if provided false will result in rendering the red dot at the very left of the element. If not provided, will assume it is valid and not render any dot */

--- a/src/Components/CardboardList/CardboardListItem.stories.tsx
+++ b/src/Components/CardboardList/CardboardListItem.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ComponentStory } from '@storybook/react';
 import { CardboardListItem } from './CardboardListItem';
-import { IContextualMenuItem } from '@fluentui/react';
+import { IContextualMenuItem, Image } from '@fluentui/react';
 import {
     getDefaultStoryDecorator,
     waitForFirstRender
@@ -9,6 +9,7 @@ import {
 import { userEvent, within } from '@storybook/testing-library';
 import { Theme } from '../..';
 import { ICardboardListItemPropsInternal } from './CardboardList.types';
+import GenericErrorImg from '../../Resources/Static/noResults.svg';
 
 const cardStyle = {
     width: '300px',
@@ -114,10 +115,22 @@ WithStartIcon.args = {
     iconStart: { name: 'Shapes' }
 };
 
+export const WithStartIconCustom = Template.bind({}) as TemplateStory;
+WithStartIconCustom.args = {
+    ...defaultProps,
+    iconStart: () => <Image src={GenericErrorImg} height={14} />
+};
+
 export const WithEndIcon = Template.bind({}) as TemplateStory;
 WithEndIcon.args = {
     ...defaultProps,
     iconEnd: { name: 'Add' }
+};
+
+export const WithEndIconCustom = Template.bind({}) as TemplateStory;
+WithEndIconCustom.args = {
+    ...defaultProps,
+    iconEnd: () => <Image src={GenericErrorImg} height={14} />
 };
 
 export const WithEndIconButton = Template.bind({}) as TemplateStory;
@@ -130,6 +143,14 @@ export const WithStartAndEndIcon = Template.bind({}) as TemplateStory;
 WithStartAndEndIcon.args = {
     ...WithStartIcon.args,
     ...WithEndIcon.args
+};
+
+export const WithStartAndEndIconCustom = Template.bind({}) as TemplateStory;
+WithStartAndEndIconCustom.args = {
+    ...defaultProps,
+    textPrimary: 'something crazy super long and overflowing',
+    iconStart: () => <Image src={GenericErrorImg} height={14} />,
+    iconEnd: () => <Image src={GenericErrorImg} height={14} />
 };
 
 export const WithStartIconAndMenu = Template.bind({}) as TemplateStory;

--- a/src/Components/CardboardList/CardboardListItem.tsx
+++ b/src/Components/CardboardList/CardboardListItem.tsx
@@ -35,10 +35,19 @@ export const CardboardListItem = <T extends unknown>(
     const [isMenuOpen, setIsMenuOpen] = useState(false);
     const showCheckbox = isChecked === true || isChecked === false;
     const showSecondaryText = !!textSecondary;
-    const showStartIcon = !!iconStart;
-    const showNotValidIcon = isValid === false;
-    const showEndIconButton = iconEnd?.name && iconEnd?.onClick;
-    const showEndIcon = iconEnd?.name && !showEndIconButton;
+
+    // start icon
+    const isStartIconCustomRender = typeof iconStart === 'function';
+    const showStartIcon = !!iconStart && !isStartIconCustomRender;
+    const showWarningIndicator = isValid === false;
+
+    // end icon
+    const isEndIconCustomRender = typeof iconEnd === 'function';
+    const showEndIconButton =
+        !isEndIconCustomRender && iconEnd?.name && iconEnd?.onClick;
+    const showEndIcon =
+        !isEndIconCustomRender && iconEnd?.name && !showEndIconButton;
+
     const showOverflow = !!overflowMenuItems?.length;
 
     const overflowRef = useRef(null);
@@ -50,11 +59,11 @@ export const CardboardListItem = <T extends unknown>(
         overflowRef?.current?.openMenu?.();
         // set state for css
         onMenuStateChange(true);
-    }, [overflowRef, setIsMenuOpen]);
+    }, [onMenuStateChange]);
 
     const onSecondaryAction = useCallback(() => {
-        iconEnd?.onClick?.(item);
-    }, [iconEnd, item]);
+        !isEndIconCustomRender && iconEnd?.onClick?.(item);
+    }, [iconEnd, isEndIconCustomRender, item]);
 
     const onButtonClick = useCallback(() => {
         if (openMenuOnClick) {
@@ -62,7 +71,7 @@ export const CardboardListItem = <T extends unknown>(
         } else {
             onClick(item);
         }
-    }, [onMenuClick, onClick]);
+    }, [openMenuOnClick, onMenuClick, onClick, item]);
     const onButtonKeyPress = useCallback(
         (event: React.KeyboardEvent<HTMLButtonElement>) => {
             if (event.code === 'Space') {
@@ -75,7 +84,7 @@ export const CardboardListItem = <T extends unknown>(
                 }
             }
         },
-        [onMenuClick]
+        [onMenuClick, onSecondaryAction, showEndIconButton, showOverflow]
     );
 
     const theme = useTheme();
@@ -96,7 +105,7 @@ export const CardboardListItem = <T extends unknown>(
                     onClick={onButtonClick}
                     onKeyPress={onButtonKeyPress}
                 >
-                    {showNotValidIcon && (
+                    {showWarningIndicator && (
                         <span className={classNames.alertDot} />
                     )}
                     {showCheckbox && (
@@ -107,6 +116,7 @@ export const CardboardListItem = <T extends unknown>(
                             />
                         </>
                     )}
+                    {isStartIconCustomRender && iconStart(item)}
                     {showStartIcon &&
                         (typeof iconStart.name === 'string' ? (
                             <FontIcon
@@ -137,6 +147,7 @@ export const CardboardListItem = <T extends unknown>(
                             </div>
                         )}
                     </div>
+                    {isEndIconCustomRender && iconEnd(item)}
                     {showEndIcon && (
                         <FontIcon
                             iconName={iconEnd.name}

--- a/src/Components/CardboardList/CardboardListItem.tsx
+++ b/src/Components/CardboardList/CardboardListItem.tsx
@@ -37,16 +37,16 @@ export const CardboardListItem = <T extends unknown>(
     const showSecondaryText = !!textSecondary;
 
     // start icon
-    const isStartIconCustomRender = typeof iconStart === 'function';
+    const isStartIconCustomRender = typeof iconStart !== 'object';
     const showStartIcon = !!iconStart && !isStartIconCustomRender;
     const showWarningIndicator = isValid === false;
 
     // end icon
-    const isEndIconCustomRender = typeof iconEnd === 'function';
+    const isEndIconCustomRender = typeof iconEnd !== 'object';
     const showEndIconButton =
-        !isEndIconCustomRender && iconEnd?.name && iconEnd?.onClick;
+        typeof iconEnd === 'object' && iconEnd?.name && iconEnd?.onClick;
     const showEndIcon =
-        !isEndIconCustomRender && iconEnd?.name && !showEndIconButton;
+        typeof iconEnd === 'object' && iconEnd?.name && !showEndIconButton;
 
     const showOverflow = !!overflowMenuItems?.length;
 
@@ -62,7 +62,7 @@ export const CardboardListItem = <T extends unknown>(
     }, [onMenuStateChange]);
 
     const onSecondaryAction = useCallback(() => {
-        !isEndIconCustomRender && iconEnd?.onClick?.(item);
+        typeof iconEnd === 'object' && iconEnd?.onClick?.(item);
     }, [iconEnd, isEndIconCustomRender, item]);
 
     const onButtonClick = useCallback(() => {
@@ -116,7 +116,7 @@ export const CardboardListItem = <T extends unknown>(
                             />
                         </>
                     )}
-                    {isStartIconCustomRender && iconStart(item)}
+                    {typeof iconStart === 'function' && iconStart(item)}
                     {showStartIcon &&
                         (typeof iconStart.name === 'string' ? (
                             <FontIcon
@@ -147,7 +147,7 @@ export const CardboardListItem = <T extends unknown>(
                             </div>
                         )}
                     </div>
-                    {isEndIconCustomRender && iconEnd(item)}
+                    {typeof iconEnd === 'function' && iconEnd(item)}
                     {showEndIcon && (
                         <FontIcon
                             iconName={iconEnd.name}

--- a/src/Components/ElementsPanel/Internal/ElementsList.tsx
+++ b/src/Components/ElementsPanel/Internal/ElementsList.tsx
@@ -155,11 +155,9 @@ function getListItems(
                     onBlur: () => onItemBlur(element, panelItem)
                 })
             },
-            iconStart: {
-                name: (
-                    <ElementStatus statuses={statuses} panelItem={panelItem} />
-                )
-            },
+            iconStart: () => (
+                <ElementStatus statuses={statuses} panelItem={panelItem} />
+            ),
             item: element,
             itemType: 'header',
             onClick: () => onItemClick(element, panelItem),
@@ -184,18 +182,15 @@ function getListItems(
                     onMouseLeave: onLeave,
                     onBlur: onLeave
                 },
-                iconStart: {
-                    name: (
-                        <span className={alertStyles.alertCircle}>
-                            <Icon
-                                iconName={
-                                    alert.alertVisual.valueRanges[0].visual
-                                        .iconName
-                                }
-                            />
-                        </span>
-                    )
-                },
+                iconStart: () => (
+                    <span className={alertStyles.alertCircle}>
+                        <Icon
+                            iconName={
+                                alert.alertVisual.valueRanges[0].visual.iconName
+                            }
+                        />
+                    </span>
+                ),
                 item: alert.alertVisual,
                 itemType: 'item',
                 onClick: () =>


### PR DESCRIPTION
### Summary of changes 🔍 
Adding support for rendering arbitrary content at the start and end of the list item in place of the icons.
Consumers will be responsible for dealing with the right amount of spacing on the start icon since that would require a lot of backwards validation on existing stuff to add a stack.

Both start & end customized
![image](https://user-images.githubusercontent.com/57726991/196791692-43f39251-8bc4-43d4-9c4c-4e6506a69759.png)

Start only
![image](https://user-images.githubusercontent.com/57726991/196791970-4a3f0d60-9e4b-4f48-a229-3a788d648224.png)

End only
![image](https://user-images.githubusercontent.com/57726991/196791929-f63b8ed3-e7cf-43f1-8812-bc150500512d.png)


### Testing 🧪
Check the following stories
- [x] Lists --> Items --> WithStartIconCustom
- [x] Lists --> Items --> WithEndIconCustom
- [x] Lists --> Items --> WithStartAndEndIconCustom

### Checklist ✔️
- [ ] Linked associated issue (if present)
- [ ] Added relevant labels
- [ ] Requested developer reviews
- [ ] Request UI review from design / PM
- [ ] Verify all code checks are passing