### PR TITLE
Ensure that we write the configuration value for local storage on deeplink as a JSON object using appAdtUrl instead of as a string literal

### DIFF
--- a/src/Pages/ADT3DScenePage/ADT3DScenePage.tsx
+++ b/src/Pages/ADT3DScenePage/ADT3DScenePage.tsx
@@ -267,7 +267,7 @@ const ADT3DScenePageBase: React.FC<IADT3DScenePageProps> = ({
                 // TODO: instead should we expose a prop in ConsumerDeepLinkContext like "onAdtUrlChange" and
                 // do this update in the consumer side not to rely on environmentPickerOptions local storage key?
                 environmentPickerOptions.adt.selectedItemLocalStorageKey,
-                deeplinkState.adtUrl
+                JSON.stringify({ appAdtUrl: deeplinkState.adtUrl })
             );
         }
     }, [adapter, deeplinkState.adtUrl]);


### PR DESCRIPTION
See title, simple as that