### PR TITLE
OAT: Bug fix for loading previous project into context

### DIFF
--- a/src/Components/OATGraphViewer/OATGraphViewer.types.ts
+++ b/src/Components/OATGraphViewer/OATGraphViewer.types.ts
@@ -2,7 +2,6 @@ import {
     IStyleFunctionOrObject,
     ITheme,
     IStyle,
-    IStackStyles,
     ICalloutContentStyles
 } from '@fluentui/react';
 import { SimulationNodeDatum } from 'd3-force';

--- a/src/Models/Context/OatPageContext/OatPageContext.tsx
+++ b/src/Models/Context/OatPageContext/OatPageContext.tsx
@@ -338,7 +338,8 @@ const getInitialState = (
         project = files.find((x) => x.id === projectIdToUse).data;
         logDebugConsole(
             'debug',
-            'Bootstrapping OAT context with existing project.'
+            'Bootstrapping OAT context with existing project. {projectId}',
+            projectIdToUse
         );
     } else if (!files.length || !lastProjectId) {
         // create a project if none exists

--- a/src/Models/Services/OatUtils.ts
+++ b/src/Models/Services/OatUtils.ts
@@ -27,7 +27,7 @@ export const storeLastUsedProjectId = (id: string) => {
 /** Gets the last used project id */
 export const getLastUsedProjectId = (): string => {
     const data = localStorage.getItem(OAT_LAST_PROJECT_STORAGE_KEY);
-    return data ? data : '';
+    return data ? JSON.parse(data) : '';
 };
 
 // Load files from local storage

--- a/src/Pages/OATEditorPage/OATEditorPage.tsx
+++ b/src/Pages/OATEditorPage/OATEditorPage.tsx
@@ -16,7 +16,7 @@ import { IOATEditorPageProps } from './OATEditorPage.types';
 import { OatPageContextProvider } from '../../Models/Context/OatPageContext/OatPageContext';
 import { Stack } from '@fluentui/react';
 
-const debugLogging = true;
+const debugLogging = false;
 const logDebugConsole = getDebugLogger('OATEditorPage', debugLogging);
 
 const OATEditorPageContent: React.FC<IOATEditorPageProps> = (props) => {


### PR DESCRIPTION
### Summary of changes 🔍 
The previous project id was not getting parsed correctly and thus wasn't loading up the right project on boot.
