### PR TITLE
[Data history]: Changed schema config to store adx connection info separately

### DIFF
--- a/schemas/3DScenesConfiguration/v1.0.0/3DScenesConfiguration.schema.json
+++ b/schemas/3DScenesConfiguration/v1.0.0/3DScenesConfiguration.schema.json
@@ -236,6 +236,30 @@
                 "time"
             ]
         },
+        "IADXTimeSeriesConnection": {
+            "type": "object",
+            "description": "Azure Data Explorer connection information for time series data",
+            "additionalProperties": false,
+            "properties": {
+                "adxClusterUrl": {
+                    "type": "string"
+                },
+                "adxDatabaseName": {
+                    "type": "string"
+                },
+                "adxTableName": {
+                    "type": "string"
+                }
+            },
+            "required": ["adxClusterUrl", "adxDatabaseName", "adxTableName"]
+        },
+        "ITimeSeriesConnection": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/IADXTimeSeriesConnection"
+                }
+            ]
+        },
         "IDataHistoryBasicTimeSeries": {
             "type": "object",
             "description": "A basic timeseries to be rendered in the chart of the data history widget",
@@ -457,9 +481,9 @@
             "additionalProperties": false,
             "description": "Widget configuration specifies widget specific properties that are used for rendering this data history",
             "properties": {
-                "connectionString": {
-                    "type": "string",
-                    "description": "Timeseries database connection string in key1=value1;key2=value2;key3=value3 format that is used for the connection of a data history widget"
+                "connection": {
+                    "description": "Database connection information of timeseries data",
+                    "$ref": "#/$defs/ITimeSeriesConnection"
                 },
                 "displayName": {
                     "type": "string"
@@ -470,7 +494,7 @@
                 }
             },
             "required": [
-                "connectionString",
+                "connection",
                 "displayName",
                 "timeSeries",
                 "chartOptions"

--- a/src/Adapters/__mockData__/TruckAndMachinesConfig.json
+++ b/src/Adapters/__mockData__/TruckAndMachinesConfig.json
@@ -25,9 +25,7 @@
                         "id": "4cb0990d646a4bbea3e1102676e200fe",
                         "displayName": "tank",
                         "primaryTwinID": "SaltMachine_C1",
-                        "objectIDs": [
-                            "tankMesh"
-                        ],
+                        "objectIDs": ["tankMesh"],
                         "twinAliases": {
                             "temperatureTag": "PasteurizationMachine_A01"
                         },
@@ -38,10 +36,7 @@
                         "id": "0c785dde26664341b1f391a4e1b35180",
                         "displayName": "box1",
                         "primaryTwinID": "BoxA",
-                        "objectIDs": [
-                            "boxLid1Mesh",
-                            "boxBody1Mesh"
-                        ]
+                        "objectIDs": ["boxLid1Mesh", "boxBody1Mesh"]
                     }
                 ],
                 "behaviorIDs": [
@@ -87,30 +82,21 @@
                                     "valueRanges": [
                                         {
                                             "id": "0278cd377adbc30253b0fdb6b5fcf160",
-                                            "values": [
-                                                "-Infinity",
-                                                200
-                                            ],
+                                            "values": ["-Infinity", 200],
                                             "visual": {
                                                 "color": "#C32F27"
                                             }
                                         },
                                         {
                                             "id": "0278cd377adbc30253b0fdb6b5fcf161",
-                                            "values": [
-                                                500,
-                                                800
-                                            ],
+                                            "values": [500, 800],
                                             "visual": {
                                                 "color": "#FEE440"
                                             }
                                         },
                                         {
                                             "id": "0278cd377adbc30253b0fdb6b5fcf162",
-                                            "values": [
-                                                800,
-                                                1000
-                                            ],
+                                            "values": [800, 1000],
                                             "visual": {
                                                 "color": "#26C485"
                                             }
@@ -130,20 +116,14 @@
                                     "valueRanges": [
                                         {
                                             "id": "0278cd377adbc30253b0fdb6b5fcf149",
-                                            "values": [
-                                                700,
-                                                900
-                                            ],
+                                            "values": [700, 900],
                                             "visual": {
                                                 "color": "#26C485"
                                             }
                                         },
                                         {
                                             "id": "0278cd377adbc30253b0fdb6b5fc3sak",
-                                            "values": [
-                                                2000,
-                                                3000
-                                            ],
+                                            "values": [2000, 3000],
                                             "visual": {
                                                 "color": "#26C485"
                                             }
@@ -175,7 +155,11 @@
                                 "groupID": "8bf489e804884596afe8abb7e803d5c5",
                                 "id": "b2cf0aa2415f4e029f27f957fb559db3",
                                 "widgetConfiguration": {
-                                    "connectionString": "kustoClusterUrl=https://mockKustoClusterName.westus2.kusto.windows.net;kustoDatabaseName=mockKustoDatabaseName;kustoTableName=mockKustoTableName",
+                                    "connection": {
+                                        "adxClusterUrl": "https://mockKustoClusterName.westus2.kusto.windows.net",
+                                        "adxDatabaseName": "mockKustoDatabaseName",
+                                        "adxTableName": "mockKustoTableName"
+                                    },
                                     "displayName": "Temperature and InFlow Data History",
                                     "timeSeries": [
                                         {
@@ -228,20 +212,14 @@
                         "valueRanges": [
                             {
                                 "id": "0278cd377adbc30253b0fdb6b5fcf149",
-                                "values": [
-                                    30,
-                                    35
-                                ],
+                                "values": [30, 35],
                                 "visual": {
                                     "color": "#26C485"
                                 }
                             },
                             {
                                 "id": "0278cd377adbc30253b0fdb6b5fc3sak",
-                                "values": [
-                                    0,
-                                    20
-                                ],
+                                "values": [0, 20],
                                 "visual": {
                                     "color": "#FF0000"
                                 }
@@ -259,20 +237,14 @@
                         "valueRanges": [
                             {
                                 "id": "0278ed377adbc30153b0fdb6b5fcf167",
-                                "values": [
-                                    100,
-                                    "Infinity"
-                                ],
+                                "values": [100, "Infinity"],
                                 "visual": {
                                     "color": "#0000FF"
                                 }
                             },
                             {
                                 "id": "0278bd377adbc30254b0fdb6b5fcf169",
-                                "values": [
-                                    "-Infinity",
-                                    100
-                                ],
+                                "values": ["-Infinity", 100],
                                 "visual": {
                                     "color": "#00FF00"
                                 }
@@ -291,9 +263,7 @@
                         "valueRanges": [
                             {
                                 "id": "d0d2edff7c80438fa529206848866i91",
-                                "values": [
-                                    true
-                                ],
+                                "values": [true],
                                 "visual": {
                                     "labelExpression": "Tire pressure too low!",
                                     "iconName": "heart",
@@ -310,15 +280,11 @@
             {
                 "id": "8b99ab46fabd45fab3adbaf88245a6b5",
                 "displayName": "Tank too hot",
-                "twinAliases": [
-                    "temperatureTag"
-                ],
+                "twinAliases": ["temperatureTag"],
                 "datasources": [
                     {
                         "type": "ElementTwinToObjectMappingDataSource",
-                        "elementIDs": [
-                            "4cb0990d646a4bbea3e1102676e200fe"
-                        ]
+                        "elementIDs": ["4cb0990d646a4bbea3e1102676e200fe"]
                     }
                 ],
                 "visuals": [
@@ -329,20 +295,14 @@
                         "valueRanges": [
                             {
                                 "id": "0278ed377adbc30153b0fdb6b5fcf167",
-                                "values": [
-                                    100,
-                                    "Infinity"
-                                ],
+                                "values": [100, "Infinity"],
                                 "visual": {
                                     "color": "#0000FF"
                                 }
                             },
                             {
                                 "id": "0278bd377adbc30254b0fdb6b5fcf169",
-                                "values": [
-                                    "-Infinity",
-                                    100
-                                ],
+                                "values": ["-Infinity", 100],
                                 "visual": {
                                     "color": "#00FF00"
                                 }
@@ -360,9 +320,7 @@
                         "valueRanges": [
                             {
                                 "id": "d0d2edff7c80438fa529206848866i91",
-                                "values": [
-                                    true
-                                ],
+                                "values": [true],
                                 "visual": {
                                     "labelExpression": "${PrimaryTwin.$dtId} is too hot!",
                                     "iconName": "heart",
@@ -381,17 +339,13 @@
             {
                 "id": "3511cc0c61394d0e857cde735ddb4e81",
                 "displayName": "TireStuff",
-                "behaviorIDs": [
-                    "bf1ec41d7886438d880c140fb1bb570a"
-                ],
+                "behaviorIDs": ["bf1ec41d7886438d880c140fb1bb570a"],
                 "extensionProperties": {}
             },
             {
                 "id": "a2912b78335c4e75a58ba72d987fefac",
                 "displayName": "HotStuff",
-                "behaviorIDs": [
-                    "8b99ab46fabd45fab3adbaf88245a6b5"
-                ],
+                "behaviorIDs": ["8b99ab46fabd45fab3adbaf88245a6b5"],
                 "extensionProperties": {}
             }
         ]

--- a/src/Components/ADT3DSceneBuilder/Internal/Behaviors/Widgets/WidgetBuilders/DataHistoryWidgetBuilder/DataHistoryWidgetBuilder.tsx
+++ b/src/Components/ADT3DSceneBuilder/Internal/Behaviors/Widgets/WidgetBuilders/DataHistoryWidgetBuilder/DataHistoryWidgetBuilder.tsx
@@ -22,10 +22,10 @@ import React, {
     useState
 } from 'react';
 import { useTranslation } from 'react-i18next';
-import { IADXConnection } from '../../../../../../../Models/Constants';
 import { DOCUMENTATION_LINKS } from '../../../../../../../Models/Constants/Constants';
 import { isValidADXClusterUrl } from '../../../../../../../Models/Services/Utils';
 import {
+    IADXTimeSeriesConnection,
     IDataHistoryAggregationType,
     IDataHistoryBasicTimeSeries,
     IDataHistoryChartYAxisType
@@ -89,10 +89,10 @@ const DataHistoryWidgetBuilder: React.FC<IDataHistoryWidgetBuilderProps> = ({
     useEffect(() => {
         const {
             displayName,
-            connectionString,
+            connection,
             timeSeries
         } = formData.widgetConfiguration;
-        if (displayName && connectionString && timeSeries.length) {
+        if (displayName && connection && timeSeries.length) {
             setIsWidgetConfigValid(true);
         } else {
             setIsWidgetConfigValid(false);
@@ -107,16 +107,18 @@ const DataHistoryWidgetBuilder: React.FC<IDataHistoryWidgetBuilderProps> = ({
             const connection = adxConnectionInformation.connection;
             updateWidgetData(
                 produce(formData, (draft) => {
-                    draft.widgetConfiguration.connectionString = generateConnectionString(
-                        connection
-                    );
+                    draft.widgetConfiguration.connection = {
+                        adxClusterUrl: connection.kustoClusterUrl,
+                        adxDatabaseName: connection.kustoDatabaseName,
+                        adxTableName: connection.kustoTableName
+                    };
                 })
             );
         }
     }, [adxConnectionInformation]);
 
-    const connectionString = formData.widgetConfiguration.connectionString
-        ? formData.widgetConfiguration.connectionString
+    const connectionString = formData.widgetConfiguration.connection
+        ? generateConnectionString(formData.widgetConfiguration.connection)
         : adxConnectionInformation.loadingState ===
           ADXConnectionInformationLoadingState.LOADING
         ? t('widgets.dataHistory.form.connectionLoadingText')
@@ -437,16 +439,16 @@ const DataHistoryWidgetBuilder: React.FC<IDataHistoryWidgetBuilderProps> = ({
 };
 
 const generateConnectionString = (
-    connection: IADXConnection
+    connection: IADXTimeSeriesConnection
 ): string | null => {
     if (
-        connection?.kustoClusterUrl &&
-        connection?.kustoDatabaseName &&
-        connection?.kustoTableName
+        connection?.adxClusterUrl &&
+        connection?.adxDatabaseName &&
+        connection?.adxTableName
     ) {
         try {
-            if (isValidADXClusterUrl(connection?.kustoClusterUrl)) {
-                return `kustoClusterUrl=${connection.kustoClusterUrl};kustoDatabaseName=${connection.kustoDatabaseName};kustoTableName=${connection.kustoTableName}`;
+            if (isValidADXClusterUrl(connection?.adxClusterUrl)) {
+                return `kustoClusterUrl=${connection.adxClusterUrl};kustoDatabaseName=${connection.adxDatabaseName};kustoTableName=${connection.adxTableName}`;
             }
         } catch (error) {
             return null;

--- a/src/Components/BehaviorsModal/Internal/Widgets/DataHistoryWidget/DataHistoryWidget.tsx
+++ b/src/Components/BehaviorsModal/Internal/Widgets/DataHistoryWidget/DataHistoryWidget.tsx
@@ -4,6 +4,7 @@ import {
     ADXTimeSeries,
     BehaviorModalMode,
     DTwin,
+    IADXConnection,
     IDataHistoryWidgetTimeSeriesTwin,
     TimeSeriesData
 } from '../../../../../Models/Constants';
@@ -34,7 +35,7 @@ const DataHistoryWidget: React.FC<IDataHistoryWidgetProps> = ({
 }) => {
     const {
         displayName,
-        connectionString,
+        connection,
         timeSeries,
         chartOptions
     } = widget.widgetConfiguration;
@@ -43,6 +44,17 @@ const DataHistoryWidget: React.FC<IDataHistoryWidgetProps> = ({
     const twinIdPropertyMap = getTwinIdPropertyMap(timeSeries, twins);
     const isRequestSent = useRef(false);
 
+    const connectionToQuery: IADXConnection = useMemo(
+        () =>
+            connection
+                ? {
+                      kustoClusterUrl: connection.adxClusterUrl,
+                      kustoDatabaseName: connection.adxDatabaseName,
+                      kustoTableName: connection.adxTableName
+                  }
+                : null,
+        [connection]
+    );
     const {
         query,
         deeplink,
@@ -51,7 +63,7 @@ const DataHistoryWidget: React.FC<IDataHistoryWidgetProps> = ({
         isLoading
     } = useTimeSeriesData({
         adapter,
-        connectionString,
+        connection: connectionToQuery,
         quickTimeSpanInMillis: chartOptions.defaultQuickTimeSpanInMillis,
         twins: twinIdPropertyMap
     });
@@ -63,7 +75,7 @@ const DataHistoryWidget: React.FC<IDataHistoryWidgetProps> = ({
         if (
             mode === BehaviorModalMode.viewer &&
             query &&
-            (adapter || connectionString) &&
+            (adapter || connection) &&
             !isRequestSent.current &&
             twinIdPropertyMap
         ) {
@@ -74,14 +86,7 @@ const DataHistoryWidget: React.FC<IDataHistoryWidgetProps> = ({
                 nowInMillis - chartOptions.defaultQuickTimeSpanInMillis;
             xMaxDateInMillisRef.current = nowInMillis;
         }
-    }, [
-        adapter,
-        query,
-        connectionString,
-        twinIdPropertyMap,
-        chartOptions,
-        mode
-    ]);
+    }, [adapter, query, connection, twinIdPropertyMap, chartOptions, mode]);
 
     const placeholderTimeSeriesData: Array<
         Array<TimeSeriesData>

--- a/src/Components/BehaviorsModal/__mockData__/BehaviorsModalMockData.json
+++ b/src/Components/BehaviorsModal/__mockData__/BehaviorsModalMockData.json
@@ -143,7 +143,11 @@
                                 "type": "Data history",
                                 "id": "b2cf0aa2415f4e029f27f957fb559db2",
                                 "widgetConfiguration": {
-                                    "connectionString": "kustoClusterUrl=https://mockKustoClusterName.westus2.kusto.windows.net;kustoDatabaseName=mockKustoDatabaseName;kustoTableName=mockKustoTableName",
+                                    "connection": {
+                                        "adxClusterUrl": "https://mockKustoClusterName.westus2.kusto.windows.net",
+                                        "adxDatabaseName": "mockKustoDatabaseName",
+                                        "adxTableName": "mockKustoTableName"
+                                    },
                                     "displayName": "Temperature and InFlow Trends",
                                     "timeSeries": [
                                         {
@@ -295,7 +299,11 @@
                                 "type": "Data history",
                                 "id": "b2cf0aa2415f4e029f27f957fb559db3",
                                 "widgetConfiguration": {
-                                    "connectionString": "kustoClusterUrl=https://mockKustoClusterName.westus2.kusto.windows.net;kustoDatabaseName=mockKustoDatabaseName;kustoTableName=mockKustoTableName",
+                                    "connection": {
+                                        "adxClusterUrl": "https://mockKustoClusterName.westus2.kusto.windows.net",
+                                        "adxDatabaseName": "mockKustoDatabaseName",
+                                        "adxTableName": "mockKustoTableName"
+                                    },
                                     "displayName": "Temperature and InFlow Data History",
                                     "timeSeries": [
                                         {

--- a/src/Models/Classes/3DVConfig.ts
+++ b/src/Models/Classes/3DVConfig.ts
@@ -176,7 +176,7 @@ export const defaultDataHistoryWidget: IDataHistoryWidget = {
     id: '',
     type: WidgetType.DataHistory,
     widgetConfiguration: {
-        connectionString: '',
+        connection: null,
         displayName: '',
         timeSeries: [],
         chartOptions: {

--- a/src/Models/Types/Generated/3DScenesConfiguration-v1.0.0.d.ts
+++ b/src/Models/Types/Generated/3DScenesConfiguration-v1.0.0.d.ts
@@ -252,12 +252,20 @@ export interface IDataHistoryWidget {
  */
 export interface IDataHistoryWidgetConfiguration {
     /**
-     * Timeseries database connection string in key1=value1;key2=value2;key3=value3 format that is used for the connection of a data history widget
+     * Database connection information of timeseries data
      */
-    connectionString: string;
+    connection: IADXTimeSeriesConnection;
     displayName: string;
     timeSeries: IDataHistoryTimeSeries;
     chartOptions: IDataHistoryChartOptions;
+}
+/**
+ * Azure Data Explorer connection information for time series data
+ */
+export interface IADXTimeSeriesConnection {
+    adxClusterUrl: string;
+    adxDatabaseName: string;
+    adxTableName: string;
 }
 /**
  * A basic timeseries to be rendered in the chart of the data history widget


### PR DESCRIPTION
### Summary of changes 🔍 
- Changed schema to store the adx connection information in separate fields instead of single connection string with key and values (defined the `ITimeSeriesConnection` as connection field in the widget configuration which can be extendable easily in the future in "anyof" field if there is going to be another type of storage than `IADXTimeSeriesConnection`)
- Changed the code accordingly in data history widget related components

![image](https://user-images.githubusercontent.com/45217314/197303692-281a0cce-ba4e-4d6d-a5d0-d50061486932.png)
![image](https://user-images.githubusercontent.com/45217314/197303705-7708d41f-b86d-4cd6-9660-40375985a2ae.png)

![image](https://user-images.githubusercontent.com/45217314/197303655-c5b628cc-99fb-457d-a101-fd9d042df7e4.png)


### Testing 🧪
If you already created data history widgets the config syntax validation would fail so you can reset your config file or you can delete the data history widget parts in your config file and upload back again. You can test it by creating a new data history widget in ADT3DScenePage

### Checklist ✔️
- [ ] Linked associated issue (if present)
- [x] Added relevant labels
- [x] Requested developer reviews
- [ ] Request UI review from design / PM
- [x] Verify all code checks are passing