### PR TITLE
added string to list of allowed property schemas in timeseries builder

### DIFF
--- a/schemas/3DScenesConfiguration/v1.0.0/3DScenesConfiguration.schema.json
+++ b/schemas/3DScenesConfiguration/v1.0.0/3DScenesConfiguration.schema.json
@@ -272,7 +272,7 @@
                     "type": "string"
                 },
                 "propertyType": {
-                    "type": "string"
+                    "$ref": "#/$defs/IDTDLPropertyType"
                 },
                 "unit": {
                     "type": "string"

--- a/schemas/3DScenesConfiguration/v1.0.0/3DScenesConfiguration.schema.json
+++ b/schemas/3DScenesConfiguration/v1.0.0/3DScenesConfiguration.schema.json
@@ -271,6 +271,9 @@
                 "expression": {
                     "type": "string"
                 },
+                "propertyType": {
+                    "type": "string"
+                },
                 "unit": {
                     "type": "string"
                 },

--- a/src/Components/ADT3DSceneBuilder/Internal/Behaviors/Widgets/WidgetBuilders/DataHistoryWidgetBuilder/Internal/TimeSeriesFormCallout.tsx
+++ b/src/Components/ADT3DSceneBuilder/Internal/Behaviors/Widgets/WidgetBuilders/DataHistoryWidgetBuilder/Internal/TimeSeriesFormCallout.tsx
@@ -31,6 +31,7 @@ import {
     PropertyExpression
 } from '../../../../../../../ModelledPropertyBuilder/ModelledPropertyBuilder.types';
 import { createGUID } from '../../../../../../../../Models/Services/Utils';
+import { PropertyValueType } from '../../../../../../../../Models/Constants/Constants';
 
 interface IProp {
     calloutTarget: string;
@@ -48,6 +49,12 @@ const defaultSeries: IDataHistoryBasicTimeSeries = {
     id: '',
     expression: ''
 };
+
+// Allow numerics + string as users often use string properties as the lowest common denominator
+const allowedTimeseriesPropertyValueTypes: Array<PropertyValueType> = [
+    'string',
+    ...numericPropertyValueTypes
+];
 
 /** This callout component consists form for time series authoring to show in line chart */
 const TimeSeriesFormCallout: React.FC<IProp> = ({
@@ -152,7 +159,9 @@ const TimeSeriesFormCallout: React.FC<IProp> = ({
                         expression: seriesToEdit?.expression
                     }}
                     onChange={handlePropertyChange}
-                    allowedPropertyValueTypes={numericPropertyValueTypes}
+                    allowedPropertyValueTypes={
+                        allowedTimeseriesPropertyValueTypes
+                    }
                     required
                 />
                 <TextField

--- a/src/Components/ADT3DSceneBuilder/Internal/Behaviors/Widgets/WidgetBuilders/DataHistoryWidgetBuilder/Internal/TimeSeriesFormCallout.tsx
+++ b/src/Components/ADT3DSceneBuilder/Internal/Behaviors/Widgets/WidgetBuilders/DataHistoryWidgetBuilder/Internal/TimeSeriesFormCallout.tsx
@@ -101,6 +101,8 @@ const TimeSeriesFormCallout: React.FC<IProp> = ({
             setSeriesToEdit(
                 produce((draft) => {
                     draft.expression = newPropertyExpression.expression;
+                    draft.propertyType =
+                        newPropertyExpression.property.propertyType;
                 })
             );
         },
@@ -172,6 +174,16 @@ const TimeSeriesFormCallout: React.FC<IProp> = ({
                     value={seriesToEdit?.label}
                     onChange={handleLabelChange}
                 />
+                {seriesToEdit?.propertyType &&
+                    !numericPropertyValueTypes.includes(
+                        seriesToEdit.propertyType
+                    ) && (
+                        <Text className={styles.description}>
+                            {t(
+                                'widgets.dataHistory.form.timeSeries.nonNumericWarning'
+                            )}
+                        </Text>
+                    )}
                 <TextField
                     placeholder={t(
                         'widgets.dataHistory.form.timeSeries.unitPlaceholder'

--- a/src/Components/ADT3DSceneBuilder/Internal/Behaviors/Widgets/WidgetBuilders/DataHistoryWidgetBuilder/Internal/TimeSeriesFormCallout.tsx
+++ b/src/Components/ADT3DSceneBuilder/Internal/Behaviors/Widgets/WidgetBuilders/DataHistoryWidgetBuilder/Internal/TimeSeriesFormCallout.tsx
@@ -166,14 +166,6 @@ const TimeSeriesFormCallout: React.FC<IProp> = ({
                     }
                     required
                 />
-                <TextField
-                    placeholder={t(
-                        'widgets.dataHistory.form.timeSeries.labelPlaceholder'
-                    )}
-                    label={t('widgets.dataHistory.form.timeSeries.label')}
-                    value={seriesToEdit?.label}
-                    onChange={handleLabelChange}
-                />
                 {seriesToEdit?.propertyType &&
                     !numericPropertyValueTypes.includes(
                         seriesToEdit.propertyType
@@ -184,6 +176,14 @@ const TimeSeriesFormCallout: React.FC<IProp> = ({
                             )}
                         </Text>
                     )}
+                <TextField
+                    placeholder={t(
+                        'widgets.dataHistory.form.timeSeries.labelPlaceholder'
+                    )}
+                    label={t('widgets.dataHistory.form.timeSeries.label')}
+                    value={seriesToEdit?.label}
+                    onChange={handleLabelChange}
+                />
                 <TextField
                     placeholder={t(
                         'widgets.dataHistory.form.timeSeries.unitPlaceholder'

--- a/src/Components/ADT3DSceneBuilder/Internal/Behaviors/Widgets/WidgetBuilders/DataHistoryWidgetBuilder/Internal/TimeSeriesFormCallout.tsx
+++ b/src/Components/ADT3DSceneBuilder/Internal/Behaviors/Widgets/WidgetBuilders/DataHistoryWidgetBuilder/Internal/TimeSeriesFormCallout.tsx
@@ -160,22 +160,22 @@ const TimeSeriesFormCallout: React.FC<IProp> = ({
                     propertyExpression={{
                         expression: seriesToEdit?.expression
                     }}
+                    description={
+                        seriesToEdit?.propertyType &&
+                        !numericPropertyValueTypes.includes(
+                            seriesToEdit.propertyType
+                        )
+                            ? t(
+                                  'widgets.dataHistory.form.timeSeries.nonNumericWarning'
+                              )
+                            : ''
+                    }
                     onChange={handlePropertyChange}
                     allowedPropertyValueTypes={
                         allowedTimeseriesPropertyValueTypes
                     }
                     required
                 />
-                {seriesToEdit?.propertyType &&
-                    !numericPropertyValueTypes.includes(
-                        seriesToEdit.propertyType
-                    ) && (
-                        <Text className={styles.description}>
-                            {t(
-                                'widgets.dataHistory.form.timeSeries.nonNumericWarning'
-                            )}
-                        </Text>
-                    )}
                 <TextField
                     placeholder={t(
                         'widgets.dataHistory.form.timeSeries.labelPlaceholder'

--- a/src/Models/Hooks/useTimeSeriesData.ts
+++ b/src/Models/Hooks/useTimeSeriesData.ts
@@ -139,6 +139,8 @@ const getBulkADXQueryFromTimeSeriesTwins = (
         twins?.forEach((twin, idx) => {
             query += `${connection.kustoTableName} | where TimeStamp > ago(${agoTimeInMillis}ms)`;
             query += ` | where Id == '${twin.twinId}' and Key == '${twin.twinPropertyName}'`;
+            query += ` | extend Value = todouble(${ADXTableColumns.Value})`;
+            query += ` | where isnotnull(${ADXTableColumns.Value})`;
             query += ' | order by TimeStamp asc';
             query += ` | project ${ADXTableColumns.TimeStamp}, ${ADXTableColumns.Id}, ${ADXTableColumns.Key}, ${ADXTableColumns.Value}`;
             if (idx < twins.length - 1) {

--- a/src/Models/Types/Generated/3DScenesConfiguration-v1.0.0.d.ts
+++ b/src/Models/Types/Generated/3DScenesConfiguration-v1.0.0.d.ts
@@ -5,6 +5,8 @@
  * and run json-schema-to-typescript to regenerate this file.
  */
 
+import { PropertyValueType } from "../../Constants";
+
 export type IElement = ITwinToObjectMapping | ICustomProperty;
 export type IDataSource = IElementTwinToObjectMappingDataSource | ICustomProperty;
 export type IVisual = IPopoverVisual | IExpressionRangeVisual;
@@ -273,6 +275,7 @@ export interface IADXTimeSeriesConnection {
 export interface IDataHistoryBasicTimeSeries {
     id: string;
     expression: string;
+    propertyType?: PropertyValueType;
     unit?: string;
     label?: string;
 }

--- a/src/Models/Types/Generated/3DScenesConfiguration-v1.0.0.d.ts
+++ b/src/Models/Types/Generated/3DScenesConfiguration-v1.0.0.d.ts
@@ -5,8 +5,6 @@
  * and run json-schema-to-typescript to regenerate this file.
  */
 
-import { PropertyValueType } from "../../Constants";
-
 export type IElement = ITwinToObjectMapping | ICustomProperty;
 export type IDataSource = IElementTwinToObjectMappingDataSource | ICustomProperty;
 export type IVisual = IPopoverVisual | IExpressionRangeVisual;
@@ -275,7 +273,7 @@ export interface IADXTimeSeriesConnection {
 export interface IDataHistoryBasicTimeSeries {
     id: string;
     expression: string;
-    propertyType?: PropertyValueType;
+    propertyType?: IDTDLPropertyType;
     unit?: string;
     label?: string;
 }

--- a/src/Resources/Locales/en.json
+++ b/src/Resources/Locales/en.json
@@ -652,6 +652,7 @@
                     "labelPlaceholder": "Enter label to show in chart",
                     "add": "Add time series",
                     "edit": "Edit time series",
+                    "nonNumericWarning": "Note: Non-numeric properties will be cast to numeric at query time, and may result in some values being omitted",
                     "update": "Update time series",
                     "remove": "Remove time series"
                 },


### PR DESCRIPTION
### Summary of changes 🔍 

In some environments numeric values are streamed into string fields, for example they stream "N/A" sometimes - or if they use something like the isa-95 ontology equipment property values are all strings

In order to make it easier for them to use the timeseries widget - this change allows them to select "string" properties as well as numeric ones,

The ADX query has then been updated to filter out non-numeric values.

Also added a warning note to a timeseries field when the type is not numeric something like 

``` Note: Non-numeric properties will be cast to numeric at query time, and may result in some values being omitted```

To do this I had to add a nullable field 'PropertyType' to the IDataHistoryBasicTimeSeries type.

Without warning 

![image](https://user-images.githubusercontent.com/7986264/200900437-0c9fd0a2-835d-4359-b6ae-55085735dec4.png)

With warning

![image](https://user-images.githubusercontent.com/7986264/200900348-d9d258f3-3b54-4420-995f-fbb1e3291b97.png)

### Testing 🧪

1. Open the /pages-adt3dscenepage--adt-3-d-scene-page-card storybook 
2. Edit a behavior 
3. Add a timeseries widget 
4. The Properties dropdown should allow you to select "string" schema'd properties also

#### ADX Queries

I tested the query with a twin in the ISS adt Instance which has a string property "Value" in the ADT Instance.

1. Write a numeric value 1 into the Value Field
2. Write a string value "Fred" into the value field
3. Write a series of numeric values

The graph in the viewer mode should show the timeseries points without the "Fred" entry.

I also tested the query in adx:

``` 
adt_dh_ah_iss_adt_02_weu
| where TimeStamp > ago(3d)
| where Id == 'NODE2000005' and Key == 'Value'
| order by TimeStamp asc 
| project TimeStamp, Id, Key, Value

```
This brings back ALL the values in the timeseries regardless of type.

```
adt_dh_ah_iss_adt_02_weu
| where TimeStamp > ago(3d)
| where Id == 'NODE2000005' and Key == 'Value'
| extend Value=todouble(Value)
| where isnotnull(Value)
| order by TimeStamp asc 
| project TimeStamp, Id, Key, Value
```

This brings back the timeseries values **Excluding** the entry for "Fred"



### Checklist ✔️
- [ x] Linked associated issue (if present) #770 
- [ ] Added relevant labels
- [ ] Requested developer reviews
- [ ] Request UI review from design / PM
- [x] Verify all code checks are passing