### PR TITLE
Fix target for conditions callout

### DIFF
--- a/src/Components/ADT3DSceneBuilder/Internal/VisualRuleForm/Internal/ConditionsList.tsx
+++ b/src/Components/ADT3DSceneBuilder/Internal/VisualRuleForm/Internal/ConditionsList.tsx
@@ -45,6 +45,9 @@ const defaultCalloutInfo: CalloutInfo = {
     selectedTarget: ''
 };
 
+const CONDITIONS_ITEM_ID_PREFIX = 'cb-visual-rule-conditions-list-item-';
+const CONDITIONS_ADD_BUTTON_ID = 'cb-visual-rule-add-condition-button';
+
 const ConditionsList: React.FC<IConditionsListProps> = (props) => {
     // Props
     const {
@@ -77,7 +80,7 @@ const ConditionsList: React.FC<IConditionsListProps> = (props) => {
                 valueRangeType,
                 getNextColor(valueRanges, defaultSwatchColors)
             ),
-            selectedTarget: `#${LIST_KEY}`
+            selectedTarget: `#${CONDITIONS_ADD_BUTTON_ID}`
         });
     }, [valueRangeType]);
 
@@ -99,7 +102,9 @@ const ConditionsList: React.FC<IConditionsListProps> = (props) => {
                         selectedCondition: valueRanges.find(
                             (vr) => vr.id === conditionId
                         ),
-                        selectedTarget: `#${LIST_KEY}`
+                        selectedTarget: `#${
+                            CONDITIONS_ITEM_ID_PREFIX + conditionId
+                        }`
                     });
                 },
                 data: {
@@ -156,6 +161,7 @@ const ConditionsList: React.FC<IConditionsListProps> = (props) => {
                 (condition) => {
                     const showBadgeIcon = hasBadge(condition.iconName);
                     return {
+                        id: CONDITIONS_ITEM_ID_PREFIX + condition.id,
                         item: condition,
                         ariaLabel: `Condition for ${condition.primaryText}`,
                         textPrimary: condition.primaryText,
@@ -174,7 +180,9 @@ const ConditionsList: React.FC<IConditionsListProps> = (props) => {
                                 selectedCondition: valueRanges.find(
                                     (vr) => vr.id === condition.id
                                 ),
-                                selectedTarget: `#${LIST_KEY}`
+                                selectedTarget: `#${
+                                    CONDITIONS_ITEM_ID_PREFIX + condition.id
+                                }`
                             });
                         },
                         buttonProps: {
@@ -213,8 +221,8 @@ const ConditionsList: React.FC<IConditionsListProps> = (props) => {
                         items={conditions}
                     />
                     <ActionButton
-                        id={'visual-rule-add-condition'}
-                        data-testid={'visual-rule-add-condition'}
+                        id={CONDITIONS_ADD_BUTTON_ID}
+                        data-testid={CONDITIONS_ADD_BUTTON_ID}
                         styles={classNames.subComponentStyles.addButton?.()}
                         onClick={handleOpenNewConditionFlyout}
                     >

--- a/src/Components/ADT3DSceneBuilder/Internal/VisualRuleForm/Internal/ConditionsList.tsx
+++ b/src/Components/ADT3DSceneBuilder/Internal/VisualRuleForm/Internal/ConditionsList.tsx
@@ -46,7 +46,7 @@ const defaultCalloutInfo: CalloutInfo = {
 };
 
 const CONDITIONS_ITEM_ID_PREFIX = 'cb-visual-rule-conditions-list-item-';
-const CONDITIONS_ADD_BUTTON_ID = 'cb-visual-rule-add-condition-button';
+const CONDITIONS_ADD_BUTTON_TEST_ID = 'cb-visual-rule-add-condition-button';
 
 const ConditionsList: React.FC<IConditionsListProps> = (props) => {
     // Props
@@ -61,12 +61,17 @@ const ConditionsList: React.FC<IConditionsListProps> = (props) => {
 
     // Hooks
     const { t } = useTranslation();
+    const addButtonId = useId('cb-add-conditions');
     const LIST_KEY = useId('cb-visual-rule-conditions-list');
 
     // Constants
     const classNames = getClassNames(styles, {
         theme: useTheme()
     });
+
+    const getListItemId = (id: string) => {
+        return CONDITIONS_ITEM_ID_PREFIX + id;
+    };
 
     const [calloutInfo, setCalloutInfo] = useState<CalloutInfo>(
         defaultCalloutInfo
@@ -80,7 +85,7 @@ const ConditionsList: React.FC<IConditionsListProps> = (props) => {
                 valueRangeType,
                 getNextColor(valueRanges, defaultSwatchColors)
             ),
-            selectedTarget: `#${CONDITIONS_ADD_BUTTON_ID}`
+            selectedTarget: `#${addButtonId}`
         });
     }, [valueRangeType]);
 
@@ -102,9 +107,7 @@ const ConditionsList: React.FC<IConditionsListProps> = (props) => {
                         selectedCondition: valueRanges.find(
                             (vr) => vr.id === conditionId
                         ),
-                        selectedTarget: `#${
-                            CONDITIONS_ITEM_ID_PREFIX + conditionId
-                        }`
+                        selectedTarget: `#${getListItemId(conditionId)}`
                     });
                 },
                 data: {
@@ -161,7 +164,7 @@ const ConditionsList: React.FC<IConditionsListProps> = (props) => {
                 (condition) => {
                     const showBadgeIcon = hasBadge(condition.iconName);
                     return {
-                        id: CONDITIONS_ITEM_ID_PREFIX + condition.id,
+                        id: getListItemId(condition.id),
                         item: condition,
                         ariaLabel: `Condition for ${condition.primaryText}`,
                         textPrimary: condition.primaryText,
@@ -180,9 +183,9 @@ const ConditionsList: React.FC<IConditionsListProps> = (props) => {
                                 selectedCondition: valueRanges.find(
                                     (vr) => vr.id === condition.id
                                 ),
-                                selectedTarget: `#${
-                                    CONDITIONS_ITEM_ID_PREFIX + condition.id
-                                }`
+                                selectedTarget: `#${getListItemId(
+                                    condition.id
+                                )}`
                             });
                         },
                         buttonProps: {
@@ -221,8 +224,8 @@ const ConditionsList: React.FC<IConditionsListProps> = (props) => {
                         items={conditions}
                     />
                     <ActionButton
-                        id={CONDITIONS_ADD_BUTTON_ID}
-                        data-testid={CONDITIONS_ADD_BUTTON_ID}
+                        id={addButtonId}
+                        data-testid={CONDITIONS_ADD_BUTTON_TEST_ID}
                         styles={classNames.subComponentStyles.addButton?.()}
                         onClick={handleOpenNewConditionFlyout}
                     >


### PR DESCRIPTION
### Summary of changes 🔍 
Fixed the target HTML element for Conditions callout. Now it targets the Cardboard list items instead of the list itself.

### Testing 🧪
Open visual rules list form, click on several Condition list items and notice how the callout changes where it is rendered.

### Checklist ✔️
- [ ] Linked associated issue (if present)
- [ ] Added relevant labels
- [ ] Requested developer reviews
- [ ] Request UI review from design / PM
- [ ] Verify all code checks are passing