### PR TITLE
Gauge widget should be configurable to show decimals

### DIFF
--- a/src/Adapters/__mockData__/MockGaugeData.json
+++ b/src/Adapters/__mockData__/MockGaugeData.json
@@ -1,0 +1,255 @@
+[
+  {
+    "type": "Gauge",
+    "id": "3dbbbde93325c334c93e47d077b93995",
+    "groupID": "8bf489e804884596afe8abb7e803d5c5",
+    "valueExpression": "PrimaryTwin.Outflow",
+    "widgetConfiguration": {
+      "units": "PSI",
+      "label": "Outflow",
+      "valueRanges": [
+        {
+          "id": "0278cd377adbc30253b0fdb6b5fcf160",
+          "values": [
+            "-Infinity",
+            "Infinity"
+          ],
+          "visual": {
+            "color": "#C32F27"
+          }
+        }
+      ]
+    },
+    "extensionProperties": {}
+  },
+  {
+    "type": "Gauge",
+    "id": "3dbbbde93325c334c93e47d077b93995",
+    "groupID": "8bf489e804884596afe8abb7e803d5c5",
+    "valueExpression": "PrimaryTwin.Outflow",
+    "widgetConfiguration": {
+      "units": "PSI",
+      "label": "Outflow",
+      "valueRanges": [
+        {
+          "id": "0278cd377adbc30253b0fdb6b5fcf160",
+          "values": [
+            99000000000000,
+            100000000000000
+          ],
+          "visual": {
+            "color": "#C32F27"
+          }
+        }
+      ]
+    },
+    "extensionProperties": {}
+  },
+  {
+    "type": "Gauge",
+    "id": "3dbbbde93325c334c93e47d077b93995",
+    "groupID": "8bf489e804884596afe8abb7e803d5c5",
+    "valueExpression": "PrimaryTwin.Outflow",
+    "widgetConfiguration": {
+      "units": "PSI",
+      "label": "Outflow",
+      "valueRanges": [
+        {
+          "id": "0278cd377adbc30253b0fdb6b5fcf160",
+          "values": [
+            998456543234,
+            1000000000000
+          ],
+          "visual": {
+            "color": "#C32F27"
+          }
+        }
+      ]
+    },
+    "extensionProperties": {}
+  },
+  {
+    "type": "Gauge",
+    "id": "3dbbbde93325c334c93e47d077b93995",
+    "groupID": "8bf489e804884596afe8abb7e803d5c5",
+    "valueExpression": "PrimaryTwin.Outflow",
+    "widgetConfiguration": {
+      "units": "PSI",
+      "label": "Outflow",
+      "valueRanges": [
+        {
+          "id": "0278cd377adbc30253b0fdb6b5fcf160",
+          "values": [
+            -1890000,
+            10000000
+          ],
+          "visual": {
+            "color": "#C32F27"
+          }
+        }
+      ]
+    },
+    "extensionProperties": {}
+  },
+  {
+    "type": "Gauge",
+    "id": "3dbbbde93325c334c93e47d077b93995",
+    "groupID": "8bf489e804884596afe8abb7e803d5c5",
+    "valueExpression": "PrimaryTwin.Outflow",
+    "widgetConfiguration": {
+      "units": "PSI",
+      "label": "Outflow",
+      "valueRanges": [
+        {
+          "id": "0278cd377adbc30253b0fdb6b5fcf160",
+          "values": [
+            999300.4451,
+            1000000
+          ],
+          "visual": {
+            "color": "#C32F27"
+          }
+        }
+      ]
+    },
+    "extensionProperties": {}
+  },
+  {
+    "type": "Gauge",
+    "id": "3dbbbde93325c334c93e47d077b93995",
+    "groupID": "8bf489e804884596afe8abb7e803d5c5",
+    "valueExpression": "PrimaryTwin.Outflow",
+    "widgetConfiguration": {
+      "units": "PSI",
+      "label": "Outflow",
+      "valueRanges": [
+        {
+          "id": "0278cd377adbc30253b0fdb6b5fcf160",
+          "values": [
+            977.432245,
+            1000
+          ],
+          "visual": {
+            "color": "#C32F27"
+          }
+        }
+      ]
+    },
+    "extensionProperties": {}
+  },
+  {
+    "type": "Gauge",
+    "id": "3dbbbde93325c334c93e47d077b93995",
+    "groupID": "8bf489e804884596afe8abb7e803d5c5",
+    "valueExpression": "PrimaryTwin.Outflow",
+    "widgetConfiguration": {
+      "units": "PSI",
+      "label": "Outflow",
+      "valueRanges": [
+        {
+          "id": "0278cd377adbc30253b0fdb6b5fcf160",
+          "values": [
+            99.234,
+            1000
+          ],
+          "visual": {
+            "color": "#C32F27"
+          }
+        }
+      ]
+    },
+    "extensionProperties": {}
+  },
+  {
+    "type": "Gauge",
+    "id": "3dbbbde93325c334c93e47d077b93995",
+    "groupID": "8bf489e804884596afe8abb7e803d5c5",
+    "valueExpression": "PrimaryTwin.Outflow",
+    "widgetConfiguration": {
+      "units": "PSI",
+      "label": "Outflow",
+      "valueRanges": [
+        {
+          "id": "0278cd377adbc30253b0fdb6b5fcf160",
+          "values": [
+            9.6755432,
+            1000
+          ],
+          "visual": {
+            "color": "#C32F27"
+          }
+        }
+      ]
+    },
+    "extensionProperties": {}
+  },
+  {
+    "type": "Gauge",
+    "id": "3dbbbde93325c334c93e47d077b93995",
+    "groupID": "8bf489e804884596afe8abb7e803d5c5",
+    "valueExpression": "PrimaryTwin.Outflow",
+    "widgetConfiguration": {
+      "units": "PSI",
+      "label": "Outflow",
+      "valueRanges": [
+        {
+          "id": "0278cd377adbc30253b0fdb6b5fcf160",
+          "values": [
+            0.000000001,
+            1000
+          ],
+          "visual": {
+            "color": "#C32F27"
+          }
+        }
+      ]
+    },
+    "extensionProperties": {}
+  },
+  {
+    "type": "Gauge",
+    "id": "3dbbbde93325c334c93e47d077b93995",
+    "groupID": "8bf489e804884596afe8abb7e803d5c5",
+    "valueExpression": "PrimaryTwin.Outflow",
+    "widgetConfiguration": {
+      "units": "PSI",
+      "label": "Outflow",
+      "valueRanges": [
+        {
+          "id": "0278cd377adbc30253b0fdb6b5fcf160",
+          "values": [
+            0.0000001,
+            1000
+          ],
+          "visual": {
+            "color": "#C32F27"
+          }
+        }
+      ]
+    },
+    "extensionProperties": {}
+  },
+  {
+    "type": "Gauge",
+    "id": "3dbbbde93325c334c93e47d077b93995",
+    "groupID": "8bf489e804884596afe8abb7e803d5c5",
+    "valueExpression": "PrimaryTwin.Outflow",
+    "widgetConfiguration": {
+      "units": "PSI",
+      "label": "Outflow",
+      "valueRanges": [
+        {
+          "id": "0278cd377adbc30253b0fdb6b5fcf160",
+          "values": [
+            0.001,
+            1000
+          ],
+          "visual": {
+            "color": "#C32F27"
+          }
+        }
+      ]
+    },
+    "extensionProperties": {}
+  }
+]

