### PR TITLE
[React-select]: Styling fixes

### DIFF
--- a/src/Components/TwinPropertySearchDropdown/TwinPropertySearchDropdown.styles.ts
+++ b/src/Components/TwinPropertySearchDropdown/TwinPropertySearchDropdown.styles.ts
@@ -20,7 +20,7 @@ export const getStyles = (
 ): ITwinPropertySearchDropdownStyles => {
     const { theme } = props;
     return {
-        root: [classNames.root],
+        root: [classNames.root, { flexGrow: 1 }],
         dropdown: [classNames.dropdown],
         label: [classNames.label, { alignItems: 'center', display: 'flex' }],
         requiredIcon: [
@@ -44,6 +44,9 @@ export const getStyles = (
                     backgroundColor: theme.semanticColors.inputBackground,
                     boxShadow: theme.effects.elevation16,
                     width: props.menuWidth
+                },
+                calloutMain: {
+                    overflow: 'hidden'
                 }
             }
         }

--- a/src/Components/TwinPropertySearchDropdown/TwinPropertySearchDropdown.tsx
+++ b/src/Components/TwinPropertySearchDropdown/TwinPropertySearchDropdown.tsx
@@ -20,7 +20,7 @@ import {
     useTheme
 } from '@fluentui/react';
 import { useId } from '@fluentui/react-hooks';
-import { components, MenuProps } from 'react-select';
+import { components, MenuListProps, MenuProps } from 'react-select';
 import CreatableSelect from 'react-select/creatable';
 import useAdapter from '../../Models/Hooks/useAdapter';
 import { AdapterMethodParamsForSearchADTTwins } from '../../Models/Constants/Types';
@@ -159,6 +159,7 @@ const TwinPropertySearchDropdown = (
     }, [twinSuggestionListRef.current]);
 
     const handleOnScroll = (event) => {
+        debugger;
         const divElement = event.currentTarget as HTMLDivElement;
         if (
             divElement.scrollHeight - divElement.scrollTop <=
@@ -193,6 +194,24 @@ const TwinPropertySearchDropdown = (
     };
 
     const Menu = (props: MenuProps) => {
+        return (
+            <Callout
+                directionalHintFixed
+                directionalHint={DirectionalHint.bottomCenter}
+                gapSpace={-1}
+                isBeakVisible={false}
+                styles={classNames.subComponentStyles.callout}
+                target={`#${selectId}`}
+            >
+                <components.Menu
+                    {...(props as any)}
+                    style={{ position: 'relative' }}
+                />
+            </Callout>
+        );
+    };
+
+    const MenuList = (props: MenuListProps) => {
         const twinSuggestionListWrapperRef = useRef<HTMLDivElement>(null);
 
         // register onscroll event to the original menuList component
@@ -204,22 +223,12 @@ const TwinPropertySearchDropdown = (
                 twinSuggestionListRef.current.onscroll = handleOnScroll;
             }
         }, [twinSuggestionListWrapperRef]);
+
         return (
-            <Callout
-                directionalHintFixed
-                directionalHint={DirectionalHint.bottomCenter}
-                gapSpace={-1}
-                isBeakVisible={false}
-                styles={classNames.subComponentStyles.callout}
-                target={`#${selectId}`}
-            >
-                <div
-                    ref={twinSuggestionListWrapperRef}
-                    onScroll={handleOnScroll}
-                >
-                    <components.MenuList {...(props as any)} />
-                </div>
-            </Callout>
+            <components.MenuList
+                {...(props as any)}
+                onScroll={handleOnScroll}
+            />
         );
     };
 
