### PR TITLE
Bug fix: Fixing the refresh issue

### DIFF
--- a/src/Adapters/ADTAdapter.ts
+++ b/src/Adapters/ADTAdapter.ts
@@ -1067,25 +1067,27 @@ export default class ADTAdapter implements IADTAdapter {
                             behaviorId
                         );
 
-                        // skip if we don't find the behavior OR if it's not in a visible layer
-                        const behaviorIdsInSelectedLayers = ViewerConfigUtility.getBehaviorIdsInSelectedLayers(
-                            config,
-                            visibleLayerIds,
-                            sceneId
-                        );
-                        if (
-                            !behavior ||
-                            (visibleLayerIds &&
-                                behaviorIdsInSelectedLayers &&
-                                !behaviorIdsInSelectedLayers.includes(
-                                    behaviorId
-                                ))
-                        ) {
-                            logDebugConsole(
-                                'debug',
-                                `Not refreshing twins for behavior (id: ${behavior.id}, name: ${behavior.displayName}) that is not in the selected layers`
+                        if (visibleLayerIds?.length > 0) {
+                            // skip if we don't find the behavior OR if it's not in a visible layer
+                            const behaviorIdsInSelectedLayers = ViewerConfigUtility.getBehaviorIdsInSelectedLayers(
+                                config,
+                                visibleLayerIds,
+                                sceneId
                             );
-                            continue;
+                            if (
+                                !behavior ||
+                                (visibleLayerIds &&
+                                    behaviorIdsInSelectedLayers &&
+                                    !behaviorIdsInSelectedLayers.includes(
+                                        behaviorId
+                                    ))
+                            ) {
+                                logDebugConsole(
+                                    'debug',
+                                    `Not refreshing twins for behavior (id: ${behavior.id}, name: ${behavior.displayName}) that is not in the selected layers`
+                                );
+                                continue;
+                            }
                         }
                         const {
                             primaryTwinIds,

--- a/src/Adapters/ADTAdapter.ts
+++ b/src/Adapters/ADTAdapter.ts
@@ -1067,27 +1067,25 @@ export default class ADTAdapter implements IADTAdapter {
                             behaviorId
                         );
 
-                        if (visibleLayerIds?.length > 0) {
-                            // skip if we don't find the behavior OR if it's not in a visible layer
-                            const behaviorIdsInSelectedLayers = ViewerConfigUtility.getBehaviorIdsInSelectedLayers(
-                                config,
-                                visibleLayerIds,
-                                sceneId
+                        // skip if we don't find the behavior OR if it's not in a visible layer
+                        const behaviorIdsInSelectedLayers = ViewerConfigUtility.getBehaviorIdsInSelectedLayers(
+                            config,
+                            visibleLayerIds,
+                            sceneId
+                        );
+                        if (
+                            !behavior ||
+                            (visibleLayerIds?.length > 0 &&
+                                behaviorIdsInSelectedLayers &&
+                                !behaviorIdsInSelectedLayers.includes(
+                                    behaviorId
+                                ))
+                        ) {
+                            logDebugConsole(
+                                'debug',
+                                `Not refreshing twins for behavior (id: ${behavior.id}, name: ${behavior.displayName}) that is not in the selected layers`
                             );
-                            if (
-                                !behavior ||
-                                (visibleLayerIds &&
-                                    behaviorIdsInSelectedLayers &&
-                                    !behaviorIdsInSelectedLayers.includes(
-                                        behaviorId
-                                    ))
-                            ) {
-                                logDebugConsole(
-                                    'debug',
-                                    `Not refreshing twins for behavior (id: ${behavior.id}, name: ${behavior.displayName}) that is not in the selected layers`
-                                );
-                                continue;
-                            }
+                            continue;
                         }
                         const {
                             primaryTwinIds,

--- a/src/Models/Hooks/useRuntimeSceneData.ts
+++ b/src/Models/Hooks/useRuntimeSceneData.ts
@@ -186,7 +186,7 @@ export const useRuntimeSceneData = (
                 twinCount: number,
                 pollingConfig: IPollingConfiguration
             ) => {
-                const fastestPossibleRefreshRateSeconds = twinCount * 100; // 10 twin/second
+                const fastestPossibleRefreshRateSeconds = twinCount * 500; // 2 twin/second
                 const actualRefreshRateSeconds = pollingConfig.minimumPollingFrequency
                     ? Math.max(
                           fastestPossibleRefreshRateSeconds,


### PR DESCRIPTION
### Summary of changes 🔍 
When manually refreshing a scene, the twins would lose the data that had been previously fetched. The long poll was working fine but when manually triggered, they would lose their data and thus the status and alerts would disappear. 
This was due to a bug where the adapter did not think the twins were in the visible layers. The root cause is that the `callAdapter` function is capturing the selectedLayer list by value and thus when the refresh is triggered, it doesn't include the right values and passes in an empty [] so the adapter thinks it shouldn't fetch any twins. When it returns back the empty `sceneVisual` collection the alerts all go away. 
Now we are assuming that if there are no selected layers, it should fetch all twins instead which avoids this pitfall.

### Testing 🧪
 > [ Add any special instructions needed to test or view your changes such as environment URLs or other config details. ]

### Checklist ✔️
- [ ] Linked associated issue (if present)
- [ ] Added relevant labels
- [ ] Requested developer reviews
- [ ] Request UI review from design / PM
- [ ] Verify all code checks are passing