### PR TITLE
Resolve Conditions on save schema issue

### DIFF
--- a/src/Models/Classes/3DVConfig.ts
+++ b/src/Models/Classes/3DVConfig.ts
@@ -147,8 +147,8 @@ export const getDefaultVisualRuleCondition = (
     values: isNumericType(type) ? [0, 1] : type === 'boolean' ? [true] : [],
     visual: {
         color: color,
-        iconName: null,
-        labelExpression: null
+        iconName: undefined,
+        labelExpression: undefined
     }
 });
 


### PR DESCRIPTION
### Summary of changes 🔍 
When saving a Condition without an `iconName` a schema issue would pop-up that broke the whole app. This resolves the issue by changing the default condition to use undefined instead of null, one is schema safe (undefined) the other (null) is not.

### Testing 🧪
- Add a condition to an existing visual rule, this condition should be mesh/element coloring and not have an icon.

### Checklist ✔️
- [x] Linked associated issue (if present)
- [x] Added relevant labels
- [x] Requested developer reviews
- [x] Request UI review from design / PM
- [x] Verify all code checks are passing