### PR TITLE
Create twin search component and use where needed

### DIFF
--- a/src/Components/ADT3DSceneBuilder/Internal/Behaviors/Twins/BehaviorTwinAliasForm.tsx
+++ b/src/Components/ADT3DSceneBuilder/Internal/Behaviors/Twins/BehaviorTwinAliasForm.tsx
@@ -23,16 +23,13 @@ import {
     IBehaviorTwinAliasItem
 } from '../../../../../Models/Classes/3DVConfig';
 import ViewerConfigUtility from '../../../../../Models/Classes/ViewerConfigUtility';
-import {
-    DTID_PROPERTY_NAME,
-    TwinAliasFormMode
-} from '../../../../../Models/Constants';
+import { TwinAliasFormMode } from '../../../../../Models/Constants';
 import { useBehaviorFormContext } from '../../../../../Models/Context/BehaviorFormContext/BehaviorFormContext';
 import { BehaviorFormContextActionType } from '../../../../../Models/Context/BehaviorFormContext/BehaviorFormContext.types';
 import { deepCopy } from '../../../../../Models/Services/Utils';
 import { ITwinToObjectMapping } from '../../../../../Models/Types/Generated/3DScenesConfiguration-v1.0.0';
 import TooltipCallout from '../../../../TooltipCallout/TooltipCallout';
-import TwinPropertySearchDropdown from '../../../../TwinPropertySearchDropdown/TwinPropertySearchDropdown';
+import TwinSearch from '../../../../TwinSearch/TwinSearch';
 import { SceneBuilderContext } from '../../../ADT3DSceneBuilder';
 import { getLeftPanelStyles } from '../../Shared/LeftPanel.styles';
 import PanelFooter from '../../Shared/PanelFooter';
@@ -268,27 +265,46 @@ const BehaviorTwinAliasForm: React.FC<{
                                     )}
                                 </Text>
                             ) : (
-                                selectedElements?.map((element, idx) => (
-                                    <TwinPropertySearchDropdown
-                                        key={`aliased-twin-${idx}`}
-                                        adapter={adapter}
-                                        label={element.displayName}
-                                        labelIconName="Shapes"
-                                        initialSelectedValue={
-                                            element.twinAliases?.[
-                                                formData.alias
-                                            ]
-                                        }
-                                        searchPropertyName={DTID_PROPERTY_NAME}
-                                        styles={{ root: { paddingBottom: 16 } }}
-                                        onChange={(selectedTwinId: string) => {
-                                            handleTwinSelect(
-                                                element.id,
-                                                selectedTwinId
-                                            );
-                                        }}
-                                    />
-                                ))
+                                selectedElements?.map((element, idx) => {
+                                    const twinId = formData.elementToTwinMappings.find(
+                                        (mapping) =>
+                                            mapping.elementId === element.id
+                                    )?.twinId;
+                                    return (
+                                        <TwinSearch
+                                            key={`aliased-twin-${idx}`}
+                                            adapter={adapter}
+                                            disableDropdownDescription={true}
+                                            dropdownLabel={element.displayName}
+                                            dropdownLabelIconName={'Shapes'}
+                                            handleSelectTwinId={(
+                                                selectedTwinId: string
+                                            ) => {
+                                                handleTwinSelect(
+                                                    element.id,
+                                                    selectedTwinId
+                                                );
+                                            }}
+                                            initialSelectedValue={
+                                                element.twinAliases?.[
+                                                    formData.alias
+                                                ]
+                                            }
+                                            isInspectorDisabled={!twinId}
+                                            twinId={twinId}
+                                            styles={{
+                                                subComponentStyles: {
+                                                    twinPropertySearchDropdown: {
+                                                        root: {
+                                                            width: '100%',
+                                                            paddingBottom: 16
+                                                        }
+                                                    }
+                                                }
+                                            }}
+                                        />
+                                    );
+                                })
                             )}
                         </div>
                     </div>

--- a/src/Components/ADT3DSceneBuilder/Internal/Elements/Internal/ElementTwinAliasForm.tsx
+++ b/src/Components/ADT3DSceneBuilder/Internal/Elements/Internal/ElementTwinAliasForm.tsx
@@ -129,18 +129,6 @@ const ElementTwinAliasForm: React.FC = () => {
                         }
                     }}
                 />
