### PR TITLE
OAT: Polishing graph experience

### DIFF
--- a/src/Components/OATGraphViewer/Internal/OATGraphCustomEdge.tsx
+++ b/src/Components/OATGraphViewer/Internal/OATGraphCustomEdge.tsx
@@ -856,7 +856,15 @@ const OATGraphCustomEdge: React.FC<IOATGraphCustomEdgeProps> = (props) => {
     }
     return (
         <>
+            {/* add a wider path to make the click target bigger */}
+            <path
+                id={edgeId}
+                className={graphViewerStyles.widthPath}
+                d={edgePath}
+            />
+            {/* actual colored lined */}
             <path id={edgeId} className={edgeClassName} d={edgePath} />
+            {/* text label */}
             {!hasStackedReferences ? (
                 <text>
                     <textPath
@@ -869,16 +877,6 @@ const OATGraphCustomEdge: React.FC<IOATGraphCustomEdgeProps> = (props) => {
                     </textPath>
                 </text>
             ) : (
-                // <text>
-                //     <textPath
-                //         href={`#${edgeId}`}
-                //         className={classNames.stackedReferenceCountLabel}
-                //         startOffset="50%"
-                //         textAnchor="middle"
-                //     >
-                //         {String(stackedEdges.length)}
-                //     </textPath>
-                // </text>
                 <foreignObject
                     width={STACKED_EDGE_NUMBER_OBJECT_SIZE}
                     height={STACKED_EDGE_NUMBER_OBJECT_SIZE}
@@ -893,6 +891,7 @@ const OATGraphCustomEdge: React.FC<IOATGraphCustomEdgeProps> = (props) => {
                     </div>
                 </foreignObject>
             )}
+            {/* the callout with the menu or list of stacked edges */}
             {isSelected && (
                 <foreignObject
                     width={foreignObjectSize}
@@ -938,7 +937,7 @@ const OATGraphCustomEdge: React.FC<IOATGraphCustomEdgeProps> = (props) => {
                     </Callout>
                 </foreignObject>
             )}
-            {/* Hide the indicators for self referencing ones, cause the math is wayyy too hard for V1 */}
+            {/* Hide the indicators for self referencing ones, because the math is wayyy too hard for V1 */}
             {!isSelfReferencing && (
                 <polygon
                     points={shapePoints}

--- a/src/Components/OATModelList/OATModelList.tsx
+++ b/src/Components/OATModelList/OATModelList.tsx
@@ -27,6 +27,7 @@ import {
 } from './OATModelList.types';
 import { useExtendedTheme } from '../../Models/Hooks/useExtendedTheme';
 import { TFunction } from 'i18next';
+import { parseModelId } from '../../Models/Services/OatUtils';
 
 const debugLogging = false;
 const logDebugConsole = getDebugLogger('OatModelList', debugLogging);
@@ -165,10 +166,10 @@ function getListItems(
     };
 
     const getDisplayNameText = (item: DtdlInterface) => {
-        const displayName = getModelPropertyListItemName(item.displayName);
-        return displayName.length > 0
-            ? displayName
-            : t('OATPropertyEditor.displayName');
+        return (
+            parseModelId(item['@id'])?.name ??
+            t('OATPropertyEditor.displayName')
+        );
     };
 
     const onModelDelete = (item: DtdlInterface) => {


### PR DESCRIPTION
### Summary of changes 🔍 
Adding larger click target along edges to make it easier to select

Adding ability to show the stacked model list when the edge is hovered instead of only on select.
![image](https://user-images.githubusercontent.com/57726991/212149997-6c370305-7ec3-4e52-aeb3-2ff672a5a0e4.png)


Swapping from display name to unique model name in the model list
Before
![image](https://user-images.githubusercontent.com/57726991/212149813-68e4c840-f081-4abc-be97-7518e4035dbd.png)

After
![image](https://user-images.githubusercontent.com/57726991/212149878-f40d996b-4a4d-476c-99ec-052ccfb770b3.png)


### Testing 🧪
- [x] You no longer have to click on the 1px wide line between nodes to select
- [x] Hover over an edge between nodes and see overlay
- [x] Hover over number on stacked edge and see overlay
- [x] Change a model unique name in the property editor and see the name change in the model list now.