### PR TITLE
3DConfig file showing as a selectable 3D asset 

### DIFF
--- a/src/Adapters/MockAdapter.ts
+++ b/src/Adapters/MockAdapter.ts
@@ -954,12 +954,6 @@ export default class MockAdapter
                 Path:
                     'https://cardboardresources.blob.core.windows.net/cardboard-mock-files/BluePackingLine.gltf',
                 Properties: { 'Content-Length': 2000 }
-            },
-            {
-                Name: '3DScenesConfiguration.json',
-                Path:
-                    'https://cardboardresources.blob.core.windows.net/cardboard-mock-files/3DScenesConfiguration.json',
-                Properties: { 'Content-Length': 3000 }
             }
         ];
         try {


### PR DESCRIPTION
### Summary of changes 🔍 
>Addressed this issue: https://github.com/microsoft/iot-cardboard-js/issues/677


### Testing 🧪
 >
Go to Mock3DScenePage story

1. Click on Add scene
2. Click on CHOOSE FILE dropdown
3. 3DConfig.json shown as a choice

Expected behavior
json file should not be shown in dropdown

### Checklist ✔️
- [ ] Linked associated issue (if present)
- [ ] Added relevant labels
- [ ] Requested developer reviews
- [ ] Request UI review from design / PM
- [ ] Verify all code checks are passing