### PR TITLE
Iteratively remove models when they fail the parser

### DIFF
--- a/src/Adapters/__mockData__/MockAdapterData/MockModelData.json
+++ b/src/Adapters/__mockData__/MockAdapterData/MockModelData.json
@@ -2,11 +2,21 @@
     {
         "@id": "dtmi:assetGen:PasteurizationMachine;1",
         "@type": "Interface",
-        "@context": ["dtmi:dtdl:context;2"],
+        "@context": [
+            "dtmi:dtdl:context;2"
+        ],
         "displayName": "PasteurizationMachine",
         "contents": [
-            { "@type": "Property", "name": "InFlow", "schema": "double" },
-            { "@type": "Property", "name": "OutFlow", "schema": "double" },
+            {
+                "@type": "Property",
+                "name": "InFlow",
+                "schema": "double"
+            },
+            {
+                "@type": "Property",
+                "name": "OutFlow",
+                "schema": "double"
+            },
             {
                 "@type": "Property",
                 "name": "Temperature",
@@ -34,11 +44,21 @@
     {
         "@id": "dtmi:assetGen:SaltMachine;1",
         "@type": "Interface",
-        "@context": ["dtmi:dtdl:context;2"],
+        "@context": [
+            "dtmi:dtdl:context;2"
+        ],
         "displayName": "SaltMachine",
         "contents": [
-            { "@type": "Property", "name": "InFlow", "schema": "double" },
-            { "@type": "Property", "name": "OutFlow", "schema": "double" },
+            {
+                "@type": "Property",
+                "name": "InFlow",
+                "schema": "double"
+            },
+            {
+                "@type": "Property",
+                "name": "OutFlow",
+                "schema": "double"
+            },
             {
                 "@type": "Property",
                 "name": "Temperature",
@@ -49,7 +69,9 @@
     {
         "@id": "dtmi:assetGen:MaintenancePersonnel;1",
         "@type": "Interface",
-        "@context": ["dtmi:dtdl:context;2"],
+        "@context": [
+            "dtmi:dtdl:context;2"
+        ],
         "displayName": "MaintenancePersonnel",
         "contents": [
             {
@@ -68,7 +90,9 @@
     {
         "@id": "dtmi:assetGen:Factory;1",
         "@type": "Interface",
-        "@context": ["dtmi:dtdl:context;2"],
+        "@context": [
+            "dtmi:dtdl:context;2"
+        ],
         "displayName": "Factory",
         "contents": [
             {
@@ -99,7 +123,9 @@
     {
         "@id": "dtmi:assetGen:Country;1",
         "@type": "Interface",
-        "@context": ["dtmi:dtdl:context;2"],
+        "@context": [
+            "dtmi:dtdl:context;2"
+        ],
         "displayName": "Country",
         "contents": [
             {
@@ -195,7 +221,10 @@
                 "writable": true
             },
             {
-                "@type": ["Property", "Energy"],
+                "@type": [
+                    "Property",
+                    "Energy"
+                ],
                 "@id": "dtmi:com:cocrowle:batterycapacity;1",
                 "name": "BatteryCapacity",
                 "schema": "float",
@@ -206,7 +235,10 @@
                 "writable": true
             },
             {
-                "@type": ["Property", "Distance"],
+                "@type": [
+                    "Property",
+                    "Distance"
+                ],
                 "@id": "dtmi:com:cocrowle:mileage;1",
                 "name": "Mileage",
                 "schema": "integer",
@@ -458,7 +490,9 @@
                 "schema": "dtmi:digitaltwins:ngsi_ld:city:geoLocation;1"
             }
         ],
-        "@context": ["dtmi:dtdl:context;2"]
+        "@context": [
+            "dtmi:dtdl:context;2"
+        ]
     },
     {
         "@id": "dtmi:digitaltwins:ngsi_ld:city:Address;1",
@@ -502,7 +536,9 @@
                 "writable": true
             }
         ],
-        "@context": ["dtmi:dtdl:context;2"]
+        "@context": [
+            "dtmi:dtdl:context;2"
+        ]
     },
     {
         "@id": "dtmi:digitaltwins:ngsi_ld:city:geoLocation;1",
@@ -562,6 +598,58 @@
                 "writable": true
             }
         ],
-        "@context": ["dtmi:dtdl:context;2"]
+        "@context": [
+            "dtmi:dtdl:context;2"
+        ]
+    },
+    {
+        "@id": "dtmi:com:matdar:dupedProperty;1",
+        "@type": "Interface",
+        "displayName": "DupedProperty1",
+        "@context": "dtmi:dtdl:context;2",
+        "contents": [
+            {
+                "@type": "Property",
+                "name": "configurations",
+                "schema": {
+                    "@type": "Object",
+                    "fields": [
+                        {
+                            "name": "dupedProperty",
+                            "schema": "integer"
+                        },
+                        {
+                            "name": "dupedProperty",
+                            "schema": "integer"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    {
+        "@id": "dtmi:com:matdar:otherDupedProperty;1",
+        "@type": "Interface",
+        "displayName": "DupedProperty2",
+        "@context": "dtmi:dtdl:context;2",
+        "contents": [
+            {
+                "@type": "Property",
+                "name": "configurations",
+                "schema": {
+                    "@type": "Object",
+                    "fields": [
+                        {
+                            "name": "otherDupedProperty",
+                            "schema": "integer"
+                        },
+                        {
+                            "name": "otherDupedProperty",
+                            "schema": "integer"
+                        }
+                    ]
+                }
+            }
+        ]
     }
 ]

--- a/src/Models/Services/Utils.ts
+++ b/src/Models/Services/Utils.ts
@@ -83,13 +83,13 @@ export const parseDTDLModelsAsync = async (dtdlInterfaces: DtdlInterface[]) => {
                 }
             );
 
-            /* Recursively parse models if we successfully removed some models, and there are still some left */
+            /* Iteratively parse models if we successfully removed some models, and there are still some left */
             if (
                 interfacesWithoutParserErrors.length <
                     previousInterfaces.length &&
                 interfacesWithoutParserErrors.length > 0
             ) {
-                console.log('Removing model that failed to parse and retrying');
+                console.log('Removing models that failed to parse and retrying');
                 modelDict = await tryParseWorkerFunction(
                     interfacesWithoutParserErrors
                 );

--- a/src/Models/Services/Utils.ts
+++ b/src/Models/Services/Utils.ts
@@ -95,6 +95,9 @@ export const parseDTDLModelsAsync = async (dtdlInterfaces: DtdlInterface[]) => {
                 );
                 previousInterfaces = interfacesWithoutParserErrors;
                 failedModelCount++;
+            } else {
+                console.warn('Could not remove models with parser errors');
+                return null;
             }
         } catch (e) {
             console.warn('Could not remove models with parser errors');

--- a/src/Models/Services/Utils.ts
+++ b/src/Models/Services/Utils.ts
@@ -89,7 +89,9 @@ export const parseDTDLModelsAsync = async (dtdlInterfaces: DtdlInterface[]) => {
                     previousInterfaces.length &&
                 interfacesWithoutParserErrors.length > 0
             ) {
-                console.log('Removing models that failed to parse and retrying');
+                console.log(
+                    'Removing models that failed to parse and retrying'
+                );
                 modelDict = await tryParseWorkerFunction(
                     interfacesWithoutParserErrors
                 );

--- a/src/Models/Services/Utils.ts
+++ b/src/Models/Services/Utils.ts
@@ -44,40 +44,65 @@ const parser = createParser(ModelParsingOption.PermitAnyTopLevelElement);
 /** Parse DTDL models via model parser */
 export const parseDTDLModelsAsync = async (dtdlInterfaces: DtdlInterface[]) => {
     let modelDict = null;
-    try {
-        modelDict = await parser.parse(
-            dtdlInterfaces.map((dtdlInterface) => JSON.stringify(dtdlInterface))
-        );
-    } catch (e) {
-        /* Some models failed to parse, we will try to remove them and parse the rest of the models */
-        logDtdlParserError(e);
+
+    /* We loop over this function to attempt to parse models, and remove models that fail */
+    const tryParseWorkerFunction = async (interfaces: DtdlInterface[]) => {
         try {
-            const parsingErrorCauses = e?._parsingErrors.map(
+            return await parser.parse(
+                interfaces.map((dtdlInterface) => JSON.stringify(dtdlInterface))
+            );
+        } catch (e) {
+            logDtdlParserError(e);
+            return e;
+        }
+    };
+
+    modelDict = await tryParseWorkerFunction(dtdlInterfaces);
+
+    /* If some models failed to parse, we will try to remove them and parse the rest of the models */
+    let previousInterfaces = dtdlInterfaces;
+    let failedModelCount = 0;
+    const maxFailedModelCount = 20;
+    while (
+        modelDict?._parsingErrors &&
+        failedModelCount < maxFailedModelCount
+    ) {
+        try {
+            const parsingErrorCauses = modelDict?._parsingErrors?.map(
                 (pe) => pe?.cause
             ) as Array<string>;
 
             /* The parsing error cause is not a model ID, but it contains a model ID 
-               so we remove the a model if its ID is contained in the cause */
-            const modelsWithoutParserErrors = dtdlInterfaces.filter((intf) => {
-                const modelId = intf['@id'];
-                return !parsingErrorCauses.filter((parseError) =>
-                    parseError.includes(modelId)
-                ).length;
-            });
+            so we remove the a model if its ID is contained in the cause */
+            const interfacesWithoutParserErrors = previousInterfaces.filter(
+                (intf) => {
+                    const modelId = intf['@id'];
+                    return !parsingErrorCauses?.filter((parseError) =>
+                        parseError.includes(modelId)
+                    ).length;
+                }
+            );
 
-            // Recursively parse models if we successfully removed some models, and there are still some left
+            /* Recursively parse models if we successfully removed some models, and there are still some left */
             if (
-                modelsWithoutParserErrors.length < dtdlInterfaces.length &&
-                modelsWithoutParserErrors.length > 0
+                interfacesWithoutParserErrors.length <
+                    previousInterfaces.length &&
+                interfacesWithoutParserErrors.length > 0
             ) {
                 console.log('Removing model that failed to parse and retrying');
-                return await parseDTDLModelsAsync(modelsWithoutParserErrors);
+                modelDict = await tryParseWorkerFunction(
+                    interfacesWithoutParserErrors
+                );
+                previousInterfaces = interfacesWithoutParserErrors;
+                failedModelCount++;
             }
         } catch (e) {
             console.warn('Could not remove models with parser errors');
             console.log(e);
+            return null;
         }
     }
+
     return modelDict;
 };
 


### PR DESCRIPTION
### Summary of changes 🔍 
ADT allows models to have duplicate property names in object definitions in DTDL.  This is a problem, because our parser implementation forbids this.  The parser may also fail in other cases that are supported in ADT, but this is the only known case thus far.

When parsing models, if any model fails, the parser will return null.  In order to at least resolve _some_ of the valid models, we attempt to remove offending models by iteratively calling the parser by removing the models that do not parse.  In general, the parser implementation fails only one model at a time, so this may require multiple iterations.  This is a performance concern if the environment has a large number of offending models, but I think its a good balance to attempt to gracefully degrade with this recursive function since the experience degrades _so poorly_ if one of the models doesn't parse.

We limit iteration to 20 iterations, and only iterate if we successfully removed at least one model and there are models left

### Testing 🧪
I have added models with duplicate properties to MockModelData.json.  You can test the ModelledPropertyBuilder and see the associated console logging that describes the parse issues.  If you were to use this mock data in main, the ModelledPropertyBuilder dropdown would be empty because the parser would fail.  

See here: 
https://601c6b2fcd385c002100f14c-xayuksuoqh.chromatic.com/?path=/story/components-modelledpropertybuilder--toggle-mode

The console warnings for parsing are pretty printed like this...
![image](https://user-images.githubusercontent.com/4854357/212442384-c3c952fd-7adc-427d-8c53-629ff8f6b808.png)

Try it for yourself in a real environment by adding the models from the MockModelData file to your environment, and compare the hosted version with the work that I've done here.

### Checklist ✔️
- [ ] Linked associated issue (if present)
- [ ] Added relevant labels
- [ ] Requested developer reviews
- [ ] Request UI review from design / PM
- [ ] Verify all code checks are passing