### PR TITLE
[Bugfix] Highchart module import fix for build

### DIFF
--- a/src/Components/HighChartsWrapper/HighChartsWrapper.tsx
+++ b/src/Components/HighChartsWrapper/HighChartsWrapper.tsx
@@ -98,8 +98,6 @@ const HighChartsWrapper: React.FC<IHighChartsWrapperProps> = (props) => {
     });
 
     //side-effects
-    useEffect(() => {}, []);
-
     useEffect(() => {
         if (!isLoading) {
             chartComponentRef.current?.chart?.hideLoading();

--- a/src/Components/HighChartsWrapper/HighChartsWrapper.tsx
+++ b/src/Components/HighChartsWrapper/HighChartsWrapper.tsx
@@ -16,12 +16,13 @@ import {
 } from 'highcharts';
 import Highcharts from 'highcharts/highstock';
 import HighchartsReact from 'highcharts-react-official';
-import { useTranslation } from 'react-i18next';
+import HighchartsAccessibility from 'highcharts/modules/accessibility';
 import NoDataToDisplay from 'highcharts/modules/no-data-to-display';
+import { useTranslation } from 'react-i18next';
 import { deepCopy } from '../../Models/Services/Utils';
 import { IDataHistoryAggregationType } from '../../Models/Types/Generated/3DScenesConfiguration-v1.0.0';
 NoDataToDisplay(Highcharts);
-require('highcharts/modules/accessibility')(Highcharts);
+HighchartsAccessibility(Highcharts);
 
 const getClassNames = classNamesFunction<
     IHighChartsWrapperStyleProps,
@@ -97,6 +98,8 @@ const HighChartsWrapper: React.FC<IHighChartsWrapperProps> = (props) => {
     });
 
     //side-effects
+    useEffect(() => {}, []);
+
     useEffect(() => {
         if (!isLoading) {
             chartComponentRef.current?.chart?.hideLoading();


### PR DESCRIPTION
### Summary of changes 🔍 
Fix for build. The error I was getting in flights app was .defaultOptions and I downloaded the HighCharts stock zipped library to see where it is called and noticed that it was in accessibility module. I noticed that I used "import" to import one module but "require" for another one. Used import for accessibility module too as suggested [here](https://github.com/highcharts/highcharts-react/issues/141)

### Testing 🧪
You can test by building cardboard locally with `>npm run build` and install it in flights app (on the branch that my PR is up for) using `>npm install <full path to tgz file in build artifacts folder in cardboard>` and run there with `>npm start`.

### Checklist ✔️
- [ ] Linked associated issue (if present)
- [x] Added relevant labels
- [x] Requested developer reviews
- [ ] Request UI review from design / PM
- [x] Verify all code checks are passing