### PR TITLE
Fix bugs in Visual rules

### DIFF
--- a/src/Components/ADT3DSceneBuilder/Internal/VisualRuleForm/Internal/ConditionsCallout/ConditionsCallout.tsx
+++ b/src/Components/ADT3DSceneBuilder/Internal/VisualRuleForm/Internal/ConditionsCallout/ConditionsCallout.tsx
@@ -119,6 +119,11 @@ const ConditionsCallout: React.FC<IConditionsCalloutProps> = (props) => {
                     payload: { values: newValues }
                 });
             } else {
+                // If user types infinity or -infinity handle that case (JSON parsing turns numerical infinities to null)
+                if (newValues[0] === Infinity || newValues[0] === -Infinity) {
+                    newValues[0] = String(newValues[0]);
+                }
+
                 const rangeValues = conditionCalloutState.conditionToEdit
                     ?.values
                     ? deepCopy(conditionCalloutState.conditionToEdit.values)

--- a/src/Components/ADT3DSceneBuilder/Internal/VisualRuleForm/Internal/ConditionsCallout/ConditionsCallout.types.ts
+++ b/src/Components/ADT3DSceneBuilder/Internal/VisualRuleForm/Internal/ConditionsCallout/ConditionsCallout.types.ts
@@ -71,11 +71,7 @@ export enum ConditionCalloutActionType {
     FORM_CONDITION_VALUES_SET = 'FORM_CONDITION_VALUES_SET',
     FORM_CONDITION_COLOR_SET = 'FORM_CONDITION_COLOR_SET',
     FORM_CONDITION_ICON_SET = 'FORM_CONDITION_ICON_SET',
-    INITIALIZE_CONDITION = 'INITIALIZE_CONDITION',
-    /** Numerical values handling */
-    FORM_CONDITION_NUMERICAL_VALUES_SET = 'FORM_CONDITION_NUMERICAL_VALUES_SET',
-    FORM_CONDITION_SNAP_VALUE_TO_INFINITY = 'FORM_CONDITION_SNAP_VALUE_TO_INFINITY',
-    FORM_CONDITION_SET_ARE_RANGES_VALID = 'FORM_CONDITION_SET_ARE_RANGES_VALID'
+    INITIALIZE_CONDITION = 'INITIALIZE_CONDITION'
 }
 
 export type ConditionCalloutAction =
@@ -98,16 +94,4 @@ export type ConditionCalloutAction =
     | {
           type: ConditionCalloutActionType.INITIALIZE_CONDITION;
           payload: { valueRange: IValueRange };
-      }
-    | {
-          type: ConditionCalloutActionType.FORM_CONDITION_NUMERICAL_VALUES_SET;
-          payload: { values: ValueRangeValueType[] };
-      }
-    | {
-          type: ConditionCalloutActionType.FORM_CONDITION_SNAP_VALUE_TO_INFINITY;
-          payload: { values: ValueRangeValueType[] };
-      }
-    | {
-          type: ConditionCalloutActionType.FORM_CONDITION_SET_ARE_RANGES_VALID;
-          payload: { min: string; max: string };
       };

--- a/src/Components/ADT3DSceneBuilder/Internal/VisualRuleForm/VisualRuleForm.tsx
+++ b/src/Components/ADT3DSceneBuilder/Internal/VisualRuleForm/VisualRuleForm.tsx
@@ -11,6 +11,7 @@ import {
     TextField,
     useTheme
 } from '@fluentui/react';
+import produce from 'immer';
 import React, {
     useCallback,
     useContext,
@@ -204,15 +205,19 @@ const VisualRuleForm: React.FC<IVisualRuleFormProps> = (props) => {
             visualRuleFormState.visualRuleToEdit.valueRanges &&
             visualRuleFormState.visualRuleToEdit.valueRanges.length >= 1
         ) {
-            setValidityMap((validityMap) => {
-                validityMap.set('conditions', { isValid: true });
-                return validityMap;
-            });
+            setValidityMap(
+                produce((validityMap) => {
+                    validityMap.set('conditions', { isValid: true });
+                    return validityMap;
+                })
+            );
         } else {
-            setValidityMap((validityMap) => {
-                validityMap.set('conditions', { isValid: false });
-                return validityMap;
-            });
+            setValidityMap(
+                produce((validityMap) => {
+                    validityMap.set('conditions', { isValid: false });
+                    return validityMap;
+                })
+            );
         }
     }, [visualRuleFormState.visualRuleToEdit.valueRanges]);
 
@@ -223,10 +228,12 @@ const VisualRuleForm: React.FC<IVisualRuleFormProps> = (props) => {
             name: string
         ) => {
             const isValid = name?.trim().length > 0;
-            setValidityMap((validityMap) => {
-                validityMap.set('displayName', { isValid: isValid });
-                return validityMap;
-            });
+            setValidityMap(
+                produce((validityMap) => {
+                    validityMap.set('displayName', { isValid: isValid });
+                    return validityMap;
+                })
+            );
             visualRuleFormDispatch({
                 type:
                     VisualRuleFormActionType.FORM_VISUAL_RULE_DISPLAY_NAME_SET,
@@ -239,10 +246,12 @@ const VisualRuleForm: React.FC<IVisualRuleFormProps> = (props) => {
     const onPropertyChange = useCallback(
         (propertyExpression: PropertyExpression) => {
             const isValid = propertyExpression.expression?.trim().length > 0;
-            setValidityMap((validityMap) => {
-                validityMap.set('expression', { isValid: isValid });
-                return validityMap;
-            });
+            setValidityMap(
+                produce((validityMap) => {
+                    validityMap.set('expression', { isValid: isValid });
+                    return validityMap;
+                })
+            );
             visualRuleFormDispatch({
                 type: VisualRuleFormActionType.FORM_VISUAL_RULE_EXPRESSION_SET,
                 payload: { expression: propertyExpression.expression }


### PR DESCRIPTION
### Summary of changes 🔍 
Fixes following bugs:
- Condition range turns to null after user inputs Infinity
- Condition amount does not change Save button disabled

Also removes some unused lines.

### Testing 🧪
- Create a new visual rule
  - When adding a condition input -Infinity or Infinity in the number range input fields. (This should lead to the range having infinity set as one the values)
  - Add a condition when the rule has none. (This should remove the disabled state of the save button)
  - Remove a condition if the rule only has one. (This should add the disabled state of the save button)

### Checklist ✔️
- [ ] Linked associated issue (if present)
- [ ] Added relevant labels
- [ ] Requested developer reviews
- [ ] Request UI review from design / PM
- [ ] Verify all code checks are passing