-                {/* <TwinPropertySearchDropdown
-                    key={'aliased-twin'}
-                    adapter={adapter}
-                    label={t('twinId')}
-                    labelIconName="Shapes"
-                    onChange={(selectedTwinId: string) => {
-                        handleTwinSelect(selectedTwinId);
-                    }}
-                    initialSelectedValue={formData.twinId}
-                    searchPropertyName={DTID_PROPERTY_NAME}
-                    styles={{ root: { paddingTop: 16 } }}
-                /> */}
                 <TwinSearch
                     adapter={adapter}
                     dropdownLabel={t('twinId')}

--- a/src/Components/ADT3DSceneBuilder/Internal/Elements/Internal/ElementTwinAliasForm.tsx
+++ b/src/Components/ADT3DSceneBuilder/Internal/Elements/Internal/ElementTwinAliasForm.tsx
@@ -13,14 +13,11 @@ import {
     defaultElementTwinAlias,
     IElementTwinAliasItem
 } from '../../../../../Models/Classes/3DVConfig';
-import {
-    DTID_PROPERTY_NAME,
-    TwinAliasFormMode
-} from '../../../../../Models/Constants';
+import { TwinAliasFormMode } from '../../../../../Models/Constants';
 import { useElementFormContext } from '../../../../../Models/Context/ElementsFormContext/ElementFormContext';
 import { ElementFormContextActionType } from '../../../../../Models/Context/ElementsFormContext/ElementFormContext.types';
 import TooltipCallout from '../../../../TooltipCallout/TooltipCallout';
-import TwinPropertySearchDropdown from '../../../../TwinPropertySearchDropdown/TwinPropertySearchDropdown';
+import TwinSearch from '../../../../TwinSearch/TwinSearch';
 import { SceneBuilderContext } from '../../../ADT3DSceneBuilder';
 import PanelFooter from '../../Shared/PanelFooter';
 import { getPanelFormStyles } from '../../Shared/PanelForms.styles';
@@ -132,7 +129,7 @@ const ElementTwinAliasForm: React.FC = () => {
                         }
                     }}
                 />
-                <TwinPropertySearchDropdown
+                {/* <TwinPropertySearchDropdown
                     key={'aliased-twin'}
                     adapter={adapter}
                     label={t('twinId')}
@@ -143,6 +140,25 @@ const ElementTwinAliasForm: React.FC = () => {
                     initialSelectedValue={formData.twinId}
                     searchPropertyName={DTID_PROPERTY_NAME}
                     styles={{ root: { paddingTop: 16 } }}
+                /> */}
+                <TwinSearch
+                    adapter={adapter}
+                    dropdownLabel={t('twinId')}
+                    dropdownLabelIconName={'Shapes'}
+                    handleSelectTwinId={handleTwinSelect}
+                    initialSelectedValue={formData.twinId}
+                    isInspectorDisabled={!formData.twinId}
+                    twinId={formData.twinId}
+                    styles={{
+                        subComponentStyles: {
+                            twinPropertySearchDropdown: {
+                                root: {
+                                    width: '100%',
+                                    paddingBottom: 16
+                                }
+                            }
+                        }
+                    }}
                 />
             </div>
             <PanelFooter>

--- a/src/Components/TwinSearch/TwinSearch.stories.tsx
+++ b/src/Components/TwinSearch/TwinSearch.stories.tsx
@@ -1,0 +1,37 @@
+import React, { useState } from 'react';
+import { ComponentStory } from '@storybook/react';
+import { getDefaultStoryDecorator } from '../../Models/Services/StoryUtilities';
+import TwinSearch from './TwinSearch';
+import { ITwinSearchProps } from './TwinSearch.types';
+import { MockAdapter } from '../../Adapters';
+
+const wrapperStyle = { width: '100%', height: '600px', padding: 8 };
+
+export default {
+    title: 'Components/TwinSearch',
+    component: TwinSearch,
+    decorators: [getDefaultStoryDecorator<ITwinSearchProps>(wrapperStyle)]
+};
+
+type TwinSearchStory = ComponentStory<typeof TwinSearch>;
+
+const Template: TwinSearchStory = (args) => {
+    const [selectedTwinId, setSelectedTwinId] = useState('');
+    const handleSelectTwinId = (twinId) => {
+        console.log('Selected: ' + twinId);
+        setSelectedTwinId(twinId);
+    };
+
+    return (
+        <TwinSearch
+            {...args}
+            adapter={new MockAdapter()}
+            handleSelectTwinId={handleSelectTwinId}
+            twinId={selectedTwinId}
+            isInspectorDisabled={!selectedTwinId}
+        />
+    );
+};
+
+export const Base = Template.bind({}) as TwinSearchStory;
+Base.args = {} as ITwinSearchProps;

