### PR TITLE
OAT: Fix bug with switching causing crash

### DIFF
--- a/src/Models/Context/OatPageContext/OatPageContext.tsx
+++ b/src/Models/Context/OatPageContext/OatPageContext.tsx
@@ -4,7 +4,10 @@
 import produce from 'immer';
 import React, { useContext, useReducer } from 'react';
 import i18n from '../../../i18n';
-import { ProjectData } from '../../../Pages/OATEditorPage/Internal/Classes/ProjectData';
+import {
+    IOatProjectData,
+    ProjectData
+} from '../../../Pages/OATEditorPage/Internal/Classes/ProjectData';
 import {
     OAT_MODEL_ID_PREFIX,
     OAT_NAMESPACE_DEFAULT_VALUE
@@ -540,7 +543,7 @@ const getInitialState = (
         ? initialState.currentOntologyId
         : getLastUsedProjectId();
 
-    let project: ProjectData;
+    let project: IOatProjectData;
     let projectIdToUse = '';
     if (files.length > 0 && lastProjectId) {
         if (files.some((x) => x.id === lastProjectId)) {

--- a/src/Models/Context/OatPageContext/OatPageContext.types.ts
+++ b/src/Models/Context/OatPageContext/OatPageContext.types.ts
@@ -13,7 +13,7 @@ import {
     IOATModelsMetadata
 } from '../../../Pages/OATEditorPage/OATEditorPage.types';
 import { DTDLProperty } from '../../Classes/DTDL';
-import { ProjectData } from '../../../Pages/OATEditorPage/Internal/Classes/ProjectData';
+import { IOatProjectData } from '../../../Pages/OATEditorPage/Internal/Classes/ProjectData';
 import { IOATFile } from '../../../Pages/OATEditorPage/Internal/Classes/OatTypes';
 import { IDropdownOption } from '@fluentui/react';
 
@@ -215,7 +215,7 @@ export type OatPageContextAction =
       }
     | {
           type: OatPageContextActionType.SET_CURRENT_PROJECT;
-          payload: ProjectData;
+          payload: IOatProjectData;
       }
     | {
           type: OatPageContextActionType.CLEAR_GRAPH_LAYOUT;

--- a/src/Models/Context/OatPageContext/OatPageContextUtils.ts
+++ b/src/Models/Context/OatPageContext/OatPageContextUtils.ts
@@ -1,6 +1,9 @@
 import i18n from '../../../i18n';
 import { getDisplayName } from '../../../Components/OATPropertyEditor/Utils';
-import { ProjectData } from '../../../Pages/OATEditorPage/Internal/Classes';
+import {
+    IOatProjectData,
+    ProjectData
+} from '../../../Pages/OATEditorPage/Internal/Classes';
 import { IOATFile } from '../../../Pages/OATEditorPage/Internal/Classes/OatTypes';
 import {
     IOATModelPosition,
@@ -21,7 +24,6 @@ import {
 } from '../../Constants';
 import {
     buildModelId,
-    convertDtdlInterfacesToModels,
     ensureIsArray,
     getUntargetedRelationshipNodeId,
     isUntargeted,
@@ -605,7 +607,7 @@ export function switchCurrentProject(
         const projectToOpen = new ProjectData(
             data.projectName,
             data.namespace,
-            convertDtdlInterfacesToModels(data.models),
+            data.models,
             data.modelPositions,
             data.modelsMetadata,
             data.templates
@@ -627,23 +629,24 @@ export function switchCurrentProject(
 /** TODO: remove this helper when we move the project data into a sub object on the state */
 export function convertStateToProject(
     draft: IOatPageContextState
-): ProjectData {
-    // NOTE: need to recreate the arrays to break proxy links that were causing issues downstream
-    const project = new ProjectData(
-        draft.currentOntologyProjectName || '',
-        draft.currentOntologyNamespace,
-        convertDtdlInterfacesToModels(draft.currentOntologyModels),
-        Array.from(draft.currentOntologyModelPositions),
-        Array.from(draft.currentOntologyModelMetadata),
-        Array.from(draft.currentOntologyTemplates)
-    );
+): IOatProjectData {
+    // NOTE: not using constructor as it causes proxy errors on saving to JSON
+    const project: IOatProjectData = {
+        modelPositions: draft.currentOntologyModelPositions ?? [],
+        models: draft.currentOntologyModels ?? [],
+        modelsMetadata: draft.currentOntologyModelMetadata ?? [],
+        namespace: draft.currentOntologyNamespace || '',
+        projectDescription: '',
+        projectName: draft.currentOntologyProjectName || '',
+        templates: draft.currentOntologyTemplates ?? []
+    };
 
     return project;
 }
 
 export function mapProjectOntoState(
     draft: IOatPageContextState,
-    projectToOpen: ProjectData
+    projectToOpen: IOatProjectData
 ) {
     draft.currentOntologyModelPositions = projectToOpen.modelPositions;
     draft.currentOntologyModels = projectToOpen.models;

--- a/src/Models/Services/OatUtils.ts
+++ b/src/Models/Services/OatUtils.ts
@@ -1,6 +1,5 @@
 import { i18n } from 'i18next';
 import { IOATFile } from '../../Pages/OATEditorPage/Internal/Classes/OatTypes';
-import { DTDLModel } from '../Classes/DTDL';
 import {
     DtdlInterface,
     OAT_FILES_STORAGE_KEY,
@@ -75,31 +74,6 @@ export const getDirectoryPathFromDTMI = (dtmi: string) => {
         // Scheme - replace ":" with "\"
         return directoryPath.replace(':', '\\');
     }
-};
-
-/**
- * takes in a group of dtdl interfaces and builds the models objects.
- * since the properties overlap, we simply map them between objects
- */
-export const convertDtdlInterfacesToModels = (
-    dtdlInterfaces: DtdlInterface[]
-): DTDLModel[] => {
-    return dtdlInterfaces.map(convertDtdlInterfaceToModel);
-};
-export const convertDtdlInterfaceToModel = (
-    dtdlInterface: DtdlInterface
-): DTDLModel => {
-    const model = deepCopy(dtdlInterface);
-    return new DTDLModel(
-        model['@id'],
-        model.displayName,
-        model.description,
-        model.comment,
-        model.contents?.filter((x) => x['@type'] === 'Property'),
-        model.contents?.filter((x) => x['@type'] === 'Relationship'),
-        model.contents?.filter((x) => x['@type'] === 'Component'),
-        ensureIsArray(model.extends)
-    );
 };
 
 /**

--- a/src/Pages/OATEditorPage/Internal/Classes/OatTypes.ts
+++ b/src/Pages/OATEditorPage/Internal/Classes/OatTypes.ts
@@ -1,10 +1,10 @@
 import { FitViewFunc, Node, XYPosition } from 'react-flow-renderer';
 
-import { ProjectData } from './ProjectData';
+import { IOatProjectData } from './ProjectData';
 
 export interface IOATFile {
     id: string;
-    data: ProjectData;
+    data: IOatProjectData;
 }
 
 interface ViewportHelperFunctionOptions {

--- a/src/Pages/OATEditorPage/Internal/Classes/ProjectData.ts
+++ b/src/Pages/OATEditorPage/Internal/Classes/ProjectData.ts
@@ -1,11 +1,20 @@
-import { DTDLModel } from '../../../../Models/Classes/DTDL';
+import { DtdlInterface } from '../../../../Models/Constants';
 import {
     IOATModelPosition,
     IOATModelsMetadata
 } from '../../OATEditorPage.types';
 
-export class ProjectData {
-    models: DTDLModel[];
+export interface IOatProjectData {
+    models: DtdlInterface[];
+    modelPositions: IOATModelPosition[];
+    modelsMetadata: IOATModelsMetadata[];
+    namespace: string;
+    projectDescription: string;
+    projectName: string;
+    templates: any[];
+}
+export class ProjectData implements IOatProjectData {
+    models: DtdlInterface[];
     modelPositions: IOATModelPosition[];
     modelsMetadata: IOATModelsMetadata[];
     namespace: string;
@@ -16,7 +25,7 @@ export class ProjectData {
     constructor(
         projectName: string,
         namespace: string,
-        models?: DTDLModel[],
+        models?: DtdlInterface[],
         modelPositions?: IOATModelPosition[],
         modelsMetadata?: IOATModelsMetadata[],
         templates?: any[]


### PR DESCRIPTION
### Summary of changes 🔍 
Fixing this bug where making a change, switching ontologies, make another change --> crash the app
![image](https://user-images.githubusercontent.com/57726991/212436382-f44a649f-d46b-4571-9ae5-2b27158c74de.png)



### Testing 🧪
- [x] change ontology 1, switch to ontology 2, move a model --> no crash
