### PR TITLE
Fix loc name in form subtitle

### DIFF
--- a/src/Components/ADT3DSceneBuilder/Internal/VisualRuleForm/VisualRuleForm.tsx
+++ b/src/Components/ADT3DSceneBuilder/Internal/VisualRuleForm/VisualRuleForm.tsx
@@ -350,7 +350,7 @@ const VisualRuleForm: React.FC<IVisualRuleFormProps> = (props) => {
                 <div className={commonFormStyles.header}>
                     <Stack tokens={{ childrenGap: 12 }}>
                         <div className={classNames.descriptionContainer}>
-                            {t('3dSceneBuilder.visualRuleForm.formSubtitle')}
+                            {t('3dSceneBuilder.visualRuleForm.formSubTitle')}
                         </div>
                         <TextField
                             label={t('displayName')}


### PR DESCRIPTION
### Summary of changes 🔍 
Quick fix for a typo in Visual rule form subtitle

Before:
![image](https://user-images.githubusercontent.com/55852250/199320137-03910f4f-ec36-4290-a96c-ab6c5549ed46.png)

Now:
![image](https://user-images.githubusercontent.com/55852250/199320249-d063f30d-b220-4d87-8274-d849b3931cab.png)

### Testing 🧪
N/A

### Checklist ✔️
- [ ] Linked associated issue (if present)
- [ ] Added relevant labels
- [ ] Requested developer reviews
- [ ] Request UI review from design / PM
- [ ] Verify all code checks are passing