--- a/src/Components/TwinSearch/TwinSearch.styles.ts
+++ b/src/Components/TwinSearch/TwinSearch.styles.ts
@@ -1,0 +1,28 @@
+import { ITwinSearchStyleProps, ITwinSearchStyles } from './TwinSearch.types';
+
+export const getStyles = (props: ITwinSearchStyleProps): ITwinSearchStyles => {
+    const { theme } = props;
+
+    return {
+        subComponentStyles: {
+            propertyInspector: {
+                subComponentStyles: {
+                    button: {
+                        root: {
+                            marginTop: '34px', // Needed to align button to dropdown
+                            color: theme.semanticColors.buttonText,
+                            border: `1px solid ${theme.semanticColors.inputBorder}`
+                        }
+                    }
+                }
+            },
+            advancedSearchButton: {
+                root: {
+                    marginTop: '34px', // Needed to align button to dropdown
+                    color: theme.semanticColors.buttonText,
+                    border: `1px solid ${theme.semanticColors.inputBorder}`
+                }
+            }
+        }
+    };
+};

--- a/src/Components/TwinSearch/TwinSearch.tsx
+++ b/src/Components/TwinSearch/TwinSearch.tsx
@@ -1,0 +1,139 @@
+import React, { useCallback, useRef } from 'react';
+import {
+    ITwinSearchProps,
+    ITwinSearchStyleProps,
+    ITwinSearchStyles
+} from './TwinSearch.types';
+import { getStyles } from './TwinSearch.styles';
+import {
+    classNamesFunction,
+    useTheme,
+    styled,
+    Stack,
+    IconButton
+} from '@fluentui/react';
+import { useBoolean } from '@fluentui/react-hooks';
+import TwinPropertySearchDropdown from '../TwinPropertySearchDropdown/TwinPropertySearchDropdown';
+import PropertyInspectorCallout from '../PropertyInspector/PropertyInspectorCallout/PropertyInspectorCallout';
+import { useTranslation } from 'react-i18next';
+import { DTID_PROPERTY_NAME } from '../../Models/Constants/Constants';
+import AdvancedSearch from '../AdvancedSearch/AdvancedSearch';
+import { queryAllowedPropertyValueTypes } from '../AdvancedSearch/Internal/QueryBuilder/QueryBuilder.types';
+import { PropertyValueHandle } from '../TwinPropertySearchDropdown/TwinPropertySearchDropdown.types';
+
+const getClassNames = classNamesFunction<
+    ITwinSearchStyleProps,
+    ITwinSearchStyles
+>();
+
+const TwinSearch: React.FC<ITwinSearchProps> = (props) => {
+    const {
+        adapter,
+        disableDropdownDescription,
+        dropdownDescription,
+        dropdownLabel,
+        dropdownLabelIconName,
+        handleSelectTwinId,
+        initialSelectedValue,
+        isInspectorDisabled,
+        twinId,
+        styles
+    } = props;
+
+    // Refs
+    const propertyDropdownRef = useRef<PropertyValueHandle>(null);
+
+    // contexts
+
+    // state
+    const [
+        isAdvancedSearchOpen,
+        { toggle: toggleAdvancedSearchOpen }
+    ] = useBoolean(false);
+
+    // hooks
+    const { t } = useTranslation();
+
+    // callbacks
+    const handleSearchSelectTwinId = useCallback(
+        (selectedTwinId: string) => {
+            if (propertyDropdownRef.current && selectedTwinId.length) {
+                propertyDropdownRef.current.setValue(selectedTwinId);
+                handleSelectTwinId(selectedTwinId);
+            }
+        },
+        [handleSelectTwinId]
+    );
+
+    // side effects
+
+    // styles
+    const classNames = getClassNames(styles, {
+        theme: useTheme()
+    });
+
+    return (
+        <>
+            <Stack horizontal={true} tokens={{ childrenGap: 4 }}>
+                <TwinPropertySearchDropdown
+                    ref={propertyDropdownRef}
+                    adapter={adapter}
+                    descriptionText={
+                        disableDropdownDescription
+                            ? undefined
+                            : dropdownDescription ||
+                              t(
+                                  '3dSceneBuilder.elementForm.twinNameDescription'
+                              )
+                    }
+                    label={dropdownLabel || t('3dSceneBuilder.primaryTwin')}
+                    labelIconName={dropdownLabelIconName}
+                    labelTooltip={{
+                        buttonAriaLabel: t(
+                            '3dSceneBuilder.elementForm.twinNameTooltip'
+                        ),
+                        calloutContent: t(
+                            '3dSceneBuilder.elementForm.twinNameTooltip'
+                        )
+                    }}
+                    initialSelectedValue={initialSelectedValue}
+                    searchPropertyName={DTID_PROPERTY_NAME}
+                    onChange={handleSelectTwinId}
+                    styles={
+                        classNames.subComponentStyles.twinPropertySearchDropdown
+                    }
+                />
+                <PropertyInspectorCallout
+                    adapter={adapter}
+                    twinId={twinId}
+                    disabled={isInspectorDisabled}
+                    styles={classNames.subComponentStyles.propertyInspector}
+                />
+                <IconButton
+                    iconProps={{
+                        iconName: 'QueryList'
+                    }}
+                    onClick={toggleAdvancedSearchOpen}
+                    styles={classNames.subComponentStyles.advancedSearchButton()}
+                    title={t('advancedSearch.modalTitle')}
+                />
+            </Stack>
+            {/* Modal */}
+            {isAdvancedSearchOpen && (
+                <AdvancedSearch
+                    adapter={adapter}
+                    allowedPropertyValueTypes={queryAllowedPropertyValueTypes}
+                    isOpen={isAdvancedSearchOpen}
+                    onDismiss={toggleAdvancedSearchOpen}
+                    onTwinIdSelect={handleSearchSelectTwinId}
+                />
+            )}
+        </>
+    );
+};
+
+export default styled<
+    ITwinSearchProps,
+    ITwinSearchStyleProps,
+    ITwinSearchStyles
+>(TwinSearch, getStyles);

