### PR TITLE
Styling: Add extended palette to the theme

### DIFF
--- a/src/Models/Hooks/useExtendedTheme.ts
+++ b/src/Models/Hooks/useExtendedTheme.ts
@@ -1,0 +1,6 @@
+import { useTheme } from '@fluentui/react';
+import { IExtendedTheme } from '../../Theming/Theme.types';
+
+export const useExtendedTheme = () => {
+    return useTheme() as IExtendedTheme;
+};

--- a/src/Models/Hooks/useExtendedTheme.ts
+++ b/src/Models/Hooks/useExtendedTheme.ts
@@ -3,7 +3,7 @@ import { IExtendedTheme } from '../../Theming/Theme.types';
 
 /**
  * Gives back the current theme object for the app
- * @returns the curren theme object with the right colors for the selected theme
+ * @returns the current theme object with the right colors for the selected theme
  */
 export const useExtendedTheme = () => {
     return useTheme() as IExtendedTheme;

--- a/src/Models/Hooks/useExtendedTheme.ts
+++ b/src/Models/Hooks/useExtendedTheme.ts
@@ -1,6 +1,10 @@
 import { useTheme } from '@fluentui/react';
 import { IExtendedTheme } from '../../Theming/Theme.types';
 
+/**
+ * Gives back the current theme object for the app
+ * @returns the curren theme object with the right colors for the selected theme
+ */
 export const useExtendedTheme = () => {
     return useTheme() as IExtendedTheme;
 };

--- a/src/Theming/FluentThemes.ts
+++ b/src/Theming/FluentThemes.ts
@@ -1,9 +1,4 @@
-import {
-    createTheme,
-    IPartialTheme,
-    ITheme,
-    Theme as FluentTheme
-} from '@fluentui/react';
+import { createTheme, ITheme, Theme as FluentTheme } from '@fluentui/react';
 import {
     fluentDarkThemePalette,
     fluentExplorerThemePalette,

--- a/src/Theming/FluentThemes.ts
+++ b/src/Theming/FluentThemes.ts
@@ -13,7 +13,7 @@ import {
     fluentKrakenThemeSemanticColors,
     fluentLightThemeSemanticColors
 } from './SemanticColors';
-import { IPartialExtendedTheme } from './Theme.types';
+import { IExtendedPartialTheme } from './Theme.types';
 
 export const getFluentTheme = (theme: Theme): ITheme => {
     switch (theme) {
@@ -35,7 +35,7 @@ export const getFluentTheme = (theme: Theme): ITheme => {
     then applies custom component style overrides.
 */
 const createThemeWithCustomStyles = (
-    themeInfo: IPartialExtendedTheme,
+    themeInfo: IExtendedPartialTheme,
     themeSetting: Theme
 ): FluentTheme => {
     const theme = createTheme(themeInfo);
@@ -49,22 +49,22 @@ const createThemeWithCustomStyles = (
     semanticColors: Specific UI color slots.  These are created using 
     the palette colors, but can be overriden for more stylistic control.
 */
-const fluentLightThemeInfo: IPartialExtendedTheme = {
+const fluentLightThemeInfo: IExtendedPartialTheme = {
     palette: fluentLightThemePalette,
     semanticColors: fluentLightThemeSemanticColors
 };
 
-const fluentDarkThemeInfo: IPartialExtendedTheme = {
+const fluentDarkThemeInfo: IExtendedPartialTheme = {
     palette: fluentDarkThemePalette,
     semanticColors: fluentDarkThemeSemanticColors
 };
 
-const fluentExplorerThemeInfo: IPartialExtendedTheme = {
+const fluentExplorerThemeInfo: IExtendedPartialTheme = {
     palette: fluentExplorerThemePalette,
     semanticColors: fluentExplorerThemeSemanticColors
 };
 
-const fluentKrakenThemeInfo: IPartialExtendedTheme = {
+const fluentKrakenThemeInfo: IExtendedPartialTheme = {
     palette: fluentKrakenThemePalette,
     semanticColors: fluentKrakenThemeSemanticColors
 };

--- a/src/Theming/FluentThemes.ts
+++ b/src/Theming/FluentThemes.ts
@@ -18,6 +18,7 @@ import {
     fluentKrakenThemeSemanticColors,
     fluentLightThemeSemanticColors
 } from './SemanticColors';
+import { IPartialExtendedTheme } from './Theme.types';
 
 export const getFluentTheme = (theme: Theme): ITheme => {
     switch (theme) {
@@ -39,7 +40,7 @@ export const getFluentTheme = (theme: Theme): ITheme => {
     then applies custom component style overrides.
 */
 const createThemeWithCustomStyles = (
-    themeInfo: IPartialTheme,
+    themeInfo: IPartialExtendedTheme,
     themeSetting: Theme
 ): FluentTheme => {
     const theme = createTheme(themeInfo);
@@ -53,22 +54,22 @@ const createThemeWithCustomStyles = (
     semanticColors: Specific UI color slots.  These are created using 
     the palette colors, but can be overriden for more stylistic control.
 */
-const fluentLightThemeInfo: IPartialTheme = {
+const fluentLightThemeInfo: IPartialExtendedTheme = {
     palette: fluentLightThemePalette,
     semanticColors: fluentLightThemeSemanticColors
 };
 
-const fluentDarkThemeInfo: IPartialTheme = {
+const fluentDarkThemeInfo: IPartialExtendedTheme = {
     palette: fluentDarkThemePalette,
     semanticColors: fluentDarkThemeSemanticColors
 };
 
-const fluentExplorerThemeInfo: IPartialTheme = {
+const fluentExplorerThemeInfo: IPartialExtendedTheme = {
     palette: fluentExplorerThemePalette,
     semanticColors: fluentExplorerThemeSemanticColors
 };
 
-const fluentKrakenThemeInfo: IPartialTheme = {
+const fluentKrakenThemeInfo: IPartialExtendedTheme = {
     palette: fluentKrakenThemePalette,
     semanticColors: fluentKrakenThemeSemanticColors
 };

--- a/src/Theming/Palettes.ts
+++ b/src/Theming/Palettes.ts
@@ -1,6 +1,7 @@
-import { IPalette, ITheme } from '@fluentui/react';
+import { ITheme } from '@fluentui/react';
 import { IPickerOption } from '../Components/Pickers/Internal/Picker.base.types';
 import { Theme } from '../Models/Constants/Enums';
+import { IExtendedPartialPalette } from './Theme.types';
 
 export const getPrimaryButtonCustomOverrides = (
     themeSetting: Theme,
@@ -77,7 +78,7 @@ export const defaultSwatchIcons: IPickerOption[] = [
 ];
 
 // Palettes created from https://aka.ms/themedesigner
-export const fluentLightThemePalette: Partial<IPalette> = {
+export const fluentLightThemePalette: IExtendedPartialPalette = {
     themePrimary: '#0078d4',
     themeLighterAlt: '#eff6fc',
     themeLighter: '#deecf9',
@@ -99,10 +100,14 @@ export const fluentLightThemePalette: Partial<IPalette> = {
     neutralPrimary: '#323130',
     neutralDark: '#201f1e',
     black: '#000000',
-    white: '#ffffff'
+    white: '#ffffff',
+    // custom colors
+    glassyBackground75: '#faf9f8bf',
+    glassyBackground90: '#faf9f8e6',
+    glassyBorder: '#d3d3d3'
 };
 
-export const fluentDarkThemePalette: Partial<IPalette> = {
+export const fluentDarkThemePalette: IExtendedPartialPalette = {
     themePrimary: '#058bf2',
     themeLighterAlt: '#00060a',
     themeLighter: '#011627',
@@ -124,10 +129,14 @@ export const fluentDarkThemePalette: Partial<IPalette> = {
     neutralPrimary: '#ffffff',
     neutralDark: '#f4f4f4',
     black: '#f8f8f8',
-    white: '#0d0f0e'
+    white: '#0d0f0e',
+    // custom colors
+    glassyBackground75: '#040404bf',
+    glassyBackground90: '#040404e6',
+    glassyBorder: '#424242'
 };
 
-export const fluentExplorerThemePalette: Partial<IPalette> = {
+export const fluentExplorerThemePalette: IExtendedPartialPalette = {
     themePrimary: '#60aaff',
     themeLighterAlt: '#f9fcff',
     themeLighter: '#e6f2ff',
@@ -149,10 +158,14 @@ export const fluentExplorerThemePalette: Partial<IPalette> = {
     neutralPrimary: '#ffffff',
     neutralDark: '#f4f4f4',
     black: '#f8f8f8',
-    white: '#222222'
+    white: '#222222',
+    // custom colors
+    glassyBackground75: '#404040bf',
+    glassyBackground90: '#404040e6',
+    glassyBorder: '#777'
 };
 
-export const fluentKrakenThemePalette: Partial<IPalette> = {
+export const fluentKrakenThemePalette: IExtendedPartialPalette = {
     themePrimary: '#52baed',
     themeLighterAlt: '#030709',
     themeLighter: '#0d1e26',
@@ -174,5 +187,9 @@ export const fluentKrakenThemePalette: Partial<IPalette> = {
     neutralPrimary: '#ffffff',
     neutralDark: '#f4f4f4',
     black: '#f8f8f8',
-    white: '#16203c'
+    white: '#16203c',
+    // custom colors
+    glassyBackground75: '#1e2c53bf',
+    glassyBackground90: '#1e2c53e6',
+    glassyBorder: '#303d5c'
 };

--- a/src/Theming/Theme.types.ts
+++ b/src/Theming/Theme.types.ts
@@ -16,7 +16,7 @@ export type IExtendedPartialPalette = Partial<IPalette> & CustomPalette;
  */
 export type IExtendedPalette = IPalette & CustomPalette;
 
-export interface IPartialExtendedTheme extends IPartialTheme {
+export interface IExtendedPartialTheme extends IPartialTheme {
     palette: Partial<IExtendedPartialPalette>; // override with our own palette type
 }
 export interface IExtendedTheme extends Theme {

--- a/src/Theming/Theme.types.ts
+++ b/src/Theming/Theme.types.ts
@@ -1,0 +1,24 @@
+import { IPalette, IPartialTheme, Theme } from '@fluentui/react';
+
+/** custom colors our app needs */
+export interface CustomPalette {
+    /** color code for the partially transparent color for modals and overlays */
+    glassyBackground75: string;
+    glassyBackground90: string;
+    /** color for the border when using the glassy background */
+    glassyBorder: string;
+}
+/** Partial version of the theme with only overrides populated */
+export type IExtendedPartialPalette = Partial<IPalette> & CustomPalette;
+
+/**
+ * Processed theme with all the values populated
+ */
+export type IExtendedPalette = IPalette & CustomPalette;
+
+export interface IPartialExtendedTheme extends IPartialTheme {
+    palette: Partial<IExtendedPartialPalette>; // override with our own palette type
+}
+export interface IExtendedTheme extends Theme {
+    palette: IExtendedPalette;
+}


### PR DESCRIPTION
### Summary of changes 🔍 
Adding a custom palette extension to the base theme. To use it, simply call `useExtendedTheme` instead of the fluent `useTheme` and pass that to your styles file as an `IExtendedTheme` instead of `ITheme` and you should be rocking and rolling. 

### Testing 🧪
None.