@@ -274,7 +283,8 @@ const TwinPropertySearchDropdown = (
                     value={selectedOption}
                     components={{
                         Option: CustomOption,
-                        Menu: Menu
+                        Menu: Menu,
+                        MenuList: MenuList
                     }}
                     onInputChange={(inputValue, actionMeta) => {
                         logDebugConsole(
@@ -363,6 +373,7 @@ const TwinPropertySearchDropdown = (
                     isSearchable
                     isClearable
                     styles={selectStyles}
+                    menuIsOpen
                 />
                 {descriptionText && (
                     <Text

--- a/src/Components/TwinPropertySearchDropdown/TwinPropertySearchDropdown.tsx
+++ b/src/Components/TwinPropertySearchDropdown/TwinPropertySearchDropdown.tsx
@@ -20,7 +20,12 @@ import {
     useTheme
 } from '@fluentui/react';
 import { useId } from '@fluentui/react-hooks';
-import { components, MenuListProps, MenuProps } from 'react-select';
+import {
+    components,
+    MenuListProps,
+    MenuProps,
+    mergeStyles
+} from 'react-select';
 import CreatableSelect from 'react-select/creatable';
 import useAdapter from '../../Models/Hooks/useAdapter';
 import { AdapterMethodParamsForSearchADTTwins } from '../../Models/Constants/Types';
@@ -98,7 +103,18 @@ const TwinPropertySearchDropdown = (
         menuWidth: dropdownWidth
     });
     const selectStyles = useMemo(
-        () => inputStyles || getReactSelectStyles(theme),
+        () =>
+            mergeStyles(
+                getReactSelectStyles(theme, {
+                    menu: {
+                        position: 'relative',
+                        top: '0',
+                        marginBottom: 0,
+                        height: '100%'
+                    }
+                }),
+                inputStyles
+            ),
         [theme, inputStyles]
     );
 
@@ -159,7 +175,6 @@ const TwinPropertySearchDropdown = (
     }, [twinSuggestionListRef.current]);
 
     const handleOnScroll = (event) => {
-        debugger;
         const divElement = event.currentTarget as HTMLDivElement;
         if (
             divElement.scrollHeight - divElement.scrollTop <=
@@ -203,10 +218,7 @@ const TwinPropertySearchDropdown = (
                 styles={classNames.subComponentStyles.callout}
                 target={`#${selectId}`}
             >
-                <components.Menu
-                    {...(props as any)}
-                    style={{ position: 'relative' }}
-                />
+                <components.Menu {...(props as any)} />
             </Callout>
         );
     };
@@ -225,10 +237,13 @@ const TwinPropertySearchDropdown = (
         }, [twinSuggestionListWrapperRef]);
 
         return (
-            <components.MenuList
-                {...(props as any)}
+            <div
+                style={{ height: '100%' }}
+                ref={twinSuggestionListWrapperRef}
                 onScroll={handleOnScroll}
-            />
+            >
+                <components.MenuList {...(props as any)} />
+            </div>
         );
     };
 
@@ -373,7 +388,6 @@ const TwinPropertySearchDropdown = (
                     isSearchable
                     isClearable
                     styles={selectStyles}
-                    menuIsOpen
                 />
                 {descriptionText && (
                     <Text

--- a/src/Resources/Styles/ReactSelect.styles.ts
+++ b/src/Resources/Styles/ReactSelect.styles.ts
@@ -75,7 +75,7 @@ export const getReactSelectStyles = (
         }),
         menu: (provided) => ({
             ...provided,
-            marginTop: menu.marginTop
+            marginTop: menu?.marginTop
         }),
         menuList: (provided) => ({
             ...provided,

--- a/src/Resources/Styles/ReactSelect.styles.ts
+++ b/src/Resources/Styles/ReactSelect.styles.ts
@@ -39,7 +39,13 @@ const getBaseReactSelectStyles = (theme: ITheme): StylesConfig => {
 export const getReactSelectStyles = (
     theme: ITheme,
     params?: {
-        menu?: { marginTop?: number };
+        menu?: {
+            marginTop?: number;
+            marginBottom?: number;
+            position?: 'static' | 'relative' | 'absolute' | 'sticky' | 'fixed';
+            top?: string;
+            height?: string;
+        };
         menuList?: {
             isOnlyFirstRow: boolean;
             listMaxWidthLarge: number;
@@ -75,18 +81,22 @@ export const getReactSelectStyles = (
         }),
         menu: (provided) => ({
             ...provided,
-            marginTop: menu?.marginTop
+            marginTop: menu?.marginTop,
+            marginBottom: menu?.marginBottom,
+            position: menu?.position || provided.position,
+            top: menu?.top || provided.top,
+            height: menu?.height || provided.height
         }),
         menuList: (provided) => ({
             ...provided,
             backgroundColor: theme.semanticColors.inputBackground,
             color: theme.semanticColors.inputPlaceholderText,
             maxHeight: '300px',
-            maxWidth: menuList
-                ? menuList.isOnlyFirstRow
-                    ? menuList.listMaxWidthLarge
-                    : menuList.listMaxWidthCompact
-                : provided.maxWidth,
+            height: '100%',
+            maxWidth:
+                (menuList?.isOnlyFirstRow
+                    ? menuList?.listMaxWidthLarge
+                    : menuList?.listMaxWidthCompact) || provided.maxWidth,
             overflowY: 'auto',
             padding: 0,
             position: 'relative',
@@ -113,7 +123,7 @@ export const getReactSelectStyles = (
             textOverflow: 'ellipsis',
             div: {
                 // counter the menulist selector added to fix the loading message
-                color: theme.semanticColors.inputText
+                color: `${theme.semanticColors.inputText} !important`
             },
             ':active': {
                 backgroundColor: theme.semanticColors.listItemBackgroundHovered // emulate fluent behavior and keep the hover state when clicked


### PR DESCRIPTION
### Summary of changes 🔍 
- Fixed double scrollbar issue in the `TwinPropertySearchDropdown` component which consumes CreatableSelect from react-select package
- Fixed style issues like missing react-select "Menu" component in `TwinPropertySearchDropdown`
- Fixed the custom Menu and MenuList react-select components to make the onScroll callback (`handleOnScroll`) work again with scroll (to fetch the next bulk of options with adapter call)
<img width="659" alt="image" src="https://user-images.githubusercontent.com/45217314/210854420-e2fecdd2-b980-4770-a53b-c60696dba276.png">
<img width="500" alt="image" src="https://user-images.githubusercontent.com/45217314/210854444-3028b661-d8b2-4f33-ba88-ada157674a81.png">


### Testing 🧪
 You can test it in TwinSearch story, but also all the places where the TwinPropertySearchDropdown component is used:
- TwinSearch (It is in Element form in Elements tab in the 3DScene builder)
- QueryBuilderRow in advanced twin search which is opened from TwinSearch 

### Checklist ✔️
- [ ] Linked associated issue (if present)
- [x] Added relevant labels
- [x] Requested developer reviews
- [ ] Request UI review from design / PM
- [x] Verify all code checks are passing