### PR TITLE
OAT: styling the model list to use the custom color palette

### DIFF
--- a/src/Components/CardboardList/CardboardListItem.styles.ts
+++ b/src/Components/CardboardList/CardboardListItem.styles.ts
@@ -135,7 +135,7 @@ export const getButtonStyles = memoizeFunction(
             root: [
                 {
                     alignItems: 'start', // top align everything
-                    border: `1px solid ${theme.semanticColors.buttonBackground}`,
+                    border: '1px solid transparent',
                     height: 'auto',
                     ':hover .cb-more-menu, :focus .cb-more-menu, .cb-more-menu-visible': {
                         opacity: 1

--- a/src/Components/CardboardList/CardboardListItem.styles.ts
+++ b/src/Components/CardboardList/CardboardListItem.styles.ts
@@ -135,7 +135,7 @@ export const getButtonStyles = memoizeFunction(
             root: [
                 {
                     alignItems: 'start', // top align everything
-                    border: 0,
+                    border: `1px solid ${theme.semanticColors.buttonBackground}`,
                     height: 'auto',
                     ':hover .cb-more-menu, :focus .cb-more-menu, .cb-more-menu-visible': {
                         opacity: 1
@@ -153,6 +153,7 @@ export const getButtonStyles = memoizeFunction(
             ],
             rootChecked: {
                 backgroundColor: theme.semanticColors.buttonBackgroundPressed,
+                borderColor: theme.palette.black,
                 ...(customStyles?.rootChecked as IRawStyle)
             },
             flexContainer: {

--- a/src/Components/CardboardList/CardboardListItem.styles.ts
+++ b/src/Components/CardboardList/CardboardListItem.styles.ts
@@ -127,11 +127,11 @@ export const getStyles = memoizeFunction(
 export const getButtonStyles = memoizeFunction(
     (
         itemType: CardboardGroupedListItemType | undefined,
-        isSelected: boolean | undefined,
         theme: Theme,
         customStyles: Partial<IButtonStyles> | undefined
     ): IButtonStyles => {
         return {
+            ...(customStyles as IButtonStyles),
             root: [
                 {
                     alignItems: 'start', // top align everything
@@ -141,13 +141,9 @@ export const getButtonStyles = memoizeFunction(
                         opacity: 1
                     },
                     padding: '8px 12px',
-                    width: '100%',
-                    ...(customStyles?.root as IRawStyle)
+                    width: '100%'
                 },
-                isSelected && {
-                    backgroundColor:
-                        theme.semanticColors.buttonBackgroundPressed
-                },
+                { ...(customStyles?.root as IRawStyle) },
                 itemType === 'item' && {
                     paddingLeft: 40
                 },
@@ -155,6 +151,10 @@ export const getButtonStyles = memoizeFunction(
                     borderTop: `1px solid ${theme.palette.neutralLight}`
                 }
             ],
+            rootChecked: {
+                backgroundColor: theme.semanticColors.buttonBackgroundPressed,
+                ...(customStyles?.rootChecked as IRawStyle)
+            },
             flexContainer: {
                 justifyContent: 'start',
                 ...(customStyles?.flexContainer as IRawStyle)

--- a/src/Components/CardboardList/CardboardListItem.tsx
+++ b/src/Components/CardboardList/CardboardListItem.tsx
@@ -92,7 +92,6 @@ export const CardboardListItem = <T extends unknown>(
     const classNames = getStyles(theme, isMenuOpen);
     const buttonStyles = getButtonStyles(
         itemType,
-        isSelected,
         theme,
         buttonProps?.customStyles
     );
@@ -105,6 +104,7 @@ export const CardboardListItem = <T extends unknown>(
                     data-testid={`cardboard-list-item-${listKey}-${index}`}
                     id={id}
                     selected={isSelected}
+                    checked={isSelected}
                     styles={buttonStyles}
                     onClick={onButtonClick}
                     onKeyPress={onButtonKeyPress}

--- a/src/Components/ElementsPanel/ViewerElementsPanel.styles.ts
+++ b/src/Components/ElementsPanel/ViewerElementsPanel.styles.ts
@@ -154,12 +154,14 @@ export const getElementsPanelButtonSyles = memoizeFunction(() => ({
     elementButton: {
         root: {
             background: 'transparent',
+            border: 'transparent',
             fontWeight: FontWeights.semibold
         }
     } as IButtonStyles,
     alertButton: {
         root: {
-            background: 'transparent'
+            background: 'transparent',
+            border: 'transparent'
         }
     } as IButtonStyles
 }));

--- a/src/Components/ElementsPanel/ViewerElementsPanel.styles.ts
+++ b/src/Components/ElementsPanel/ViewerElementsPanel.styles.ts
@@ -154,14 +154,12 @@ export const getElementsPanelButtonSyles = memoizeFunction(() => ({
     elementButton: {
         root: {
             background: 'transparent',
-            border: 'transparent',
             fontWeight: FontWeights.semibold
         }
     } as IButtonStyles,
     alertButton: {
         root: {
-            background: 'transparent',
-            border: 'transparent'
+            background: 'transparent'
         }
     } as IButtonStyles
 }));

--- a/src/Components/OATGraphViewer/Internal/GraphViewerControls/GraphViewerControls.styles.ts
+++ b/src/Components/OATGraphViewer/Internal/GraphViewerControls/GraphViewerControls.styles.ts
@@ -7,7 +7,8 @@ import { HEADER_BUTTON_HEIGHT } from '../../../../Models/Constants/StyleConstant
 import {
     CONTROLS_BOTTOM_OFFSET,
     CONTROLS_LEFT_OFFSET,
-    CONTROLS_Z_INDEX
+    CONTROLS_Z_INDEX,
+    getControlBackgroundColor
 } from '../../../../Models/Constants/OatStyleConstants';
 
 export const classPrefix = `${CardboardClassNamePrefix}-graph-viewer-controls`;
@@ -69,6 +70,15 @@ export const getStyles = (
             }
         ],
         subComponentStyles: {
+            controlButton: {
+                subComponentStyles: {
+                    button: {
+                        rootChecked: {
+                            backgroundColor: getControlBackgroundColor(theme)
+                        }
+                    }
+                }
+            },
             controlsStack: {
                 root: {
                     '> .react-flow__controls': {

--- a/src/Components/OATGraphViewer/Internal/GraphViewerControls/GraphViewerControls.tsx
+++ b/src/Components/OATGraphViewer/Internal/GraphViewerControls/GraphViewerControls.tsx
@@ -19,6 +19,7 @@ import {
 } from './GraphViewerControls.types';
 import { getStyles } from './GraphViewerControls.styles';
 import { useOatGraphContext } from '../../../../Models/Context/OatGraphContext/OatGraphContext';
+import { useExtendedTheme } from '../../../../Models/Hooks/useExtendedTheme';
 
 const getClassNames = classNamesFunction<
     IGraphViewerControlsStyleProps,
@@ -47,7 +48,7 @@ const GraphViewerControls: React.FC<IGraphViewerControlsProps> = (props) => {
 
     // styles
     const classNames = getClassNames(styles, {
-        theme: useTheme()
+        theme: useExtendedTheme()
     });
 
     return (
@@ -65,6 +66,7 @@ const GraphViewerControls: React.FC<IGraphViewerControlsProps> = (props) => {
                         })
                     }
                     isActive={oatGraphState.isModelListVisible}
+                    styles={classNames.subComponentStyles.controlButton}
                 />
             </HeaderControlGroup>
             <FocusZone style={{ zIndex: CONTROLS_Z_INDEX }}>
@@ -83,6 +85,7 @@ const GraphViewerControls: React.FC<IGraphViewerControlsProps> = (props) => {
                                 })
                             }
                             isActive={oatGraphState.isLegendVisible}
+                            styles={classNames.subComponentStyles.controlButton}
                         />
                     </HeaderControlGroup>
                     {/* built in controls for the graph */}
@@ -101,6 +104,7 @@ const GraphViewerControls: React.FC<IGraphViewerControlsProps> = (props) => {
                                 })
                             }
                             isActive={oatGraphState.isMiniMapVisible}
+                            styles={classNames.subComponentStyles.controlButton}
                         />
                     </HeaderControlGroup>
                 </Stack>

--- a/src/Components/OATGraphViewer/Internal/GraphViewerControls/GraphViewerControls.tsx
+++ b/src/Components/OATGraphViewer/Internal/GraphViewerControls/GraphViewerControls.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { Controls, ControlButton } from 'react-flow-renderer';
 import {
     classNamesFunction,
-    useTheme,
     styled,
     FocusZone,
     Icon,

--- a/src/Components/OATGraphViewer/Internal/GraphViewerControls/GraphViewerControls.types.ts
+++ b/src/Components/OATGraphViewer/Internal/GraphViewerControls/GraphViewerControls.types.ts
@@ -1,9 +1,6 @@
-import {
-    IStackStyles,
-    IStyle,
-    IStyleFunctionOrObject,
-    ITheme
-} from '@fluentui/react';
+import { IStackStyles, IStyle, IStyleFunctionOrObject } from '@fluentui/react';
+import { IExtendedTheme } from '../../../../Theming/Theme.types';
+import { IHeaderControlButtonStyles } from '../../../HeaderControlButton/HeaderControlButton.types';
 import { IHeaderControlGroupStyles } from '../../../HeaderControlGroup/HeaderControlGroup.types';
 
 export interface IGraphViewerControlsProps {
@@ -21,7 +18,7 @@ export interface IGraphViewerControlsProps {
 }
 
 export interface IGraphViewerControlsStyleProps {
-    theme: ITheme;
+    theme: IExtendedTheme;
 }
 export interface IGraphViewerControlsStyles {
     root: IStyle;
@@ -35,5 +32,6 @@ export interface IGraphViewerControlsStyles {
 
 export interface IGraphViewerControlsSubComponentStyles {
     controlsStack?: IStackStyles;
+    controlButton?: IHeaderControlButtonStyles;
     modelsListButtonGroup?: IHeaderControlGroupStyles;
 }

--- a/src/Components/OATGraphViewer/OATGraphViewer.styles.tsx
+++ b/src/Components/OATGraphViewer/OATGraphViewer.styles.tsx
@@ -17,6 +17,7 @@ import {
     getControlBackgroundColor,
     LOADING_Z_INDEX
 } from '../../Models/Constants/OatStyleConstants';
+import { useExtendedTheme } from '../../Models/Hooks/useExtendedTheme';
 import {
     IOATGraphViewerStyleProps,
     IOATGraphViewerStyles
@@ -74,7 +75,7 @@ export const getStyles = (
                     maxWidth: 400
                 },
                 calloutMain: {
-                    backgroundColor: theme.palette.glassyBackground90,
+                    backgroundColor: getControlBackgroundColor(theme),
                     overflow: 'hidden',
                     padding: 20
                 }
@@ -128,7 +129,7 @@ const classNames = {
 };
 
 export const getGraphViewerStyles = () => {
-    const theme = useTheme();
+    const theme = useExtendedTheme();
     return mergeStyleSets({
         container: [
             classNames.container,

--- a/src/Components/OATGraphViewer/OATGraphViewer.styles.tsx
+++ b/src/Components/OATGraphViewer/OATGraphViewer.styles.tsx
@@ -74,7 +74,7 @@ export const getStyles = (
                     maxWidth: 400
                 },
                 calloutMain: {
-                    backgroundColor: getControlBackgroundColor(theme),
+                    backgroundColor: theme.palette.glassyBackground90,
                     overflow: 'hidden',
                     padding: 20
                 }

--- a/src/Components/OATGraphViewer/OATGraphViewer.tsx
+++ b/src/Components/OATGraphViewer/OATGraphViewer.tsx
@@ -87,7 +87,6 @@ import { OatGraphContextActionType } from '../../Models/Context/OatGraphContext/
 import GraphViewerControls from './Internal/GraphViewerControls/GraphViewerControls';
 import OATModelList from '../OATModelList/OATModelList';
 import { getControlBackgroundColor } from '../../Models/Constants/OatStyleConstants';
-import BaseComponent from '../BaseComponent/BaseComponent';
 import { useExtendedTheme } from '../../Models/Hooks/useExtendedTheme';
 
 const debugLogging = false;

--- a/src/Components/OATGraphViewer/OATGraphViewer.tsx
+++ b/src/Components/OATGraphViewer/OATGraphViewer.tsx
@@ -7,7 +7,6 @@ import React, {
     useContext
 } from 'react';
 import {
-    useTheme,
     Label,
     SpinnerSize,
     Spinner,
@@ -88,6 +87,8 @@ import { OatGraphContextActionType } from '../../Models/Context/OatGraphContext/
 import GraphViewerControls from './Internal/GraphViewerControls/GraphViewerControls';
 import OATModelList from '../OATModelList/OATModelList';
 import { getControlBackgroundColor } from '../../Models/Constants/OatStyleConstants';
+import BaseComponent from '../BaseComponent/BaseComponent';
+import { useExtendedTheme } from '../../Models/Hooks/useExtendedTheme';
 
 const debugLogging = false;
 const logDebugConsole = getDebugLogger('OATGraphViewer', debugLogging);
@@ -108,7 +109,7 @@ const OATGraphViewerContent: React.FC<IOATGraphViewerProps> = (props) => {
 
     // hooks
     const { t } = useTranslation();
-    const theme = useTheme();
+    const theme = useExtendedTheme();
 
     // contexts
     const { execute } = useContext(CommandHistoryContext);

--- a/src/Components/OATGraphViewer/OATGraphViewer.types.ts
+++ b/src/Components/OATGraphViewer/OATGraphViewer.types.ts
@@ -1,10 +1,11 @@
 import {
     IStyleFunctionOrObject,
-    ITheme,
     IStyle,
     ICalloutContentStyles
 } from '@fluentui/react';
 import { SimulationNodeDatum } from 'd3-force';
+import { Theme } from '../../Models/Constants';
+import { IExtendedTheme } from '../../Theming/Theme.types';
 import { ElementNode } from './Internal/Classes/ElementNode';
 
 export type IOatGraphNode = SimulationNodeDatum & {
@@ -27,7 +28,7 @@ export interface IOATGraphViewerProps {
 }
 
 export interface IOATGraphViewerStyleProps {
-    theme: ITheme;
+    theme: IExtendedTheme;
 }
 export interface IOATGraphViewerStyles {
     root: IStyle;

--- a/src/Components/OATModelList/OATModelList.styles.tsx
+++ b/src/Components/OATModelList/OATModelList.styles.tsx
@@ -38,8 +38,7 @@ export const getStyles = (
         subComponentStyles: {
             listItem: (_props?: { isSelected: boolean }) => ({
                 root: {
-                    backgroundColor: 'transparent',
-                    borderColor: 'transparent'
+                    backgroundColor: 'transparent'
                 },
                 rootCheckedHovered: {
                     backgroundColor: theme.palette.neutralLighter

--- a/src/Components/OATModelList/OATModelList.styles.tsx
+++ b/src/Components/OATModelList/OATModelList.styles.tsx
@@ -38,7 +38,11 @@ export const getStyles = (
         subComponentStyles: {
             listItem: (_props?: { isSelected: boolean }) => ({
                 root: {
-                    backgroundColor: 'transparent'
+                    backgroundColor: 'transparent',
+                    borderColor: 'transparent'
+                },
+                rootCheckedHovered: {
+                    backgroundColor: theme.palette.neutralLighter
                 }
             }),
             rootStack: {

--- a/src/Components/OATModelList/OATModelList.styles.tsx
+++ b/src/Components/OATModelList/OATModelList.styles.tsx
@@ -21,7 +21,7 @@ export const getStyles = (
         listContainer: [
             classNames.listContainer,
             {
-                backgroundColor: theme.semanticColors.bodyBackground,
+                // backgroundColor: theme.semanticColors.bodyBackground,
                 width: '100%',
                 height: 'calc(100% - 32px)', // less the search box
                 overflowX: 'hidden',
@@ -36,6 +36,11 @@ export const getStyles = (
             }
         ],
         subComponentStyles: {
+            listItem: (_props?: { isSelected: boolean }) => ({
+                root: {
+                    backgroundColor: 'transparent'
+                }
+            }),
             rootStack: {
                 root: {
                     height: '100%',

--- a/src/Components/OATModelList/OATModelList.tsx
+++ b/src/Components/OATModelList/OATModelList.tsx
@@ -122,9 +122,15 @@ const OATModelList: React.FC<IOATModelListProps> = (props) => {
                     }
                 ];
             };
+            const isSelected = x['@id'] === oatPageState.selection?.modelId;
             const item: ICardboardListItem<DtdlInterface> = {
                 ariaLabel: getDisplayNameText(x),
-                isSelected: x['@id'] === oatPageState.selection?.modelId,
+                buttonProps: {
+                    customStyles: classNames.subComponentStyles.listItem?.({
+                        isSelected
+                    })
+                },
+                isSelected: isSelected,
                 item: x,
                 onClick: () => onModelSelected(x['@id']),
                 overflowMenuItems: getOverflowMenuItems(x),

--- a/src/Components/OATModelList/OATModelList.tsx
+++ b/src/Components/OATModelList/OATModelList.tsx
@@ -5,8 +5,7 @@ import {
     IList,
     SearchBox,
     Stack,
-    styled,
-    useTheme
+    styled
 } from '@fluentui/react';
 import { useTranslation } from 'react-i18next';
 import { getStyles } from './OATModelList.styles';
@@ -23,11 +22,12 @@ import {
     IOATModelListStyles,
     IOATModelListProps
 } from './OATModelList.types';
+import { useExtendedTheme } from '../../Models/Hooks/useExtendedTheme';
 
 const debugLogging = false;
 const logDebugConsole = getDebugLogger('OatModelList', debugLogging);
 
-const LIST_ITEM_HEIGHT = 51;
+const LIST_ITEM_HEIGHT = 53;
 
 const getClassNames = classNamesFunction<
     IOATModelListStyleProps,
@@ -173,7 +173,7 @@ const OATModelList: React.FC<IOATModelListProps> = (props) => {
     }, [listItems, oatPageState.selection]);
 
     // styles
-    const classNames = getClassNames(styles, { theme: useTheme() });
+    const classNames = getClassNames(styles, { theme: useExtendedTheme() });
 
     const listHasItems = listItems.length > 0;
 

--- a/src/Components/OATModelList/OATModelList.types.ts
+++ b/src/Components/OATModelList/OATModelList.types.ts
@@ -1,11 +1,11 @@
 import {
     IStyleFunctionOrObject,
-    ITheme,
     IStyle,
     ISearchBoxStyles,
     IStackStyles,
     IButtonStyles
 } from '@fluentui/react';
+import { IExtendedTheme } from '../../Theming/Theme.types';
 
 export interface IOATModelListProps {
     /**
@@ -18,7 +18,7 @@ export interface IOATModelListProps {
 }
 
 export interface IOATModelListStyleProps {
-    theme: ITheme;
+    theme: IExtendedTheme;
 }
 export interface IOATModelListStyles {
     root: IStyle;

--- a/src/Components/OATModelList/OATModelList.types.ts
+++ b/src/Components/OATModelList/OATModelList.types.ts
@@ -3,7 +3,8 @@ import {
     ITheme,
     IStyle,
     ISearchBoxStyles,
-    IStackStyles
+    IStackStyles,
+    IButtonStyles
 } from '@fluentui/react';
 
 export interface IOATModelListProps {
@@ -31,6 +32,7 @@ export interface IOATModelListStyles {
 }
 
 export interface IOATModelListSubComponentStyles {
+    listItem?: IStyleFunctionOrObject<{ isSelected: boolean }, IButtonStyles>;
     rootStack: IStackStyles;
     searchbox?: ISearchBoxStyles;
 }

--- a/src/Models/Constants/OatStyleConstants.ts
+++ b/src/Models/Constants/OatStyleConstants.ts
@@ -1,4 +1,4 @@
-import { ITheme } from '@fluentui/theme';
+import { IExtendedTheme } from '../../Theming/Theme.types';
 
 export const OAT_HEADER_HEIGHT = 76;
 
@@ -7,5 +7,5 @@ export const CONTROLS_BOTTOM_OFFSET = 30;
 export const CONTROLS_Z_INDEX = 6;
 export const LOADING_Z_INDEX = CONTROLS_Z_INDEX + 1;
 
-export const getControlBackgroundColor = (theme: ITheme): string =>
-    theme.palette.neutralLight;
+export const getControlBackgroundColor = (theme: IExtendedTheme): string =>
+    theme.semanticColors.bodyBackgroundChecked;

--- a/src/Models/Hooks/useExtendedTheme.ts
+++ b/src/Models/Hooks/useExtendedTheme.ts
@@ -1,0 +1,10 @@
+import { useTheme } from '@fluentui/react';
+import { IExtendedTheme } from '../../Theming/Theme.types';
+
+/**
+ * Gives back the current theme object for the app
+ * @returns the curren theme object with the right colors for the selected theme
+ */
+export const useExtendedTheme = () => {
+    return useTheme() as IExtendedTheme;
+};

--- a/src/Models/Hooks/useExtendedTheme.ts
+++ b/src/Models/Hooks/useExtendedTheme.ts
@@ -3,7 +3,7 @@ import { IExtendedTheme } from '../../Theming/Theme.types';
 
 /**
  * Gives back the current theme object for the app
- * @returns the curren theme object with the right colors for the selected theme
+ * @returns the current theme object with the right colors for the selected theme
  */
 export const useExtendedTheme = () => {
     return useTheme() as IExtendedTheme;

--- a/src/Pages/OATEditorPage/OATEditorPage.stories.tsx
+++ b/src/Pages/OATEditorPage/OATEditorPage.stories.tsx
@@ -7,8 +7,9 @@ import {
 import { ComponentStory } from '@storybook/react';
 
 const wrapperStyle: React.CSSProperties = {
-    width: 'auto',
-    padding: 8
+    height: '100%',
+    width: '100%',
+    position: 'absolute'
 };
 export default {
     title: 'Pages/OATEditorPage',
@@ -23,7 +24,9 @@ const Template: SceneBuilderStory = (
 ) => {
     return (
         <OATEditorPage
-            selectedTheme={context.parameters.theme || context.globals.theme}
+            theme={context.parameters.theme || context.globals.theme}
+            locale={context.globals.locale}
+            localeStrings={context.globals.locale}
         />
     );
 };

--- a/src/Pages/OATEditorPage/OATEditorPage.tsx
+++ b/src/Pages/OATEditorPage/OATEditorPage.tsx
@@ -15,12 +15,13 @@ import { getDebugLogger } from '../../Models/Services/Utils';
 import { IOATEditorPageProps } from './OATEditorPage.types';
 import { OatPageContextProvider } from '../../Models/Context/OatPageContext/OatPageContext';
 import { Stack } from '@fluentui/react';
+import BaseComponent from '../../Components/BaseComponent/BaseComponent';
 
 const debugLogging = false;
 const logDebugConsole = getDebugLogger('OATEditorPage', debugLogging);
 
 const OATEditorPageContent: React.FC<IOATEditorPageProps> = (props) => {
-    const { selectedTheme } = props;
+    const { locale, localeStrings, theme } = props;
 
     // hooks
 
@@ -42,22 +43,28 @@ const OATEditorPageContent: React.FC<IOATEditorPageProps> = (props) => {
 
     return (
         <>
-            <div className={editorPageStyles.container}>
+            <BaseComponent
+                theme={theme}
+                locale={locale}
+                localeStrings={localeStrings}
+                containerClassName={editorPageStyles.container}
+                disableDefaultStyles={true}
+            >
                 <OATHeader />
                 <Stack horizontal className={editorPageStyles.component}>
                     <div className={editorPageStyles.viewerContainer}>
-                        <OATGraphViewerContent />
+                        <OATGraphViewerContent selectedTheme={theme} />
                     </div>
                     <div className={editorPageStyles.propertyEditorContainer}>
                         <OATPropertyEditor
-                            theme={selectedTheme}
+                            theme={theme}
                             languages={languages}
                         />
                     </div>
                 </Stack>
-            </div>
-            <OATErrorHandlingModal />
-            <OATConfirmDeleteModal />
+                <OATErrorHandlingModal />
+                <OATConfirmDeleteModal />
+            </BaseComponent>
         </>
     );
 };

--- a/src/Pages/OATEditorPage/OATEditorPage.types.ts
+++ b/src/Pages/OATEditorPage/OATEditorPage.types.ts
@@ -1,12 +1,14 @@
-import { IOATNodePosition, Theme } from '../../Models/Constants';
+import { IOATNodePosition, Locale, Theme } from '../../Models/Constants';
 import {
     DtdlInterface,
     DtdlProperty
 } from '../../Models/Constants/dtdlInterfaces';
 
 export interface IOATEditorPageProps {
-    selectedTheme: Theme;
     disableStorage?: boolean;
+    locale: Locale;
+    localeStrings?: Record<string, any>;
+    theme: Theme;
 }
 
 export interface IOATError {

--- a/src/Theming/FluentThemes.ts
+++ b/src/Theming/FluentThemes.ts
@@ -1,9 +1,4 @@
-import {
-    createTheme,
-    IPartialTheme,
-    ITheme,
-    Theme as FluentTheme
-} from '@fluentui/react';
+import { createTheme, ITheme, Theme as FluentTheme } from '@fluentui/react';
 import {
     fluentDarkThemePalette,
     fluentExplorerThemePalette,

--- a/src/Theming/FluentThemes.ts
+++ b/src/Theming/FluentThemes.ts
@@ -13,7 +13,7 @@ import {
     fluentKrakenThemeSemanticColors,
     fluentLightThemeSemanticColors
 } from './SemanticColors';
-import { IPartialExtendedTheme } from './Theme.types';
+import { IExtendedPartialTheme } from './Theme.types';
 
 export const getFluentTheme = (theme: Theme): ITheme => {
     switch (theme) {
@@ -35,7 +35,7 @@ export const getFluentTheme = (theme: Theme): ITheme => {
     then applies custom component style overrides.
 */
 const createThemeWithCustomStyles = (
-    themeInfo: IPartialExtendedTheme,
+    themeInfo: IExtendedPartialTheme,
     themeSetting: Theme
 ): FluentTheme => {
     const theme = createTheme(themeInfo);
@@ -49,22 +49,22 @@ const createThemeWithCustomStyles = (
     semanticColors: Specific UI color slots.  These are created using 
     the palette colors, but can be overriden for more stylistic control.
 */
-const fluentLightThemeInfo: IPartialExtendedTheme = {
+const fluentLightThemeInfo: IExtendedPartialTheme = {
     palette: fluentLightThemePalette,
     semanticColors: fluentLightThemeSemanticColors
 };
 
-const fluentDarkThemeInfo: IPartialExtendedTheme = {
+const fluentDarkThemeInfo: IExtendedPartialTheme = {
     palette: fluentDarkThemePalette,
     semanticColors: fluentDarkThemeSemanticColors
 };
 
-const fluentExplorerThemeInfo: IPartialExtendedTheme = {
+const fluentExplorerThemeInfo: IExtendedPartialTheme = {
     palette: fluentExplorerThemePalette,
     semanticColors: fluentExplorerThemeSemanticColors
 };
 
-const fluentKrakenThemeInfo: IPartialExtendedTheme = {
+const fluentKrakenThemeInfo: IExtendedPartialTheme = {
     palette: fluentKrakenThemePalette,
     semanticColors: fluentKrakenThemeSemanticColors
 };

--- a/src/Theming/FluentThemes.ts
+++ b/src/Theming/FluentThemes.ts
@@ -18,6 +18,7 @@ import {
     fluentKrakenThemeSemanticColors,
     fluentLightThemeSemanticColors
 } from './SemanticColors';
+import { IPartialExtendedTheme } from './Theme.types';
 
 export const getFluentTheme = (theme: Theme): ITheme => {
     switch (theme) {
@@ -39,7 +40,7 @@ export const getFluentTheme = (theme: Theme): ITheme => {
     then applies custom component style overrides.
 */
 const createThemeWithCustomStyles = (
-    themeInfo: IPartialTheme,
+    themeInfo: IPartialExtendedTheme,
     themeSetting: Theme
 ): FluentTheme => {
     const theme = createTheme(themeInfo);
@@ -53,22 +54,22 @@ const createThemeWithCustomStyles = (
     semanticColors: Specific UI color slots.  These are created using 
     the palette colors, but can be overriden for more stylistic control.
 */
-const fluentLightThemeInfo: IPartialTheme = {
+const fluentLightThemeInfo: IPartialExtendedTheme = {
     palette: fluentLightThemePalette,
     semanticColors: fluentLightThemeSemanticColors
 };
 
-const fluentDarkThemeInfo: IPartialTheme = {
+const fluentDarkThemeInfo: IPartialExtendedTheme = {
     palette: fluentDarkThemePalette,
     semanticColors: fluentDarkThemeSemanticColors
 };
 
-const fluentExplorerThemeInfo: IPartialTheme = {
+const fluentExplorerThemeInfo: IPartialExtendedTheme = {
     palette: fluentExplorerThemePalette,
     semanticColors: fluentExplorerThemeSemanticColors
 };
 
-const fluentKrakenThemeInfo: IPartialTheme = {
+const fluentKrakenThemeInfo: IPartialExtendedTheme = {
     palette: fluentKrakenThemePalette,
     semanticColors: fluentKrakenThemeSemanticColors
 };

--- a/src/Theming/Palettes.ts
+++ b/src/Theming/Palettes.ts
@@ -1,6 +1,7 @@
-import { IPalette, ITheme } from '@fluentui/react';
+import { ITheme } from '@fluentui/react';
 import { IPickerOption } from '../Components/Pickers/Internal/Picker.base.types';
 import { Theme } from '../Models/Constants/Enums';
+import { IExtendedPartialPalette } from './Theme.types';
 
 export const getPrimaryButtonCustomOverrides = (
     themeSetting: Theme,
@@ -77,7 +78,7 @@ export const defaultSwatchIcons: IPickerOption[] = [
 ];
 
 // Palettes created from https://aka.ms/themedesigner
-export const fluentLightThemePalette: Partial<IPalette> = {
+export const fluentLightThemePalette: IExtendedPartialPalette = {
     themePrimary: '#0078d4',
     themeLighterAlt: '#eff6fc',
     themeLighter: '#deecf9',
@@ -99,10 +100,14 @@ export const fluentLightThemePalette: Partial<IPalette> = {
     neutralPrimary: '#323130',
     neutralDark: '#201f1e',
     black: '#000000',
-    white: '#ffffff'
+    white: '#ffffff',
+    // custom colors
+    glassyBackground75: '#faf9f8bf',
+    glassyBackground90: '#faf9f8e6',
+    glassyBorder: '#d3d3d3'
 };
 
-export const fluentDarkThemePalette: Partial<IPalette> = {
+export const fluentDarkThemePalette: IExtendedPartialPalette = {
     themePrimary: '#058bf2',
     themeLighterAlt: '#00060a',
     themeLighter: '#011627',
@@ -124,10 +129,14 @@ export const fluentDarkThemePalette: Partial<IPalette> = {
     neutralPrimary: '#ffffff',
     neutralDark: '#f4f4f4',
     black: '#f8f8f8',
-    white: '#0d0f0e'
+    white: '#0d0f0e',
+    // custom colors
+    glassyBackground75: '#040404bf',
+    glassyBackground90: '#040404e6',
+    glassyBorder: '#424242'
 };
 
-export const fluentExplorerThemePalette: Partial<IPalette> = {
+export const fluentExplorerThemePalette: IExtendedPartialPalette = {
     themePrimary: '#60aaff',
     themeLighterAlt: '#f9fcff',
     themeLighter: '#e6f2ff',
@@ -149,10 +158,14 @@ export const fluentExplorerThemePalette: Partial<IPalette> = {
     neutralPrimary: '#ffffff',
     neutralDark: '#f4f4f4',
     black: '#f8f8f8',
-    white: '#222222'
+    white: '#222222',
+    // custom colors
+    glassyBackground75: '#404040bf',
+    glassyBackground90: '#404040e6',
+    glassyBorder: '#777'
 };
 
-export const fluentKrakenThemePalette: Partial<IPalette> = {
+export const fluentKrakenThemePalette: IExtendedPartialPalette = {
     themePrimary: '#52baed',
     themeLighterAlt: '#030709',
     themeLighter: '#0d1e26',
@@ -174,5 +187,9 @@ export const fluentKrakenThemePalette: Partial<IPalette> = {
     neutralPrimary: '#ffffff',
     neutralDark: '#f4f4f4',
     black: '#f8f8f8',
-    white: '#16203c'
+    white: '#16203c',
+    // custom colors
+    glassyBackground75: '#1e2c53bf',
+    glassyBackground90: '#1e2c53e6',
+    glassyBorder: '#303d5c'
 };

--- a/src/Theming/Theme.types.ts
+++ b/src/Theming/Theme.types.ts
@@ -16,7 +16,7 @@ export type IExtendedPartialPalette = Partial<IPalette> & CustomPalette;
  */
 export type IExtendedPalette = IPalette & CustomPalette;
 
-export interface IPartialExtendedTheme extends IPartialTheme {
+export interface IExtendedPartialTheme extends IPartialTheme {
     palette: Partial<IExtendedPartialPalette>; // override with our own palette type
 }
 export interface IExtendedTheme extends Theme {

--- a/src/Theming/Theme.types.ts
+++ b/src/Theming/Theme.types.ts
@@ -1,0 +1,24 @@
+import { IPalette, IPartialTheme, Theme } from '@fluentui/react';
+
+/** custom colors our app needs */
+export interface CustomPalette {
+    /** color code for the partially transparent color for modals and overlays */
+    glassyBackground75: string;
+    glassyBackground90: string;
+    /** color for the border when using the glassy background */
+    glassyBorder: string;
+}
+/** Partial version of the theme with only overrides populated */
+export type IExtendedPartialPalette = Partial<IPalette> & CustomPalette;
+
+/**
+ * Processed theme with all the values populated
+ */
+export type IExtendedPalette = IPalette & CustomPalette;
+
+export interface IPartialExtendedTheme extends IPartialTheme {
+    palette: Partial<IExtendedPartialPalette>; // override with our own palette type
+}
+export interface IExtendedTheme extends Theme {
+    palette: IExtendedPalette;
+}


### PR DESCRIPTION
### Summary of changes 🔍 
Styling the model list to match designs.

Before
![image](https://user-images.githubusercontent.com/57726991/198739316-453689ec-26fe-4c0f-8812-6d55a79b7fcf.png)

After
![image](https://user-images.githubusercontent.com/57726991/198739382-2365971c-7ec1-4bc5-ab64-07869564d833.png)


### Testing 🧪
 > [ Add any special instructions needed to test or view your changes such as environment URLs or other config details. ]

### Checklist ✔️
- [ ] Linked associated issue (if present)
- [ ] Added relevant labels
- [ ] Requested developer reviews
- [ ] Request UI review from design / PM
- [ ] Verify all code checks are passing