### PR TITLE
[Environment Picker] Fixed error message disappearing and made filter case insensitive

### DIFF
--- a/src/Components/EnvironmentPicker/EnvironmentPicker.tsx
+++ b/src/Components/EnvironmentPicker/EnvironmentPicker.tsx
@@ -483,11 +483,6 @@ const EnvironmentPicker = ({
         resource: IADTInstance | string,
         resources: Array<IADTInstance | string>
     ) => {
-        setResourcePickerErrorMessages(
-            produce((draft) => {
-                draft.adt = null;
-            })
-        ); // set the error state for permissions to null for default state before checking permission for the next changed resource
         if (
             resource &&
             (!areResourceValuesEqual(
@@ -503,6 +498,11 @@ const EnvironmentPicker = ({
             ) ||
                 resourcePickerErrorMessages.adt === undefined) // check permissions on mount for the default selected value as well
         ) {
+            setResourcePickerErrorMessages(
+                produce((draft) => {
+                    draft.adt = null;
+                })
+            ); // set the error state for permissions to null for default state before checking permission for the next changed resource
             checkPermissionsForResource(
                 resource,
                 AzureResourceTypes.DigitalTwinInstance
@@ -523,11 +523,6 @@ const EnvironmentPicker = ({
         resource: IAzureStorageAccount | string,
         resources: Array<IAzureStorageAccount | string>
     ) => {
-        setResourcePickerErrorMessages(
-            produce((draft) => {
-                draft.storageAccount = null;
-            })
-        ); // set the error state for permissions to null for default state before checking permission for the next changed resource
         if (
             resource &&
             (!areResourceValuesEqual(
@@ -541,6 +536,11 @@ const EnvironmentPicker = ({
             ) ||
                 resourcePickerErrorMessages.storageAccount === undefined) // check permissions on mount for the default selected value as well
         ) {
+            setResourcePickerErrorMessages(
+                produce((draft) => {
+                    draft.storageAccount = null;
+                })
+            ); // set the error state for permissions to null for default state before checking permission for the next changed resource
             checkPermissionsForResource(
                 resource,
                 AzureResourceTypes.StorageAccount
@@ -607,11 +607,6 @@ const EnvironmentPicker = ({
         resource: IAzureStorageBlobContainer | string,
         resources: Array<IAzureStorageBlobContainer | string>
     ) => {
-        setResourcePickerErrorMessages(
-            produce((draft) => {
-                draft.storageContainer = null;
-            })
-        ); // set the error state for permissions to null for default state before checking permission for the next changed resource
         if (
             resource &&
             (!areResourceValuesEqual(
@@ -627,6 +622,11 @@ const EnvironmentPicker = ({
             ) ||
                 resourcePickerErrorMessages.storageContainer === undefined) // check permissions on mount for the default selected value as well
         ) {
+            setResourcePickerErrorMessages(
+                produce((draft) => {
+                    draft.storageContainer = null;
+                })
+            ); // set the error state for permissions to null for default state before checking permission for the next changed resource
             checkPermissionsForResource(
                 resource,
                 AzureResourceTypes.StorageBlobContainer,

--- a/src/Components/ResourcePicker/ResourcePicker.tsx
+++ b/src/Components/ResourcePicker/ResourcePicker.tsx
@@ -584,8 +584,7 @@ const ResourcePicker: React.FC<IResourcePickerProps> = ({
                             <div className={classNames.optionText}>
                                 {getMarkedHtmlBySearch(
                                     props.data.label,
-                                    searchValue,
-                                    true
+                                    searchValue
                                 )}
                             </div>
                             {!resourcesState.isLoading &&
@@ -623,7 +622,9 @@ const ResourcePicker: React.FC<IResourcePickerProps> = ({
         if (!inputValue) return true;
         if (
             (isResourceOption(option.data) &&
-                option.data.label.includes(inputValue)) ||
+                option.data.label
+                    ?.toLowerCase()
+                    .includes(inputValue?.toLowerCase())) ||
             option.data.__isNew__
         ) {
             return true;


### PR DESCRIPTION
### Summary of changes 🔍 
- There was a bug in displaying error message when a resource not found - it was disappearing after on mount. 
- Also fixed casing in search to make it case insensitive


### Testing 🧪
On ADT3DScenePage story:
- Change your adt hostUrl, storage account id and blobContainerUrl to a resource that does not exist in your secrets file like:
![image](https://user-images.githubusercontent.com/45217314/205412687-f0fbdf6c-be2f-40d7-96ee-48775b20e867.png)
- Go to Environment Picker and see the error message persist
Also check casing in filtering by searching upper case and lower case letter.

### Checklist ✔️
- [ ] Linked associated issue (if present)
- [x] Added relevant labels
- [x] Requested developer reviews
- [ ] Request UI review from design / PM
- [x] Verify all code checks are passing