### PR TITLE
OAT: Restyle property editor

### DIFF
--- a/src/Components/OATGraphViewer/Internal/GraphViewerControls/GraphViewerControls.styles.ts
+++ b/src/Components/OATGraphViewer/Internal/GraphViewerControls/GraphViewerControls.styles.ts
@@ -25,7 +25,7 @@ export const getStyles = (
             classNames.root,
             {
                 display: 'grid',
-                gridTemplateColumns: '1fr 1fr',
+                gridTemplateColumns: `0.5fr 1fr 0.5fr`,
                 left: CONTROLS_LEFT_OFFSET,
                 bottom: CONTROLS_BOTTOM_OFFSET,
                 position: 'absolute',
@@ -81,6 +81,7 @@ export const getStyles = (
             },
             controlsStack: {
                 root: {
+                    justifyContent: 'center',
                     '> .react-flow__controls': {
                         position: 'unset',
                         left: 'unset'

--- a/src/Components/OATGraphViewer/Internal/GraphViewerControls/GraphViewerControls.styles.ts
+++ b/src/Components/OATGraphViewer/Internal/GraphViewerControls/GraphViewerControls.styles.ts
@@ -6,7 +6,7 @@ import { CardboardClassNamePrefix } from '../../../../Models/Constants/Constants
 import { HEADER_BUTTON_HEIGHT } from '../../../../Models/Constants/StyleConstants';
 import {
     CONTROLS_BOTTOM_OFFSET,
-    CONTROLS_LEFT_OFFSET,
+    CONTROLS_SIDE_OFFSET,
     CONTROLS_Z_INDEX,
     getControlBackgroundColor
 } from '../../../../Models/Constants/OatStyleConstants';
@@ -26,7 +26,7 @@ export const getStyles = (
             {
                 display: 'grid',
                 gridTemplateColumns: `0.5fr 1fr 0.5fr`,
-                left: CONTROLS_LEFT_OFFSET,
+                left: CONTROLS_SIDE_OFFSET,
                 bottom: CONTROLS_BOTTOM_OFFSET,
                 position: 'absolute',
                 width: '100%',

--- a/src/Components/OATGraphViewer/OATGraphViewer.styles.tsx
+++ b/src/Components/OATGraphViewer/OATGraphViewer.styles.tsx
@@ -13,10 +13,12 @@ import {
 import { CardboardClassNamePrefix } from '../../Models/Constants';
 import {
     CONTROLS_BOTTOM_OFFSET,
+    CONTROLS_CALLOUT_OFFSET,
     CONTROLS_Z_INDEX,
     getControlBackgroundColor,
     LOADING_Z_INDEX
 } from '../../Models/Constants/OatStyleConstants';
+import { HEADER_BUTTON_HEIGHT } from '../../Models/Constants/StyleConstants';
 import { useExtendedTheme } from '../../Models/Hooks/useExtendedTheme';
 import {
     IOATGraphViewerStyleProps,
@@ -40,7 +42,11 @@ export const getStyles = (
         graphMiniMapContainer: [
             classNames2.minimapContainer,
             {
-                bottom: CONTROLS_BOTTOM_OFFSET + CONTROLS_BOTTOM_OFFSET, // extra offset so they don't overlap till we have room off to the right
+                bottom:
+                    CONTROLS_BOTTOM_OFFSET +
+                    HEADER_BUTTON_HEIGHT +
+                    CONTROLS_CALLOUT_OFFSET -
+                    10,
                 position: 'absolute',
                 right: 0,
                 '.react-flow__minimap': {

--- a/src/Components/OATGraphViewer/OATGraphViewer.styles.tsx
+++ b/src/Components/OATGraphViewer/OATGraphViewer.styles.tsx
@@ -83,7 +83,7 @@ export const getStyles = (
                 calloutMain: {
                     backgroundColor: getControlBackgroundColor(theme),
                     overflow: 'hidden',
-                    padding: 20
+                    padding: 16
                 }
             }
         }

--- a/src/Components/OATGraphViewer/OATGraphViewer.tsx
+++ b/src/Components/OATGraphViewer/OATGraphViewer.tsx
@@ -86,7 +86,10 @@ import {
 import { OatGraphContextActionType } from '../../Models/Context/OatGraphContext/OatGraphContext.types';
 import GraphViewerControls from './Internal/GraphViewerControls/GraphViewerControls';
 import OATModelList from '../OATModelList/OATModelList';
-import { getControlBackgroundColor } from '../../Models/Constants/OatStyleConstants';
+import {
+    CONTROLS_CALLOUT_OFFSET,
+    getControlBackgroundColor
+} from '../../Models/Constants/OatStyleConstants';
 import { useExtendedTheme } from '../../Models/Hooks/useExtendedTheme';
 
 const debugLogging = false;
@@ -857,7 +860,7 @@ const OATGraphViewerContent: React.FC<IOATGraphViewerProps> = (props) => {
                     {oatGraphState.isModelListVisible && (
                         <Callout
                             directionalHint={DirectionalHint.bottomLeftEdge}
-                            gapSpace={16}
+                            gapSpace={CONTROLS_CALLOUT_OFFSET}
                             isBeakVisible={false}
                             styles={
                                 classNames.subComponentStyles.modelsListCallout

--- a/src/Components/OATGraphViewer/OATGraphViewer.types.ts
+++ b/src/Components/OATGraphViewer/OATGraphViewer.types.ts
@@ -4,7 +4,6 @@ import {
     ICalloutContentStyles
 } from '@fluentui/react';
 import { SimulationNodeDatum } from 'd3-force';
-import { Theme } from '../../Models/Constants';
 import { IExtendedTheme } from '../../Theming/Theme.types';
 import { ElementNode } from './Internal/Classes/ElementNode';
 

--- a/src/Components/OATModelList/OATModelList.styles.tsx
+++ b/src/Components/OATModelList/OATModelList.styles.tsx
@@ -21,7 +21,6 @@ export const getStyles = (
         listContainer: [
             classNames.listContainer,
             {
-                // backgroundColor: theme.semanticColors.bodyBackground,
                 width: '100%',
                 height: 'calc(100% - 32px)', // less the search box
                 overflowX: 'hidden',

--- a/src/Components/OATPropertyEditor/Editor.tsx
+++ b/src/Components/OATPropertyEditor/Editor.tsx
@@ -29,7 +29,7 @@ import {
 import OATModal from '../../Pages/OATEditorPage/Internal/Components/OATModal';
 import FormAddEnumItem from './Internal/FormAddEnumItem';
 import { FormBody } from './Shared/Constants';
-import { EditorProps } from './Editor.types';
+import { IEditorProps } from './Editor.types';
 import {
     OAT_INTERFACE_TYPE,
     OAT_RELATIONSHIP_HANDLE_NAME
@@ -39,8 +39,8 @@ import { OatPageContextActionType } from '../../Models/Context/OatPageContext/Oa
 import FormRootModelDetails from './Internal/FormRootModelDetails';
 import FormUpdateProperty from './Internal/FormUpdateProperty';
 
-const Editor: React.FC<EditorProps> = (props) => {
-    const { dispatch, languages, state, theme } = props;
+const Editor: React.FC<IEditorProps> = (props) => {
+    const { editorDispatch, languages, editorState, selectedThemeName } = props;
 
     // hooks
     const { t } = useTranslation();
@@ -104,25 +104,25 @@ const Editor: React.FC<EditorProps> = (props) => {
     };
 
     const onModalClose = () => {
-        dispatch({
+        editorDispatch({
             type: SET_OAT_PROPERTY_MODAL_OPEN,
             payload: false
         });
-        dispatch({
+        editorDispatch({
             type: SET_OAT_PROPERTY_MODAL_BODY,
             payload: null
         });
     };
 
     const getModalBody = () => {
-        switch (state.modalBody) {
+        switch (editorState.modalBody) {
             case FormBody.property:
                 return (
                     <FormUpdateProperty
-                        dispatch={dispatch}
+                        dispatch={editorDispatch}
                         languages={languages}
                         onClose={onModalClose}
-                        state={state}
+                        state={editorState}
                     />
                 );
             case FormBody.enum:
@@ -130,7 +130,7 @@ const Editor: React.FC<EditorProps> = (props) => {
                     <FormAddEnumItem
                         languages={languages}
                         onClose={onModalClose}
-                        state={state}
+                        state={editorState}
                     />
                 );
             case FormBody.rootModel:
@@ -146,8 +146,8 @@ const Editor: React.FC<EditorProps> = (props) => {
     };
 
     return (
-        <div>
-            <div className={propertyInspectorStyles.container}>
+        <>
+            <div className={propertyInspectorStyles.root}>
                 <Pivot className={propertyInspectorStyles.pivot}>
                     <PivotItem
                         headerButtonProps={{
@@ -159,7 +159,7 @@ const Editor: React.FC<EditorProps> = (props) => {
                         <Stack styles={propertyListPivotColumnContent}>
                             <Stack.Item>
                                 <PropertiesModelSummary
-                                    dispatch={dispatch}
+                                    dispatch={editorDispatch}
                                     isSupportedModelType={isSupportedModelType}
                                 />
                             </Stack.Item>
@@ -205,8 +205,8 @@ const Editor: React.FC<EditorProps> = (props) => {
 
                             <Stack.Item grow styles={propertyListStackItem}>
                                 <PropertyList
-                                    dispatch={dispatch}
-                                    state={state}
+                                    dispatch={editorDispatch}
+                                    state={editorState}
                                     enteredPropertyRef={enteredPropertyRef}
                                     enteredTemplateRef={enteredTemplateRef}
                                     propertyList={propertyList}
@@ -219,25 +219,27 @@ const Editor: React.FC<EditorProps> = (props) => {
                         headerText={t('OATPropertyEditor.json')}
                         className={propertyInspectorStyles.pivotItem}
                     >
-                        {isSupportedModelType && <JSONEditor theme={theme} />}
+                        {isSupportedModelType && (
+                            <JSONEditor theme={selectedThemeName} />
+                        )}
                     </PivotItem>
                 </Pivot>
                 {oatPageState.templatesActive && (
                     <TemplateColumn
                         enteredPropertyRef={enteredPropertyRef}
                         enteredTemplateRef={enteredTemplateRef}
-                        dispatch={dispatch}
-                        state={state}
+                        dispatch={editorDispatch}
+                        state={editorState}
                     />
                 )}
             </div>
             <OATModal
-                isOpen={state.modalOpen}
+                isOpen={editorState.modalOpen}
                 className={propertyInspectorStyles.modal}
             >
                 {getModalBody()}
             </OATModal>
-        </div>
+        </>
     );
 };
 

--- a/src/Components/OATPropertyEditor/Editor.types.ts
+++ b/src/Components/OATPropertyEditor/Editor.types.ts
@@ -3,9 +3,9 @@ import { IOATPropertyEditorState } from './OATPropertyEditor.types';
 import { IDropdownOption } from '@fluentui/react';
 import { Theme } from '../../Models/Constants/Enums';
 
-export type EditorProps = {
-    dispatch?: React.Dispatch<React.SetStateAction<IAction>>;
+export type IEditorProps = {
+    editorDispatch?: React.Dispatch<React.SetStateAction<IAction>>;
+    editorState?: IOATPropertyEditorState;
     languages: IDropdownOption[];
-    state?: IOATPropertyEditorState;
-    theme?: Theme;
+    selectedThemeName?: Theme;
 };

--- a/src/Components/OATPropertyEditor/Editor.types.ts
+++ b/src/Components/OATPropertyEditor/Editor.types.ts
@@ -2,10 +2,12 @@ import { IAction } from '../../Models/Constants/Interfaces';
 import { IOATPropertyEditorState } from './OATPropertyEditor.types';
 import { IDropdownOption } from '@fluentui/react';
 import { Theme } from '../../Models/Constants/Enums';
+import { DtdlInterface, DtdlInterfaceContent } from '../..';
 
 export type IEditorProps = {
     editorDispatch?: React.Dispatch<React.SetStateAction<IAction>>;
     editorState?: IOATPropertyEditorState;
     languages: IDropdownOption[];
+    selectedItem: DtdlInterface | DtdlInterfaceContent;
     selectedThemeName?: Theme;
 };

--- a/src/Components/OATPropertyEditor/Internal/FormRootModelDetails.tsx
+++ b/src/Components/OATPropertyEditor/Internal/FormRootModelDetails.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useContext, useMemo } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import {
     TextField,
     Text,
@@ -47,7 +47,7 @@ const singleLanguageOptionValue = 'singleLanguage';
 export const FormRootModelDetails: React.FC<ModalFormRootModelProps> = (
     props
 ) => {
-    const { onClose, languages } = props;
+    const { onClose, languages, selectedItem } = props;
 
     // hooks
     const { t } = useTranslation();
@@ -57,15 +57,6 @@ export const FormRootModelDetails: React.FC<ModalFormRootModelProps> = (
     const { oatPageDispatch, oatPageState } = useOatPageContext();
 
     // data
-    const model = useMemo(
-        () =>
-            oatPageState.selection &&
-            getTargetFromSelection(
-                oatPageState.currentOntologyModels,
-                oatPageState.selection
-            ),
-        [oatPageState.currentOntologyModels, oatPageState.selection]
-    );
 
     // state
     const [comment, setComment] = useState('');
@@ -128,13 +119,14 @@ export const FormRootModelDetails: React.FC<ModalFormRootModelProps> = (
                 oatPageState.currentOntologyModelMetadata
             );
             const newMetadata = {
-                '@id': model['@id'],
+                '@id': selectedItem['@id'],
                 directoryPath,
                 fileName
             };
             // Check modelsMetadata for the existence of the model, if exists, update it, if not, add it
             const modelIndex = metadataCopy.findIndex(
-                (modelMetadata: any) => modelMetadata['@id'] === model['@id']
+                (modelMetadata: any) =>
+                    modelMetadata['@id'] === selectedItem['@id']
             );
             if (modelIndex !== -1) {
                 metadataCopy[modelIndex] = newMetadata;
@@ -155,24 +147,24 @@ export const FormRootModelDetails: React.FC<ModalFormRootModelProps> = (
                 modelsCopy,
                 oatPageState.selection
             );
-            modelCopy.comment = comment ? comment : model.comment;
+            modelCopy.comment = comment ? comment : selectedItem.comment;
             modelCopy.displayName =
                 languageSelection === singleLanguageOptionValue
                     ? displayName
                         ? displayName
-                        : model.displayName
+                        : selectedItem.displayName
                     : multiLanguageSelectionsDisplayName
                     ? multiLanguageSelectionsDisplayName
-                    : model.displayName;
+                    : selectedItem.displayName;
             modelCopy.description =
                 languageSelectionDescription === singleLanguageOptionValue
                     ? description
                         ? description
-                        : model.description
+                        : selectedItem.description
                     : multiLanguageSelectionsDescription
                     ? multiLanguageSelectionsDescription
-                    : model.description;
-            modelCopy['@id'] = id ? id : model['@id'];
+                    : selectedItem.description;
+            modelCopy['@id'] = id ? id : selectedItem['@id'];
 
             oatPageDispatch({
                 type: OatPageContextActionType.SET_CURRENT_MODELS,
@@ -201,7 +193,8 @@ export const FormRootModelDetails: React.FC<ModalFormRootModelProps> = (
         // Check if there is metadata for the model, if so update fileName and directoryPath
         if (oatPageState.currentOntologyModelMetadata) {
             const modelMetadata = oatPageState.currentOntologyModelMetadata.find(
-                (modelMetadata: any) => modelMetadata['@id'] === model['@id']
+                (modelMetadata: any) =>
+                    modelMetadata['@id'] === selectedItem['@id']
             );
             if (modelMetadata) {
                 setFileName(modelMetadata.fileName);
@@ -239,31 +232,35 @@ export const FormRootModelDetails: React.FC<ModalFormRootModelProps> = (
 
     // side effects
     useEffect(() => {
-        setComment(model.comment);
-        setDisplayName(getModelPropertyListItemName(model.displayName));
-        setDescription(model.description);
-        setId(model['@id']);
+        setComment(selectedItem.comment);
+        setDisplayName(getModelPropertyListItemName(selectedItem.displayName));
+        setDescription(selectedItem.description);
+        setId(selectedItem['@id']);
         setLanguageSelection(
-            !model.displayName || typeof model.displayName === 'string'
+            !selectedItem.displayName ||
+                typeof selectedItem.displayName === 'string'
                 ? singleLanguageOptionValue
                 : multiLanguageOptionValue
         );
         setLanguageSelectionDescription(
-            !model.description || typeof model.description === 'string'
+            !selectedItem.description ||
+                typeof selectedItem.description === 'string'
                 ? singleLanguageOptionValue
                 : multiLanguageOptionValue
         );
         setMultiLanguageSelectionsDisplayName(
-            model.displayName && typeof model.displayName === 'object'
-                ? model.displayName
+            selectedItem.displayName &&
+                typeof selectedItem.displayName === 'object'
+                ? selectedItem.displayName
                 : {}
         );
         setMultiLanguageSelectionsDescription(
-            model.description && typeof model.description === 'object'
-                ? model.description
+            selectedItem.description &&
+                typeof selectedItem.description === 'object'
+                ? selectedItem.description
                 : {}
         );
-    }, [model]);
+    }, [selectedItem]);
 
     // Update multiLanguageSelectionsDisplayNames on every new language change
     useEffect(() => {
@@ -332,9 +329,9 @@ export const FormRootModelDetails: React.FC<ModalFormRootModelProps> = (
         <>
             <div className={propertyInspectorStyles.modalRowSpaceBetween}>
                 <Label>
-                    {model &&
-                        model.displayName &&
-                        getModelPropertyListItemName(model.displayName)}
+                    {selectedItem &&
+                        selectedItem.displayName &&
+                        getModelPropertyListItemName(selectedItem.displayName)}
                 </Label>
                 <ActionButton onClick={onClose}>
                     <FontIcon
@@ -353,7 +350,7 @@ export const FormRootModelDetails: React.FC<ModalFormRootModelProps> = (
                 <OATTextFieldId
                     placeholder={t('OATPropertyEditor.id')}
                     value={id}
-                    model={model}
+                    model={selectedItem}
                     models={oatPageState.currentOntologyModels}
                     modalFormCommit
                     onCommit={setId}

--- a/src/Components/OATPropertyEditor/Internal/FormRootModelDetails.types.ts
+++ b/src/Components/OATPropertyEditor/Internal/FormRootModelDetails.types.ts
@@ -1,6 +1,8 @@
 import { IDropdownOption } from '@fluentui/react';
+import { DtdlInterface, DtdlInterfaceContent } from '../../..';
 
 export type ModalFormRootModelProps = {
     onClose?: () => void;
     languages: IDropdownOption[];
+    selectedItem: DtdlInterface | DtdlInterfaceContent;
 };

--- a/src/Components/OATPropertyEditor/Internal/PropertiesModelSummary.tsx
+++ b/src/Components/OATPropertyEditor/Internal/PropertiesModelSummary.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState, useEffect, useMemo } from 'react';
+import React, { useContext, useState, useEffect } from 'react';
 import { Stack, Label, Text, IconButton } from '@fluentui/react';
 import { useTranslation } from 'react-i18next';
 import {
@@ -28,7 +28,8 @@ import { OatPageContextActionType } from '../../../Models/Context/OatPageContext
 export const PropertiesModelSummary: React.FC<PropertiesModelSummaryProps> = (
     props
 ) => {
-    const { dispatch, isSupportedModelType } = props;
+    const { dispatch, isSupportedModelType, selectedItem } = props;
+    console.log('***PropertiesModel', selectedItem);
 
     // hooks
     const { t } = useTranslation();
@@ -38,36 +39,28 @@ export const PropertiesModelSummary: React.FC<PropertiesModelSummaryProps> = (
     const { oatPageDispatch, oatPageState } = useOatPageContext();
 
     // data
-    const model = useMemo(
-        () =>
-            oatPageState.selection &&
-            getTargetFromSelection(
-                oatPageState.currentOntologyModels,
-                oatPageState.selection
-            ),
-        [oatPageState.currentOntologyModels, oatPageState.selection]
-    );
-
     const [displayName, setDisplayName] = useState(
-        model && model.displayName
-            ? getModelPropertyListItemName(model.displayName)
+        selectedItem && selectedItem.displayName
+            ? getModelPropertyListItemName(selectedItem.displayName)
             : ''
     );
-    const [name, setName] = useState(model ? model.name : '');
-    const [id, setId] = useState(model && model['@id'] ? model['@id'] : '');
+    const [name, setName] = useState(selectedItem ? selectedItem.name : '');
+    const [id, setId] = useState(
+        selectedItem && selectedItem['@id'] ? selectedItem['@id'] : ''
+    );
     const [idEditor, setIdEditor] = useState(false);
     const [nameEditor, setNameEditor] = useState(false);
     const [displayNameEditor, setDisplayNameEditor] = useState(false);
 
     useEffect(() => {
         setDisplayName(
-            model && model.displayName
-                ? getModelPropertyListItemName(model.displayName)
+            selectedItem && selectedItem.displayName
+                ? getModelPropertyListItemName(selectedItem.displayName)
                 : ''
         );
-        setName(model && model.name ? model.name : '');
-        setId(model && model['@id'] ? model['@id'] : '');
-    }, [model]);
+        setName(selectedItem && selectedItem.name ? selectedItem.name : '');
+        setId(selectedItem && selectedItem['@id'] ? selectedItem['@id'] : '');
+    }, [selectedItem]);
 
     const onIdCommit = (value) => {
         const commit = () => {
@@ -210,25 +203,26 @@ export const PropertiesModelSummary: React.FC<PropertiesModelSummaryProps> = (
         <Stack styles={generalPropertiesWrapStyles}>
             <div className={propertyInspectorStyles.rowSpaceBetween}>
                 <Label>{`${t('OATPropertyEditor.general')}`}</Label>
-                {model && model['@type'] === OAT_INTERFACE_TYPE && (
-                    <IconButton
-                        styles={iconWrapStyles}
-                        iconProps={{ iconName: 'info' }}
-                        title={t('OATPropertyEditor.info')}
-                        onClick={onInfoButtonClick}
-                    />
-                )}
+                {selectedItem &&
+                    selectedItem['@type'] === OAT_INTERFACE_TYPE && (
+                        <IconButton
+                            styles={iconWrapStyles}
+                            iconProps={{ iconName: 'info' }}
+                            title={t('OATPropertyEditor.info')}
+                            onClick={onInfoButtonClick}
+                        />
+                    )}
             </div>
             <div className={propertyInspectorStyles.gridRow}>
                 <Text>{t('type')}</Text>
                 <Text className={propertyInspectorStyles.typeTextField}>
-                    {model ? model['@type'] : ''}
+                    {selectedItem ? selectedItem['@type'] : ''}
                 </Text>
             </div>
 
             <div className={propertyInspectorStyles.gridRow}>
                 <Text>{t('id')}</Text>
-                {!idEditor && model && (
+                {!idEditor && selectedItem && (
                     <Text
                         className={propertyInspectorStyles.typeTextField}
                         onDoubleClick={() => setIdEditor(true)}
@@ -236,13 +230,13 @@ export const PropertiesModelSummary: React.FC<PropertiesModelSummaryProps> = (
                         {id}
                     </Text>
                 )}
-                {idEditor && model && (
+                {idEditor && selectedItem && (
                     <OATTextFieldId
                         placeholder={t('id')}
                         styles={textFieldStyles}
-                        disabled={!model}
+                        disabled={!selectedItem}
                         value={isSupportedModelType && id}
-                        model={model}
+                        model={selectedItem}
                         models={oatPageState.currentOntologyModels}
                         onCommit={onIdCommit}
                         borderless
@@ -250,10 +244,10 @@ export const PropertiesModelSummary: React.FC<PropertiesModelSummaryProps> = (
                     />
                 )}
             </div>
-            {model && model.name && (
+            {selectedItem && selectedItem.name && (
                 <div className={propertyInspectorStyles.gridRow}>
                     <Text>{t('name')}</Text>
-                    {!nameEditor && model && (
+                    {!nameEditor && selectedItem && (
                         <Text
                             className={propertyInspectorStyles.typeTextField}
                             onDoubleClick={() => setNameEditor(true)}
@@ -261,16 +255,16 @@ export const PropertiesModelSummary: React.FC<PropertiesModelSummaryProps> = (
                             {name}
                         </Text>
                     )}
-                    {nameEditor && model && (
+                    {nameEditor && selectedItem && (
                         <OATTextFieldName
                             placeholder={t('name')}
                             styles={textFieldStyles}
-                            disabled={!model}
+                            disabled={!selectedItem}
                             value={
                                 isSupportedModelType &&
                                 getModelPropertyListItemName(name)
                             }
-                            model={model}
+                            model={selectedItem}
                             models={oatPageState.currentOntologyModels}
                             onCommit={onNameCommit}
                             borderless
@@ -282,7 +276,7 @@ export const PropertiesModelSummary: React.FC<PropertiesModelSummaryProps> = (
             {isSupportedModelType && (
                 <div className={propertyInspectorStyles.gridRow}>
                     <Text>{t('OATPropertyEditor.displayName')}</Text>
-                    {!displayNameEditor && model && (
+                    {!displayNameEditor && selectedItem && (
                         <Text
                             className={
                                 displayName.length > 0
@@ -296,15 +290,15 @@ export const PropertiesModelSummary: React.FC<PropertiesModelSummaryProps> = (
                                 : t('OATPropertyEditor.displayName')}
                         </Text>
                     )}
-                    {displayNameEditor && model && (
+                    {displayNameEditor && selectedItem && (
                         <OATTextFieldDisplayName
                             styles={textFieldStyles}
                             borderless
                             placeholder={t('OATPropertyEditor.displayName')}
-                            disabled={!model}
+                            disabled={!selectedItem}
                             value={isSupportedModelType && displayName}
                             onCommit={onDisplayNameCommit}
-                            model={model}
+                            model={selectedItem}
                             autoFocus
                         />
                     )}

--- a/src/Components/OATPropertyEditor/Internal/PropertiesModelSummary.types.ts
+++ b/src/Components/OATPropertyEditor/Internal/PropertiesModelSummary.types.ts
@@ -1,6 +1,8 @@
+import { DtdlInterface, DtdlInterfaceContent } from '../../..';
 import { IAction } from '../../../Models/Constants/Interfaces';
 
 export type PropertiesModelSummaryProps = {
     dispatch: React.Dispatch<React.SetStateAction<IAction>>;
     isSupportedModelType: boolean;
+    selectedItem: DtdlInterface | DtdlInterfaceContent;
 };

--- a/src/Components/OATPropertyEditor/Internal/PropertyList.tsx
+++ b/src/Components/OATPropertyEditor/Internal/PropertyList.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useContext, useMemo } from 'react';
+import React, { useRef, useState, useContext } from 'react';
 import { CommandHistoryContext } from '../../../Pages/OATEditorPage/Internal/Context/CommandHistoryContext';
 import { FontIcon, ActionButton, Text } from '@fluentui/react';
 import { useTranslation } from 'react-i18next';
@@ -24,6 +24,7 @@ export const PropertyList: React.FC<PropertyListProps> = (props) => {
         enteredPropertyRef,
         enteredTemplateRef,
         isSupportedModelType,
+        selectedItem,
         propertyList,
         state
     } = props;
@@ -60,18 +61,8 @@ export const PropertyList: React.FC<PropertyListProps> = (props) => {
     const propertyInspectorStyles = getPropertyInspectorStyles();
 
     // data
-    const model = useMemo(
-        () =>
-            oatPageState.selection &&
-            getTargetFromSelection(
-                oatPageState.currentOntologyModels,
-                oatPageState.selection
-            ),
-        [oatPageState.currentOntologyModels, oatPageState.selection]
-    );
-
     const propertiesKeyName = getModelPropertyCollectionName(
-        model ? model['@type'] : null
+        selectedItem ? selectedItem['@type'] : null
     );
 
     const onPropertyItemDropOnTemplateList = () => {
@@ -79,7 +70,7 @@ export const PropertyList: React.FC<PropertyListProps> = (props) => {
             ? deepCopy(oatPageState.currentOntologyTemplates)
             : [];
         newTemplate.push(
-            model[propertiesKeyName][draggedPropertyItemRef.current]
+            selectedItem[propertiesKeyName][draggedPropertyItemRef.current]
         );
         oatPageDispatch({
             type: OatPageContextActionType.SET_CURRENT_TEMPLATES,
@@ -195,7 +186,7 @@ export const PropertyList: React.FC<PropertyListProps> = (props) => {
 
     const generateErrorMessage = (value, index) => {
         if (value) {
-            const find = model[propertiesKeyName].find(
+            const find = selectedItem[propertiesKeyName].find(
                 (item) => item.name === value
             );
 
@@ -372,7 +363,7 @@ export const PropertyList: React.FC<PropertyListProps> = (props) => {
                                 }
                                 onMove={moveItemOnPropertyList}
                                 propertiesLength={
-                                    model[propertiesKeyName].length
+                                    selectedItem[propertiesKeyName].length
                                 }
                             />
                         );
@@ -398,7 +389,7 @@ export const PropertyList: React.FC<PropertyListProps> = (props) => {
                                 dispatch={dispatch}
                                 onMove={moveItemOnPropertyList}
                                 propertiesLength={
-                                    model[propertiesKeyName].length
+                                    selectedItem[propertiesKeyName].length
                                 }
                             />
                         );

--- a/src/Components/OATPropertyEditor/Internal/PropertyList.types.ts
+++ b/src/Components/OATPropertyEditor/Internal/PropertyList.types.ts
@@ -1,5 +1,9 @@
 import { DTDLProperty } from '../../../Models/Classes/DTDL';
-import { IAction } from '../../../Models/Constants';
+import {
+    DtdlInterface,
+    DtdlInterfaceContent,
+    IAction
+} from '../../../Models/Constants';
 import { IOATPropertyEditorState } from '../OATPropertyEditor.types';
 
 export type PropertyListProps = {
@@ -7,6 +11,7 @@ export type PropertyListProps = {
     enteredPropertyRef: any;
     enteredTemplateRef: any;
     isSupportedModelType: boolean;
+    selectedItem: DtdlInterface | DtdlInterfaceContent;
     propertyList: DTDLProperty[];
     state: IOATPropertyEditorState;
 };

--- a/src/Components/OATPropertyEditor/OATPropertyEditor.stories.tsx
+++ b/src/Components/OATPropertyEditor/OATPropertyEditor.stories.tsx
@@ -5,10 +5,24 @@ import { CommandHistoryContextProvider } from '../../Pages/OATEditorPage/Interna
 import i18n from '../../i18n';
 import { OatPageContextProvider } from '../../Models/Context/OatPageContext/OatPageContext';
 import { getAvailableLanguages } from '../../Models/Services/OatUtils';
+import { getMockModelItem } from '../../Models/Context/OatPageContext/OatPageContext.mock';
 
 export default {
     title: 'Components - OAT/OATPropertyEditor',
     component: OATPropertyEditor
+};
+
+const getMockModel = () => {
+    const model = getMockModelItem('123');
+    model.contents = [
+        ...model.contents,
+        {
+            '@type': 'Property',
+            name: 'New_Property1',
+            schema: 'dateTime'
+        }
+    ];
+    return model;
 };
 
 export const Default = (_args, { globals: { theme, locale } }) => {
@@ -18,7 +32,11 @@ export const Default = (_args, { globals: { theme, locale } }) => {
         <BaseComponent locale={locale} theme={theme}>
             <OatPageContextProvider>
                 <CommandHistoryContextProvider>
-                    <OATPropertyEditor theme={theme} languages={languages} />
+                    <OATPropertyEditor
+                        languages={languages}
+                        selectedItem={getMockModel()}
+                        selectedThemeName={theme}
+                    />
                 </CommandHistoryContextProvider>
             </OatPageContextProvider>
         </BaseComponent>

--- a/src/Components/OATPropertyEditor/OATPropertyEditor.styles.ts
+++ b/src/Components/OATPropertyEditor/OATPropertyEditor.styles.ts
@@ -8,7 +8,10 @@ import {
     IStackStyles
 } from '@fluentui/react';
 import { CardboardClassNamePrefix } from '../../Models/Constants';
-import { getControlBackgroundColor } from '../../Models/Constants/OatStyleConstants';
+import {
+    getControlBackgroundColor,
+    PROPERTY_EDITOR_WIDTH
+} from '../../Models/Constants/OatStyleConstants';
 import { useExtendedTheme } from '../../Models/Hooks/useExtendedTheme';
 
 const classPrefix = `${CardboardClassNamePrefix}-oat-property-editor`;
@@ -88,8 +91,9 @@ export const getPropertyInspectorStyles = () => {
                 display: 'flex',
                 flexDirection: 'row',
                 height: '100%',
-                maxHeight: '100vh',
-                minWidth: '300px'
+                maxHeight: '80vh',
+                padding: 16,
+                width: PROPERTY_EDITOR_WIDTH
             } as IStyle
         ],
         pivot: [

--- a/src/Components/OATPropertyEditor/OATPropertyEditor.styles.ts
+++ b/src/Components/OATPropertyEditor/OATPropertyEditor.styles.ts
@@ -449,13 +449,12 @@ export const getPropertyInspectorStyles = () => {
         propertyItem: [
             classNames.propertyItem,
             {
+                alignItems: 'center',
+                cursor: 'grab',
                 display: 'grid',
                 gridTemplateColumns: '45% 35% 10% 10%',
-                width: '100%',
-                backgroundColor: theme.semanticColors.listBackground,
-                alignItems: 'center',
                 padding: '12px 0px',
-                cursor: 'grab',
+                width: '100%',
                 ':active': {
                     cursor: 'grabbing'
                 },

--- a/src/Components/OATPropertyEditor/OATPropertyEditor.styles.ts
+++ b/src/Components/OATPropertyEditor/OATPropertyEditor.styles.ts
@@ -8,6 +8,8 @@ import {
     IStackStyles
 } from '@fluentui/react';
 import { CardboardClassNamePrefix } from '../../Models/Constants';
+import { getControlBackgroundColor } from '../../Models/Constants/OatStyleConstants';
+import { useExtendedTheme } from '../../Models/Hooks/useExtendedTheme';
 
 const classPrefix = `${CardboardClassNamePrefix}-oat-property-editor`;
 const classNames = {
@@ -77,15 +79,16 @@ const classNames = {
 const OATEditorPivotContentHeightAdjustment = 82;
 
 export const getPropertyInspectorStyles = () => {
-    const theme = useTheme();
+    const theme = useExtendedTheme();
     return mergeStyleSets({
-        container: [
+        root: [
             classNames.container,
             {
-                height: '100%',
-                maxHeight: '100vh',
+                backgroundColor: getControlBackgroundColor(theme),
                 display: 'flex',
                 flexDirection: 'row',
+                height: '100%',
+                maxHeight: '100vh',
                 minWidth: '300px'
             } as IStyle
         ],
@@ -93,7 +96,6 @@ export const getPropertyInspectorStyles = () => {
             classNames.pivot,
             {
                 width: '100%',
-                backgroundColor: theme.semanticColors.listBackground,
                 '[role="tabpanel"]': {
                     height: `calc(100% - ${OATEditorPivotContentHeightAdjustment}px)`
                 },
@@ -104,15 +106,14 @@ export const getPropertyInspectorStyles = () => {
             classNames.pivotItem,
             {
                 height: '100%',
-                backgroundColor: theme.semanticColors.listBackground
+                backgroundColor: 'transparent'
             } as IStyle
         ],
         templateColumn: [
             classNames.templateColumn,
             {
                 width: '80%',
-                height: '100%',
-                backgroundColor: theme.semanticColors.buttonBackgroundDisabled
+                height: '100%'
             } as IStyle
         ],
         row: [

--- a/src/Components/OATPropertyEditor/OATPropertyEditor.styles.ts
+++ b/src/Components/OATPropertyEditor/OATPropertyEditor.styles.ts
@@ -91,7 +91,7 @@ export const getPropertyInspectorStyles = () => {
                 display: 'flex',
                 flexDirection: 'row',
                 height: '100%',
-                maxHeight: '80vh',
+                maxHeight: '70vh',
                 padding: 16,
                 width: PROPERTY_EDITOR_WIDTH
             } as IStyle

--- a/src/Components/OATPropertyEditor/OATPropertyEditor.tsx
+++ b/src/Components/OATPropertyEditor/OATPropertyEditor.tsx
@@ -1,4 +1,5 @@
 import React, { useReducer } from 'react';
+import { getDebugLogger } from '../../Models/Services/Utils';
 import Editor from './Editor';
 import {
     OATPropertyEditorReducer,
@@ -6,19 +7,26 @@ import {
 } from './OATPropertyEditor.state';
 import { OATPropertyEditorProps } from './OATPropertyEditor.types';
 
-const OATPropertyEditor = ({ theme, languages }: OATPropertyEditorProps) => {
+const debugLogging = false;
+const logDebugConsole = getDebugLogger('OATPropertyEditor', debugLogging);
+
+const OATPropertyEditor = (props: OATPropertyEditorProps) => {
+    const { selectedThemeName, languages, selectedItem } = props;
+
     // state
     const [localState, localDispatch] = useReducer(
         OATPropertyEditorReducer,
         defaultOATPropertyEditorState
     );
 
+    logDebugConsole('debug', 'Render. {selectedItem}', selectedItem);
     return (
         <Editor
-            selectedThemeName={theme}
             editorDispatch={localDispatch}
             editorState={localState}
             languages={languages}
+            selectedItem={selectedItem}
+            selectedThemeName={selectedThemeName}
         />
     );
 };

--- a/src/Components/OATPropertyEditor/OATPropertyEditor.tsx
+++ b/src/Components/OATPropertyEditor/OATPropertyEditor.tsx
@@ -14,14 +14,12 @@ const OATPropertyEditor = ({ theme, languages }: OATPropertyEditorProps) => {
     );
 
     return (
-        <div style={{ width: 340, position: 'relative' }}>
-            <Editor
-                theme={theme}
-                dispatch={localDispatch}
-                state={localState}
-                languages={languages}
-            />
-        </div>
+        <Editor
+            selectedThemeName={theme}
+            editorDispatch={localDispatch}
+            editorState={localState}
+            languages={languages}
+        />
     );
 };
 

--- a/src/Components/OATPropertyEditor/OATPropertyEditor.types.ts
+++ b/src/Components/OATPropertyEditor/OATPropertyEditor.types.ts
@@ -1,9 +1,11 @@
 import { Theme } from '../../Models/Constants/Enums';
 import { IDropdownOption } from '@fluentui/react';
+import { DtdlInterface, DtdlInterfaceContent } from '../..';
 
 export type OATPropertyEditorProps = {
-    theme?: Theme;
     languages: IDropdownOption[];
+    selectedItem: DtdlInterface | DtdlInterfaceContent;
+    selectedThemeName?: Theme;
 };
 export interface IOATPropertyEditorState {
     currentPropertyIndex?: number;

--- a/src/Models/Constants/OatStyleConstants.ts
+++ b/src/Models/Constants/OatStyleConstants.ts
@@ -1,8 +1,9 @@
 import { IExtendedTheme } from '../../Theming/Theme.types';
 
 export const OAT_HEADER_HEIGHT = 76;
+export const PROPERTY_EDITOR_WIDTH = 340;
 
-export const CONTROLS_LEFT_OFFSET = 16;
+export const CONTROLS_SIDE_OFFSET = 16;
 export const CONTROLS_BOTTOM_OFFSET = 30;
 export const CONTROLS_MINIMAP_WIDTH = 200; // controlled internally by the library
 export const CONTROLS_CALLOUT_OFFSET = 16;

--- a/src/Models/Constants/OatStyleConstants.ts
+++ b/src/Models/Constants/OatStyleConstants.ts
@@ -4,6 +4,9 @@ export const OAT_HEADER_HEIGHT = 76;
 
 export const CONTROLS_LEFT_OFFSET = 16;
 export const CONTROLS_BOTTOM_OFFSET = 30;
+export const CONTROLS_MINIMAP_WIDTH = 200; // controlled internally by the library
+export const CONTROLS_CALLOUT_OFFSET = 16;
+
 export const CONTROLS_Z_INDEX = 6;
 export const LOADING_Z_INDEX = CONTROLS_Z_INDEX + 1;
 

--- a/src/Models/Context/OatPageContext/OatPageContext.mock.ts
+++ b/src/Models/Context/OatPageContext/OatPageContext.mock.ts
@@ -27,7 +27,7 @@ const getMockPositionItem = (id: string): IOATModelPosition => {
     };
 };
 
-const getMockModelItem = (id: string): DTDLModel => {
+export const getMockModelItem = (id: string): DTDLModel => {
     return new DTDLModel(
         id,
         `model-${id}`,

--- a/src/Pages/OATEditorPage/Internal/Components/OATTextFieldId.tsx
+++ b/src/Pages/OATEditorPage/Internal/Components/OATTextFieldId.tsx
@@ -51,6 +51,7 @@ const OATTextFieldId = ({
                 if (model['@type'] === OAT_RELATIONSHIP_HANDLE_NAME) {
                     const repeatedIdOnRelationship = models.find(
                         (queryModel) =>
+                            queryModel &&
                             queryModel.contents &&
                             queryModel.contents.find(
                                 (content) =>
@@ -67,6 +68,7 @@ const OATTextFieldId = ({
                     // Check current value is not used by another model as @id within models
                     const repeatedIdModel = models.find(
                         (queryModel) =>
+                            queryModel &&
                             queryModel['@id'] === value &&
                             queryModel['@id'] !== model['@id']
                     );

--- a/src/Pages/OATEditorPage/OATEditorPage.styles.tsx
+++ b/src/Pages/OATEditorPage/OATEditorPage.styles.tsx
@@ -49,10 +49,12 @@ export const getEditorPageStyles = () => {
             } as IStyle
         ],
         viewerContainer: {
-            width: `calc(100% - ${PROPERTY_EDITOR_WIDTH}px)`
+            width: '100%'
         },
         propertyEditorContainer: {
-            width: PROPERTY_EDITOR_WIDTH
+            width: PROPERTY_EDITOR_WIDTH,
+            position: 'absolute',
+            right: 0
         },
         errorHandlingWrapper: [
             classNames.errorHandlingWrapper,

--- a/src/Pages/OATEditorPage/OATEditorPage.styles.tsx
+++ b/src/Pages/OATEditorPage/OATEditorPage.styles.tsx
@@ -1,6 +1,10 @@
 import { IStyle, mergeStyleSets, useTheme } from '@fluentui/react';
 import { CardboardClassNamePrefix } from '../../Models/Constants';
-import { OAT_HEADER_HEIGHT } from '../../Models/Constants/OatStyleConstants';
+import {
+    CONTROLS_BOTTOM_OFFSET,
+    CONTROLS_SIDE_OFFSET,
+    OAT_HEADER_HEIGHT
+} from '../../Models/Constants/OatStyleConstants';
 
 const classPrefix = `${CardboardClassNamePrefix}-oat-body`;
 const classNames = {
@@ -19,7 +23,6 @@ const classNames = {
     confirmDeleteWrapperTitle: `${classPrefix}-confirm-delete-wrapper-title`
 };
 
-const PROPERTY_EDITOR_WIDTH = 340;
 export const getEditorPageStyles = () => {
     const theme = useTheme();
     return mergeStyleSets({
@@ -52,9 +55,9 @@ export const getEditorPageStyles = () => {
             width: '100%'
         },
         propertyEditorContainer: {
-            width: PROPERTY_EDITOR_WIDTH,
             position: 'absolute',
-            right: 0
+            right: CONTROLS_SIDE_OFFSET,
+            top: CONTROLS_BOTTOM_OFFSET
         },
         errorHandlingWrapper: [
             classNames.errorHandlingWrapper,

--- a/src/Pages/OATEditorPage/OATEditorPage.styles.tsx
+++ b/src/Pages/OATEditorPage/OATEditorPage.styles.tsx
@@ -3,6 +3,7 @@ import { CardboardClassNamePrefix } from '../../Models/Constants';
 import {
     CONTROLS_BOTTOM_OFFSET,
     CONTROLS_SIDE_OFFSET,
+    CONTROLS_Z_INDEX,
     OAT_HEADER_HEIGHT
 } from '../../Models/Constants/OatStyleConstants';
 
@@ -57,7 +58,8 @@ export const getEditorPageStyles = () => {
         propertyEditorContainer: {
             position: 'absolute',
             right: CONTROLS_SIDE_OFFSET,
-            top: CONTROLS_BOTTOM_OFFSET
+            top: CONTROLS_BOTTOM_OFFSET,
+            zIndex: CONTROLS_Z_INDEX
         },
         errorHandlingWrapper: [
             classNames.errorHandlingWrapper,

--- a/src/Pages/OATEditorPage/OATEditorPage.tsx
+++ b/src/Pages/OATEditorPage/OATEditorPage.tsx
@@ -13,8 +13,12 @@ import OATConfirmDeleteModal from './Internal/OATConfirmDeleteModal';
 import { getAvailableLanguages } from '../../Models/Services/OatUtils';
 import { getDebugLogger } from '../../Models/Services/Utils';
 import { IOATEditorPageProps } from './OATEditorPage.types';
-import { OatPageContextProvider } from '../../Models/Context/OatPageContext/OatPageContext';
+import {
+    OatPageContextProvider,
+    useOatPageContext
+} from '../../Models/Context/OatPageContext/OatPageContext';
 import BaseComponent from '../../Components/BaseComponent/BaseComponent';
+import { getTargetFromSelection } from '../../Components/OATPropertyEditor/Utils';
 
 const debugLogging = false;
 const logDebugConsole = getDebugLogger('OATEditorPage', debugLogging);
@@ -24,7 +28,8 @@ const OATEditorPageContent: React.FC<IOATEditorPageProps> = (props) => {
 
     // hooks
 
-    // context
+    // contexts
+    const { oatPageState } = useOatPageContext();
 
     // data
     const languages = useMemo(() => {
@@ -36,6 +41,15 @@ const OATEditorPageContent: React.FC<IOATEditorPageProps> = (props) => {
         );
         return languages;
     }, []);
+    const selectedModel = useMemo(
+        () =>
+            oatPageState.selection &&
+            getTargetFromSelection(
+                oatPageState.currentOntologyModels,
+                oatPageState.selection
+            ),
+        [oatPageState.currentOntologyModels, oatPageState.selection]
+    );
 
     // styles
     const editorPageStyles = getEditorPageStyles();
@@ -54,12 +68,17 @@ const OATEditorPageContent: React.FC<IOATEditorPageProps> = (props) => {
                     <div className={editorPageStyles.viewerContainer}>
                         <OATGraphViewerContent />
                     </div>
-                    <div className={editorPageStyles.propertyEditorContainer}>
-                        <OATPropertyEditor
-                            theme={theme}
-                            languages={languages}
-                        />
-                    </div>
+                    {selectedModel && (
+                        <div
+                            className={editorPageStyles.propertyEditorContainer}
+                        >
+                            <OATPropertyEditor
+                                languages={languages}
+                                selectedItem={selectedModel}
+                                selectedThemeName={theme}
+                            />
+                        </div>
+                    )}
                 </div>
                 <OATErrorHandlingModal />
                 <OATConfirmDeleteModal />

--- a/src/Pages/OATEditorPage/OATEditorPage.tsx
+++ b/src/Pages/OATEditorPage/OATEditorPage.tsx
@@ -14,7 +14,6 @@ import { getAvailableLanguages } from '../../Models/Services/OatUtils';
 import { getDebugLogger } from '../../Models/Services/Utils';
 import { IOATEditorPageProps } from './OATEditorPage.types';
 import { OatPageContextProvider } from '../../Models/Context/OatPageContext/OatPageContext';
-import { Stack } from '@fluentui/react';
 import BaseComponent from '../../Components/BaseComponent/BaseComponent';
 
 const debugLogging = false;
@@ -51,9 +50,9 @@ const OATEditorPageContent: React.FC<IOATEditorPageProps> = (props) => {
                 disableDefaultStyles={true}
             >
                 <OATHeader />
-                <Stack horizontal className={editorPageStyles.component}>
+                <div className={editorPageStyles.component}>
                     <div className={editorPageStyles.viewerContainer}>
-                        <OATGraphViewerContent selectedTheme={theme} />
+                        <OATGraphViewerContent />
                     </div>
                     <div className={editorPageStyles.propertyEditorContainer}>
                         <OATPropertyEditor
@@ -61,7 +60,7 @@ const OATEditorPageContent: React.FC<IOATEditorPageProps> = (props) => {
                             languages={languages}
                         />
                     </div>
-                </Stack>
+                </div>
                 <OATErrorHandlingModal />
                 <OATConfirmDeleteModal />
             </BaseComponent>


### PR DESCRIPTION
### Summary of changes 🔍 
Restyling the property editor on the right side to be floating instead of a fixed side panel.

[Product Backlog Item 15667901](https://msazure.visualstudio.com/One/_workitems/edit/15667901): OAT: Make property inspector container floating and hidable

Before
![image](https://user-images.githubusercontent.com/57726991/199551066-73297a74-182b-4705-995f-57929359f129.png)

After
![image](https://user-images.githubusercontent.com/57726991/199551975-aca808e6-52f2-4084-bf29-2f382de900c1.png)

Also hides the panel when nothing is selected.
![image](https://user-images.githubusercontent.com/57726991/199553171-aa4a046b-326a-4b1f-b361-4356d0420053.png)


### Testing 🧪
 > [ Add any special instructions needed to test or view your changes such as environment URLs or other config details. ]

### Checklist ✔️
- [ ] Linked associated issue (if present)
- [ ] Added relevant labels
- [ ] Requested developer reviews
- [ ] Request UI review from design / PM
- [ ] Verify all code checks are passing