--- a/src/Components/BehaviorsModal/Internal/Widgets/GaugeWidget/GaugeWidget.stories.tsx
+++ b/src/Components/BehaviorsModal/Internal/Widgets/GaugeWidget/GaugeWidget.stories.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { ComponentStory } from '@storybook/react';
+import { getDefaultStoryDecorator } from '../../../../../Models/Services/StoryUtilities';
+import GaugeWidget from './GaugeWidget';
+import gaugeData from '../../../../../Adapters/__mockData__/MockGaugeData.json';
+import { IGaugeWidget } from '../../../../../Models/Types/Generated/3DScenesConfiguration-v1.0.0';
+import { BehaviorModalMode } from '../../../../../Models/Constants';
+import { BehaviorsModalContext } from '../../../BehaviorsModal';
+import { getWidgetClassNames } from '../WidgetsContainer.styles';
+import { useTheme } from '@fluentui/react';
+const wrapperStyle = { width: '100%', height: '600px', padding: 8 };
+
+export default {
+    title: 'Components/GaugeWidget',
+    component: GaugeWidget,
+    decorators: [
+        getDefaultStoryDecorator<{ widget: IGaugeWidget }>(wrapperStyle)
+    ]
+};
+
+type GaugeWidgetStory = ComponentStory<typeof GaugeWidget>;
+
+const Template: GaugeWidgetStory = (args) => {
+    const mode = BehaviorModalMode.preview;
+    const theme = useTheme();
+
+    return (
+        <BehaviorsModalContext.Provider
+            value={{
+                twins: {},
+                mode,
+                activeWidgetId: undefined
+            }}
+        >
+            <div className={getWidgetClassNames(theme, mode, false).widget}>
+                <GaugeWidget {...args} />
+            </div>
+        </BehaviorsModalContext.Provider>
+    );
+};
+
+export const InfinityValue = Template.bind({});
+InfinityValue.args = {
+    widget: gaugeData[0]
+};
+
+export const TrillionValue = Template.bind({});
+TrillionValue.args = {
+    widget: gaugeData[1]
+};
+
+export const BillionValue = Template.bind({});
+BillionValue.args = {
+    widget: gaugeData[2]
+};
+
+export const MillionValue = Template.bind({});
+MillionValue.args = {
+    widget: gaugeData[3]
+};
+
+export const ThousandsValue = Template.bind({});
+ThousandsValue.args = {
+    widget: gaugeData[4]
+};
+
+export const HundredsValue = Template.bind({});
+HundredsValue.args = {
+    widget: gaugeData[5]
+};
+
+export const TensValue = Template.bind({});
+TensValue.args = {
+    widget: gaugeData[6]
+};
+
+export const OnesValue = Template.bind({});
+OnesValue.args = {
+    widget: gaugeData[7]
+};
+
+export const BillionthValue = Template.bind({});
+BillionthValue.args = {
+    widget: gaugeData[8]
+};
+
+export const MillionthValue = Template.bind({});
+MillionthValue.args = {
+    widget: gaugeData[9]
+};
+
+export const HundredthValue = Template.bind({});
+HundredthValue.args = {
+    widget: gaugeData[10]
+};

