### PR TITLE
Fix several Contains functions in advanced search

### DIFF
--- a/src/Components/AdvancedSearch/Internal/QueryBuilder/QueryBuilderUtils.ts
+++ b/src/Components/AdvancedSearch/Internal/QueryBuilder/QueryBuilderUtils.ts
@@ -160,7 +160,7 @@ export const buildQuery = (querySnippets: QueryRowData[]) => {
     querySnippets.forEach((snippet, index) => {
         if (snippet.operatorData.operatorType === OperatorType.Function) {
             if (index !== 0) {
-                fullQuery = fullQuery.concat(snippet.combinator + ' ');
+                fullQuery = fullQuery.concat(`${snippet.combinator} `);
             }
             fullQuery = fullQuery.concat(
                 `${snippet.operatorData.operatorFunction(

--- a/src/Components/AdvancedSearch/Internal/QueryBuilder/QueryBuilderUtils.ts
+++ b/src/Components/AdvancedSearch/Internal/QueryBuilder/QueryBuilderUtils.ts
@@ -160,7 +160,7 @@ export const buildQuery = (querySnippets: QueryRowData[]) => {
     querySnippets.forEach((snippet, index) => {
         if (snippet.operatorData.operatorType === OperatorType.Function) {
             if (index !== 0) {
-                fullQuery = fullQuery.concat(snippet.combinator);
+                fullQuery = fullQuery.concat(snippet.combinator + ' ');
             }
             fullQuery = fullQuery.concat(
                 `${snippet.operatorData.operatorFunction(


### PR DESCRIPTION
### Summary of changes 🔍 
Contains and Not Contains can now be used in advanced search. Previous issue had to do with appending combinators (AND/OR) without any spaces after them.

### Testing 🧪
Go to advanced search with live data
Try searching for twins with 2 or more contains/not contains clauses.

### Checklist ✔️
- [ ] Linked associated issue (if present)
- [ ] Added relevant labels
- [ ] Requested developer reviews
- [ ] Request UI review from design / PM
- [ ] Verify all code checks are passing