--- a/src/Components/TwinSearch/TwinSearch.types.ts
+++ b/src/Components/TwinSearch/TwinSearch.types.ts
@@ -1,0 +1,37 @@
+import { IButtonStyles, IStyleFunctionOrObject, ITheme } from '@fluentui/react';
+import ADTAdapter from '../../Adapters/ADTAdapter';
+import MockAdapter from '../../Adapters/MockAdapter';
+import { IPropertyInspectorCalloutStyles } from '../PropertyInspector/PropertyInspectorCallout/PropertyInspectorCallout.types';
+import { ITwinPropertySearchDropdownStyles } from '../TwinPropertySearchDropdown/TwinPropertySearchDropdown.types';
+
+export interface ITwinSearchProps {
+    adapter: ADTAdapter | MockAdapter;
+    handleSelectTwinId: (selectedTwinId: string) => void;
+    initialSelectedValue: string;
+    isInspectorDisabled: boolean;
+    twinId: string;
+    disableDropdownDescription?: boolean;
+    dropdownDescription?: string;
+    dropdownLabel?: string;
+    dropdownLabelIconName?: string;
+    /**
+     * Call to provide customized styling that will layer on top of the variant rules.
+     */
+    styles?: IStyleFunctionOrObject<ITwinSearchStyleProps, ITwinSearchStyles>;
+}
+
+export interface ITwinSearchStyleProps {
+    theme: ITheme;
+}
+export interface ITwinSearchStyles {
+    /**
+     * SubComponent styles.
+     */
+    subComponentStyles?: ITwinSearchSubComponentStyles;
+}
+
+export interface ITwinSearchSubComponentStyles {
+    twinPropertySearchDropdown?: Partial<ITwinPropertySearchDropdownStyles>;
+    propertyInspector?: Partial<IPropertyInspectorCalloutStyles>;
+    advancedSearchButton?: Partial<IButtonStyles>;
+}


### PR DESCRIPTION
### Summary of changes 🔍 
Created `TwinSearch` component that includes `TwinPropertySearchDropdown`, `PropertyInspector`, and `AdvancedSearch`. Updated Element form and Twin alias forms to use it.

### Testing 🧪
- `TwinSearch` component story
- Update a behavior by adding a new twin alias, the form should now have `TwinSearch` component.
  - Editing the twin alias should also have `TwinSearch`.
- Element form should now have `TwinSearch` component and functionality should be the same.

### Checklist ✔️
- [x] Linked associated issue (if present)
- [x] Added relevant labels
- [x] Requested developer reviews
- [x] Request UI review from design / PM
- [x] Verify all code checks are passing