### PR TITLE
[Data History]: Added telemetry logging

### DIFF
--- a/src/Adapters/BlobAdapterUtility.ts
+++ b/src/Adapters/BlobAdapterUtility.ts
@@ -108,7 +108,8 @@ function sendBehaviorTelemetry(behavior: IBehavior, sceneHash: string) {
             totalCount: 0,
             gaugeCount: 0,
             linkCount: 0,
-            propertyCount: 0
+            propertyCount: 0,
+            dataHistoryCount: 0
         }
     };
     visuals.forEach((visual) => {
@@ -125,6 +126,9 @@ function sendBehaviorTelemetry(behavior: IBehavior, sceneHash: string) {
                         break;
                     case 'Value':
                         visualStats.widgets.propertyCount += 1;
+                        break;
+                    case 'Data history':
+                        visualStats.widgets.dataHistoryCount += 1;
                         break;
                 }
             });
@@ -153,6 +157,8 @@ function sendBehaviorTelemetry(behavior: IBehavior, sceneHash: string) {
                     visualStats.widgets.linkCount,
                 [event.properties.countWidgetPropertyType]:
                     visualStats.widgets.propertyCount,
+                [event.properties.countWidgetDataHistoryType]:
+                    visualStats.widgets.dataHistoryCount,
                 [event.properties.countWidgets]: visualStats.widgets.totalCount,
                 [event.properties.parentSceneHash]: sceneHash
             },

--- a/src/Models/Constants/TelemetryConstants.ts
+++ b/src/Models/Constants/TelemetryConstants.ts
@@ -107,6 +107,8 @@ export const TelemetryEvents = {
                         countWidgetGaugeType: 'countWidgetGaugeType',
                         countWidgetLinkType: 'countWidgetLinkType',
                         countWidgetPropertyType: 'countWidgetPropertyType',
+                        countWidgetDataHistoryType:
+                            'countWidgetDataHistoryType',
                         countVisuals: 'countVisuals',
                         countVisualBadgeType: 'countVisualBadgeType',
                         countVisualColorType: 'countVisualColorType',


### PR DESCRIPTION
### Summary of changes 🔍 
Added data history widget count to BehaviorKpis as part of telemetry logging

### Testing 🧪
1. Enable telemetry logging feature in your local storage using `localStorage.setItem('cardboard.debug.telemetryLogging',true);`
2. Go to ADT3DScenePage and load page.
3. Enable "Verbose" to see the telemetry logging in the inspector on the page
4. Observe the below screen:
<img width="1016" alt="image" src="https://user-images.githubusercontent.com/45217314/200083914-b3a60369-4721-4ce9-a0da-09af2ef23d33.png">


### Checklist ✔️
- [ ] Linked associated issue (if present)
- [x] Added relevant labels
- [x] Requested developer reviews
- [x] Request UI review from design / PM
- [x] Verify all code checks are passing