--- a/src/Components/BehaviorsModal/Internal/Widgets/GaugeWidget/GaugeWidget.tsx
+++ b/src/Components/BehaviorsModal/Internal/Widgets/GaugeWidget/GaugeWidget.tsx
@@ -6,6 +6,7 @@ import { getStyles } from './GaugeWidget.styles';
 import GaugeChart from 'react-gauge-chart';
 import { BehaviorsModalContext } from '../../../BehaviorsModal';
 import { BehaviorModalMode } from '../../../../../Models/Constants';
+import { formatNumber } from '../../../../../Models/Services/Utils';
 
 interface IProp {
     widget: IGaugeWidget;
@@ -17,6 +18,7 @@ const GaugeWidget: React.FC<IProp> = ({ widget }) => {
     const label = widget.widgetConfiguration.label;
     const units = widget.widgetConfiguration.units || '';
     let value = 0;
+    let format = '';
     try {
         if (mode === BehaviorModalMode.preview) {
             // In preview mode, gauge uses min value range as value
@@ -32,12 +34,11 @@ const GaugeWidget: React.FC<IProp> = ({ widget }) => {
             if (!value) {
                 value = 0;
             }
-            value = Math.floor(value);
         }
     } catch {
         value = 0;
     }
-
+    format = formatNumber(value);
     const { valueRanges } = widget.widgetConfiguration;
 
     // Get active color from value range -- if value not in defined range
@@ -58,8 +59,8 @@ const GaugeWidget: React.FC<IProp> = ({ widget }) => {
         <div className={styles.gaugeInfoContainer}>
             <div className={styles.gaugeInfoLabel}>{label}</div>
             <div className={styles.gaugeInfoValueContainer}>
-                <div className={styles.gaugeInfoValue} title={String(value)}>
-                    {value}
+                <div className={styles.gaugeInfoValue} title={format}>
+                    {format}
                 </div>
                 <div className={styles.gaugeInfoUnits} title={String(units)}>
                     {units}

--- a/src/Components/BehaviorsModal/Internal/Widgets/GaugeWidget/GaugeWidget.tsx
+++ b/src/Components/BehaviorsModal/Internal/Widgets/GaugeWidget/GaugeWidget.tsx
@@ -18,7 +18,7 @@ const GaugeWidget: React.FC<IProp> = ({ widget }) => {
     const label = widget.widgetConfiguration.label;
     const units = widget.widgetConfiguration.units || '';
     let value = 0;
-    let format = '';
+    let formatedValue = '';
     try {
         if (mode === BehaviorModalMode.preview) {
             // In preview mode, gauge uses min value range as value
@@ -38,7 +38,7 @@ const GaugeWidget: React.FC<IProp> = ({ widget }) => {
     } catch {
         value = 0;
     }
-    format = formatNumber(value);
+    formatedValue = formatNumber(value);
     const { valueRanges } = widget.widgetConfiguration;
 
     // Get active color from value range -- if value not in defined range
@@ -59,8 +59,8 @@ const GaugeWidget: React.FC<IProp> = ({ widget }) => {
         <div className={styles.gaugeInfoContainer}>
             <div className={styles.gaugeInfoLabel}>{label}</div>
             <div className={styles.gaugeInfoValueContainer}>
-                <div className={styles.gaugeInfoValue} title={format}>
-                    {format}
+                <div className={styles.gaugeInfoValue} title={formatedValue}>
+                    {formatedValue}
                 </div>
                 <div className={styles.gaugeInfoUnits} title={String(units)}>
                     {units}

--- a/src/Models/Services/Utils.ts
+++ b/src/Models/Services/Utils.ts
@@ -36,6 +36,7 @@ import {
     IConsoleLogFunction,
     TimeSeriesData
 } from '../Constants/Types';
+import * as d3 from 'd3';
 
 let ajv: Ajv = null;
 const parser = createParser(ModelParsingOption.PermitAnyTopLevelElement);
@@ -827,3 +828,30 @@ export const getMockTimeSeriesDataArrayInLocalTime = (
         })).sort((a, b) => (a.timestamp as number) - (b.timestamp as number));
     });
 };
+
+export function formatNumber(val: number) {
+    if (Math.abs(val) < 1000000) {
+        if (Math.abs(val) < 0.000001) {
+            // display as scientific notation if greater than 100 thousandths
+            return d3.format('.1n')(val);
+        } else {
+            //values between [0.000001, 999,999.999] are formatted in this else statement
+            let formatted = d3.format(',.3r')(val); // format value to have 3 sig figs and add commas if necessary
+            if (formatted.indexOf('.') != -1) {
+                // if it's a decimal value, remove the trailing zeroes
+                let lastChar = formatted[formatted.length - 1];
+                while (lastChar == '0') {
+                    formatted = formatted.slice(0, -1);
+                    lastChar = formatted[formatted.length - 1];
+                }
+                if (lastChar == '.') formatted = formatted.slice(0, -1);
+            }
+            return formatted;
+        }
+    } else if (Math.abs(val) >= 1000000 && Math.abs(val) < 1000000000)
+        return d3.format('.3s')(val);
+    // suffix of M for millions
+    else if (Math.abs(val) >= 1000000000 && Math.abs(val) < 1000000000000)
+        return d3.format('.3s')(val).slice(0, -1) + 'B'; // suffix of B for billions
+    return d3.format('.1n')(val); // scientific for everything else
+}

--- a/src/Models/Services/Utils.ts
+++ b/src/Models/Services/Utils.ts
@@ -850,7 +850,7 @@ export function formatNumber(val: number) {
             }
             return formatted;
         } else {
-            //values between [0.000001, 999,999.999] are formatted in this else statement
+            //values between [0.00001, 999,999.999] are formatted in this else statement
             let formatted = format(',.3r')(val); // format value to have 3 sig figs and add commas if necessary
             if (formatted.indexOf('.') != -1) {
                 // if it's a decimal value, remove the trailing zeroes

--- a/src/Models/Services/Utils.ts
+++ b/src/Models/Services/Utils.ts
@@ -843,8 +843,12 @@ export const getMockTimeSeriesDataArrayInLocalTime = (
  */
 export function formatNumber(val: number) {
     if (Math.abs(val) < 1000000) {
-        if (Math.abs(val) < 0.000001) {
-            return format('.1n')(val);
+        let formatted = format('.1e')(val);
+        if (Math.abs(val) < 0.00001) {
+            if (Math.abs(val) == 0) {
+                formatted = format('.1n')(val);
+            }
+            return formatted;
         } else {
             //values between [0.000001, 999,999.999] are formatted in this else statement
             let formatted = format(',.3r')(val); // format value to have 3 sig figs and add commas if necessary

--- a/src/Models/Services/Utils.ts
+++ b/src/Models/Services/Utils.ts
@@ -36,7 +36,7 @@ import {
     IConsoleLogFunction,
     TimeSeriesData
 } from '../Constants/Types';
-import * as d3 from 'd3';
+import { format } from 'd3-format';
 
 let ajv: Ajv = null;
 const parser = createParser(ModelParsingOption.PermitAnyTopLevelElement);
@@ -833,14 +833,21 @@ export const getMockTimeSeriesDataArrayInLocalTime = (
     });
 };
 
+/**
+ * Takes a number and returns a string representing the formatted number
+ * @param val, number that is to be formatted
+ * @returns a string representation of the number
+ * represents infinitesimally small or large numbers in scientific notation
+ * represents tens, hundreds, and thousands with 3 sig figs w/ commas when necessary
+ * represents million and billion values with M or B suffixes
+ */
 export function formatNumber(val: number) {
     if (Math.abs(val) < 1000000) {
         if (Math.abs(val) < 0.000001) {
-            // display as scientific notation if greater than 100 thousandths
-            return d3.format('.1n')(val);
+            return format('.1n')(val);
         } else {
             //values between [0.000001, 999,999.999] are formatted in this else statement
-            let formatted = d3.format(',.3r')(val); // format value to have 3 sig figs and add commas if necessary
+            let formatted = format(',.3r')(val); // format value to have 3 sig figs and add commas if necessary
             if (formatted.indexOf('.') != -1) {
                 // if it's a decimal value, remove the trailing zeroes
                 let lastChar = formatted[formatted.length - 1];
@@ -853,9 +860,9 @@ export function formatNumber(val: number) {
             return formatted;
         }
     } else if (Math.abs(val) >= 1000000 && Math.abs(val) < 1000000000)
-        return d3.format('.3s')(val);
+        return format('.3s')(val);
     // suffix of M for millions
     else if (Math.abs(val) >= 1000000000 && Math.abs(val) < 1000000000000)
-        return d3.format('.3s')(val).slice(0, -1) + 'B'; // suffix of B for billions
-    return d3.format('.1n')(val); // scientific for everything else
+        return format('.3s')(val).slice(0, -1) + 'B'; // suffix of B for billions
+    return format('.1n')(val); // scientific for everything else
 }


### PR DESCRIPTION
### Summary of changes 🔍 
> Today, gauges only show integers... which is tough because a lot of values are only decimals. Added formatNumber() function to allow users to view decimal and large numbers with the appropriate amount of sig figs.  


### Testing 🧪
 > Take a look at the Gauge Widget Stories and also, create gauge widgets with decimal or large numbers and verify that the appropriate number is displayed.

### Checklist ✔️
- [ ] Linked associated issue (if present)
- [ ] Added relevant labels
- [ ] Requested developer reviews
- [ ] Request UI review from design / PM
- [ ] Verify all code checks are passing

https://msazure.visualstudio.com/One/_workitems/edit/14610114/