### PR TITLE
OAT: Refactor import/export logic to public utils file

### DIFF
--- a/src/Components/OATHeader/OATHeader.tsx
+++ b/src/Components/OATHeader/OATHeader.tsx
@@ -19,7 +19,7 @@ import {
 import { useTranslation } from 'react-i18next';
 import JSZip from 'jszip';
 import { CommandHistoryContext } from '../../Pages/OATEditorPage/Internal/Context/CommandHistoryContext';
-import { getDebugLogger, parseModels } from '../../Models/Services/Utils';
+import { getDebugLogger } from '../../Models/Services/Utils';
 import {
     HeaderModal,
     IOATHeaderProps,
@@ -29,15 +29,14 @@ import {
 import {
     convertModelToDtdl,
     getDirectoryPathFromDTMI,
-    getFileNameFromDTMI,
-    safeJsonParse
+    getFileNameFromDTMI
 } from '../../Models/Services/OatUtils';
 import { getStyles } from './OATHeader.styles';
 import { useOatPageContext } from '../../Models/Context/OatPageContext/OatPageContext';
 import { OatPageContextActionType } from '../../Models/Context/OatPageContext/OatPageContext.types';
 import ManageOntologyModal from './internal/ManageOntologyModal/ManageOntologyModal';
 import OATConfirmDialog from '../OATConfirmDialog/OATConfirmDialog';
-import { DtdlInterface } from '../../Models/Constants';
+import { parseFilesToModels } from '../../Models/Services/OatPublicUtils';
 
 const debugLogging = false;
 const logDebugConsole = getDebugLogger('OATHeader', debugLogging);
@@ -76,202 +75,39 @@ const OATHeader: React.FC<IOATHeaderProps> = (props) => {
                 `[IMPORT] [START] Files upload. (${files.length} files) {files}`,
                 files
             );
-            // Populates fileNames and filePaths
-            // const populateMetadata = (
-            //     file: File & { webkitRelativePath?: string },
-            //     fileContent: string,
-            //     metaDataCopy: IOATModelsMetadata[]
-            // ) => {
-            //     logDebugConsole(
-            //         'debug',
-            //         '[IMPORT] [START] Populate metadata for file. {file, model, allMetadata}',
-            //         file,
-            //         fileContent,
-            //         metaDataCopy
-            //     );
-            //     // Get model metadata
-            //     // Get file name from file
-            //     let fileName = file.name;
-            //     // Get file name without extension
-            //     fileName = fileName.substring(0, fileName.lastIndexOf('.'));
-            //     // Get directory path from file
-            //     let directoryPath = file.webkitRelativePath;
-            //     // Get directory content within first and last "\"
-            //     directoryPath = directoryPath.substring(
-            //         directoryPath.indexOf('/') + 1,
-            //         directoryPath.lastIndexOf('/')
-            //     );
-
-            //     if (!metaDataCopy) {
-            //         metaDataCopy = deepCopy(
-            //             oatPageState.currentOntologyModelMetadata
-            //         );
-            //     }
-
-            //     // Get JSON from content
-            //     const json = JSON.parse(fileContent);
-            //     // Check modelsMetadata for the existence of the model, if exists, update it, if not, add it
-            //     const modelMetadata = metaDataCopy.find(
-            //         (model) => model['@id'] === json['@id']
-            //     );
-            //     if (modelMetadata) {
-            //         // Update model metadata
-            //         modelMetadata.fileName = fileName;
-            //         modelMetadata.directoryPath = directoryPath;
-            //     } else {
-            //         // Add model metadata
-            //         metaDataCopy.push({
-            //             '@id': json['@id'],
-            //             fileName: fileName,
-            //             directoryPath: directoryPath
-            //         });
-            //     }
-
-            //     logDebugConsole(
-            //         'debug',
-            //         '[IMPORT] [END] Populate metadata for file. {resultingMetadata}',
-            //         metaDataCopy
-            //     );
-            //     return metaDataCopy;
-            // };
-            const handleFileListChanged = async (files: Array<File>) => {
-                logDebugConsole(
-                    'debug',
-                    '[IMPORT] [START] Parsing files. {files}',
-                    files
-                );
-                const newModels: DtdlInterface[] = [];
-                if (files.length > 0) {
-                    const filesErrors = [];
-                    // let modelsMetadataReference = null;
-                    for (const current of files) {
-                        const content = await current.text();
-                        const model = safeJsonParse<DtdlInterface>(content);
-                        if (model) {
-                            if (
-                                oatPageState.currentOntologyModels.find(
-                                    (x) => x['@id'] === model['@id']
-                                )
-                            ) {
-                                filesErrors.push(
-                                    t(
-                                        'OATHeader.errorImportedModelAlreadyExists',
-                                        {
-                                            modelId: model['@id']
-                                        }
-                                    )
-                                );
-                            } else {
-                                newModels.push(model);
-                            }
-                        } else {
-                            filesErrors.push(
-                                t('OATHeader.errorFileInvalidJSON', {
-                                    fileName: current.name
-                                })
-                            );
-                            break;
-                        }
-                    }
-
-                    const combinedModels = [
-                        ...oatPageState.currentOntologyModels,
-                        ...newModels
-                    ];
-                    const error = await parseModels(combinedModels);
-
-                    if (error) {
-                        filesErrors.push(
-                            t('OATHeader.errorIssueWithFile', {
-                                fileName: t('OATHeader.file'),
-                                error
-                            })
-                        );
-                    }
-
-                    if (filesErrors.length === 0) {
-                        logDebugConsole(
-                            'debug',
-                            '[IMPORT] Files parsed, storing models to context. {models}',
-                            combinedModels
-                        );
-                        oatPageDispatch({
-                            type: OatPageContextActionType.IMPORT_MODELS,
-                            payload: { models: combinedModels }
-                        });
-                        // oatPageDispatch({
-                        //     type:
-                        //         OatPageContextActionType.SET_CURRENT_MODELS_METADATA,
-                        //     payload: { metadata: modelsMetadataReference }
-                        // });
-                    } else {
-                        let accumulatedError = '';
-                        for (const error of filesErrors) {
-                            accumulatedError += `${error}\n`;
-                        }
-
-                        logDebugConsole(
-                            'error',
-                            '[IMPORT] Errors while parsing. Aborting. {error}',
-                            accumulatedError
-                        );
-                        oatPageDispatch({
-                            type: OatPageContextActionType.SET_OAT_ERROR,
-                            payload: {
-                                title: t('OATHeader.errorInvalidJSON'),
-                                message: accumulatedError
-                            }
-                        });
-                    }
-                }
-                logDebugConsole(
-                    'debug',
-                    '[IMPORT] [END] Parsing files. {files}',
-                    files
-                );
-            };
-
-            const newFiles = [];
-            const newFilesErrors = [];
-
-            for (const file of files) {
-                if (file.type === 'application/json') {
-                    newFiles.push(file);
-                } else {
-                    newFilesErrors.push(
-                        t('OATHeader.errorFileFormatNotSupported', {
-                            fileName: file.name
-                        })
-                    );
-                }
-            }
-
-            if (newFilesErrors.length > 0) {
-                let accumulatedError = '';
-                for (const error of newFilesErrors) {
-                    accumulatedError += `${error} \n `;
-                }
-
+            const result = await parseFilesToModels({
+                files: files,
+                currentModels: oatPageState.currentOntologyModels,
+                translate: t
+            });
+            if (result.status === 'Success') {
+                oatPageDispatch({
+                    type: OatPageContextActionType.IMPORT_MODELS,
+                    payload: { models: result.models }
+                });
+            } else if (result.status === 'Failed') {
+                // show error
+                const error =
+                    result.errors?.length > 0
+                        ? result.errors[0]
+                        : {
+                              title: 'generic error',
+                              message: 'something went wrong'
+                          };
                 oatPageDispatch({
                     type: OatPageContextActionType.SET_OAT_ERROR,
                     payload: {
-                        title: t('OATHeader.errorFormatNoSupported'),
-                        message: accumulatedError
+                        title: error.title,
+                        message: error.message
                     }
                 });
             }
-            handleFileListChanged(newFiles);
             // Reset value of input element so that it can be reused with the same file
             uploadFolderInputRef.current.value = null;
             uploadFileInputRef.current.value = null;
-            logDebugConsole('debug', '[IMPORT] [END] Files upload.');
+            logDebugConsole('debug', '[IMPORT] [END] Files upload.', result);
         },
-        [
-            oatPageDispatch,
-            oatPageState.currentOntologyModels,
-            t,
-            uploadFileInputRef
-        ]
+        [oatPageDispatch, oatPageState.currentOntologyModels, t]
     );
 
     const getUploadFileHandler = (

--- a/src/Components/OATHeader/OATHeader.tsx
+++ b/src/Components/OATHeader/OATHeader.tsx
@@ -125,7 +125,12 @@ const OATHeader: React.FC<IOATHeaderProps> = (props) => {
                     '[END] Export models to file. {content}',
                     content
                 );
-                downloadFile(content, 'modelExport.zip');
+                downloadFile(
+                    content,
+                    `${
+                        oatPageState.currentOntologyProjectName || 'ontology'
+                    }-models.zip`
+                );
             });
         } else {
             // show error
@@ -144,7 +149,12 @@ const OATHeader: React.FC<IOATHeaderProps> = (props) => {
                 }
             });
         }
-    }, [oatPageState.currentOntologyModels, t, oatPageDispatch]);
+    }, [
+        oatPageState.currentOntologyModels,
+        oatPageState.currentOntologyProjectName,
+        t,
+        oatPageDispatch
+    ]);
 
     const getUploadFileHandler = (
         inputRef: HTMLInputElement

--- a/src/Components/OATHeader/OATHeader.tsx
+++ b/src/Components/OATHeader/OATHeader.tsx
@@ -147,12 +147,15 @@ const OATHeader: React.FC<IOATHeaderProps> = (props) => {
                     '[END] Export models to file. {content}',
                     content
                 );
-                downloadFile(
-                    content,
-                    `${
-                        oatPageState.currentOntologyProjectName || 'ontology'
-                    }-models.zip`
+                // valid filename with no special characters
+                const rgx = new RegExp(
+                    /^[a-zA-Z0-9](?:[ a-zA-Z0-9._-]*[a-zA-Z0-9])?$/g
                 );
+                let fileName = 'ontology-models.zip';
+                if (rgx.test(oatPageState.currentOntologyProjectName)) {
+                    fileName = `${oatPageState.currentOntologyProjectName}-models.zip`;
+                }
+                downloadFile(content, fileName);
             });
         } else {
             // show error

--- a/src/Components/OATHeader/OATHeader.tsx
+++ b/src/Components/OATHeader/OATHeader.tsx
@@ -32,6 +32,8 @@ import ManageOntologyModal from './internal/ManageOntologyModal/ManageOntologyMo
 import OATConfirmDialog from '../OATConfirmDialog/OATConfirmDialog';
 import {
     createZipFileFromModels,
+    IExportLocalizationKeys,
+    IImportLocalizationKeys,
     parseFilesToModels
 } from '../../Models/Services/OatPublicUtils';
 
@@ -42,6 +44,24 @@ const getClassNames = classNamesFunction<
     IOATHeaderStyleProps,
     IOATHeaderStyles
 >();
+
+/** localization keys for error messages in the Import flow */
+const IMPORT_LOC_KEYS: IImportLocalizationKeys = {
+    FileFormatNotSupportedMessage:
+        'OAT.ImportErrors.fileFormatNotSupportedMessage',
+    FileInvalidJson: 'OAT.ImportErrors.fileInvalidJSON',
+    FileFormatNotSupportedTitle: 'OAT.ImportErrors.fileFormatNotSupportedTitle',
+    ImportFailedTitle: 'OAT.ImportErrors.importFailedTitle',
+    ImportFailedMessage: 'OAT.ImportErrors.importFailedMessage',
+    ExceptionTitle: 'OAT.Common.unhandledExceptionTitle',
+    ExceptionMessage: 'OAT.Common.unhandledExceptionMessage'
+};
+
+/** localization keys for error messages in the Export flow */
+const EXPORT_LOC_KEYS: IExportLocalizationKeys = {
+    ExceptionTitle: 'OAT.Common.unhandledExceptionTitle',
+    ExceptionMessage: 'OAT.Common.unhandledExceptionMessage'
+};
 
 const OATHeader: React.FC<IOATHeaderProps> = (props) => {
     const { styles } = props;
@@ -75,6 +95,7 @@ const OATHeader: React.FC<IOATHeaderProps> = (props) => {
             const result = await parseFilesToModels({
                 files: files,
                 currentModels: oatPageState.currentOntologyModels,
+                localizationKeys: IMPORT_LOC_KEYS,
                 translate: t
             });
             if (result.status === 'Success') {
@@ -116,6 +137,7 @@ const OATHeader: React.FC<IOATHeaderProps> = (props) => {
 
         const zipResult = createZipFileFromModels({
             models: oatPageState.currentOntologyModels,
+            localizationKeys: EXPORT_LOC_KEYS,
             translate: t
         });
         if (zipResult.status === 'Success') {

--- a/src/Components/OATHeader/OATHeader.tsx
+++ b/src/Components/OATHeader/OATHeader.tsx
@@ -46,7 +46,7 @@ const getClassNames = classNamesFunction<
 >();
 
 /** localization keys for error messages in the Import flow */
-const IMPORT_LOC_KEYS: IImportLocalizationKeys = {
+export const IMPORT_LOC_KEYS: IImportLocalizationKeys = {
     FileFormatNotSupportedMessage:
         'OAT.ImportErrors.fileFormatNotSupportedMessage',
     FileInvalidJson: 'OAT.ImportErrors.fileInvalidJSON',
@@ -58,7 +58,7 @@ const IMPORT_LOC_KEYS: IImportLocalizationKeys = {
 };
 
 /** localization keys for error messages in the Export flow */
-const EXPORT_LOC_KEYS: IExportLocalizationKeys = {
+export const EXPORT_LOC_KEYS: IExportLocalizationKeys = {
     ExceptionTitle: 'OAT.Common.unhandledExceptionTitle',
     ExceptionMessage: 'OAT.Common.unhandledExceptionMessage'
 };

--- a/src/Components/OATPropertyEditor/Internal/JSONEditor.tsx
+++ b/src/Components/OATPropertyEditor/Internal/JSONEditor.tsx
@@ -7,7 +7,7 @@ import {
     getCancelButtonStyles,
     getSaveButtonStyles
 } from '../OATPropertyEditor.styles';
-import { deepCopy, parseModels } from '../../../Models/Services/Utils';
+import { deepCopy } from '../../../Models/Services/Utils';
 import { CommandHistoryContext } from '../../../Pages/OATEditorPage/Internal/Context/CommandHistoryContext';
 import { JSONEditorProps } from './JSONEditor.types';
 import { OAT_RELATIONSHIP_HANDLE_NAME } from '../../../Models/Constants';
@@ -16,6 +16,7 @@ import { getTargetFromSelection, replaceTargetFromSelection } from '../Utils';
 import { useOatPageContext } from '../../../Models/Context/OatPageContext/OatPageContext';
 import { OatPageContextActionType } from '../../../Models/Context/OatPageContext/OatPageContext.types';
 import { APP_BACKGROUND_KRAKEN } from '../../../Models/Constants/StyleConstants';
+import { parseModels } from '../../../Models/Services/OatPublicUtils';
 
 function setEditorTheme(monaco: any) {
     monaco.editor.defineTheme('kraken', {

--- a/src/Models/Context/OatPageContext/OatPageContext.mock.ts
+++ b/src/Models/Context/OatPageContext/OatPageContext.mock.ts
@@ -11,7 +11,11 @@ import {
     IOATModelsMetadata
 } from '../../../Pages/OATEditorPage/OATEditorPage.types';
 import { DTDLModel, DTDLProperty } from '../../Classes/DTDL';
-import { DtdlInterfaceContent, OatReferenceType } from '../../Constants';
+import {
+    DtdlInterface,
+    DtdlInterfaceContent,
+    OatReferenceType
+} from '../../Constants';
 import {
     buildModelId,
     getAvailableLanguages,
@@ -37,7 +41,7 @@ const getMockPositionItem = (id: string): IOATModelPosition => {
     };
 };
 
-export const getMockModelItem = (id: string): DTDLModel => {
+export const getMockModelItem = (id: string): DtdlInterface => {
     const modelName = parseModelId(id).name;
     return new DTDLModel(
         id,

--- a/src/Models/Services/OatPublicUtils.ts
+++ b/src/Models/Services/OatPublicUtils.ts
@@ -22,16 +22,15 @@ interface IImportFileResult {
     status: Status;
 }
 
-const IMPORT_LOC_KEYS = {
+export const IMPORT_LOC_KEYS = {
     ERRORS: {
         FileFormatNotSupportedMessage:
             'OAT.ImportErrors.fileFormatNotSupportedMessage',
         FileInvalidJson: 'OAT.ImportErrors.fileInvalidJSON',
         FileFormatNotSupportedTitle:
             'OAT.ImportErrors.fileFormatNotSupportedTitle',
-        InvalidJson: 'OAT.ImportErrors.invalidJSON',
-        IssueWithFile: 'OAT.ImportErrors.issueWithFile',
-        ModelAlreadyExists: 'OAT.ImportErrors.modelAlreadyExists'
+        ImportFailedTitle: 'OAT.ImportErrors.importFailedTitle',
+        IssueWithFile: 'OAT.ImportErrors.issueWithFile'
     }
 };
 export const parseFilesToModels = async (
@@ -148,7 +147,6 @@ const getModelsFromFiles = async (
     const filesErrors: string[] = [];
 
     for (const current of files) {
-        console.log(current);
         const content = await current.text();
         const model = safeJsonParse<DtdlInterface>(content);
 
@@ -160,17 +158,7 @@ const getModelsFromFiles = async (
             );
             break;
         }
-
-        // manual validations
-        if (currentModels.find((x) => x['@id'] === model['@id'])) {
-            filesErrors.push(
-                translate(IMPORT_LOC_KEYS.ERRORS.ModelAlreadyExists, {
-                    modelId: model['@id']
-                })
-            );
-        } else {
-            newModels.push(model);
-        }
+        newModels.push(model);
     }
 
     // run the parser for full validations
@@ -203,7 +191,7 @@ const getModelsFromFiles = async (
             accumulatedError
         );
         result.errors.push({
-            title: translate(IMPORT_LOC_KEYS.ERRORS.InvalidJson),
+            title: translate(IMPORT_LOC_KEYS.ERRORS.ImportFailedTitle),
             message: accumulatedError
         });
     }

--- a/src/Models/Services/OatPublicUtils.ts
+++ b/src/Models/Services/OatPublicUtils.ts
@@ -1,0 +1,211 @@
+import { TFunction } from 'i18next';
+import { DtdlInterface } from '../Constants/dtdlInterfaces';
+import { safeJsonParse } from './OatUtils';
+import { getDebugLogger, parseModels } from './Utils';
+
+const debugLogging = true;
+const logDebugConsole = getDebugLogger('OATPublicUtils', debugLogging);
+
+type Status = 'Success' | 'Failed';
+interface IImportFileArgs {
+    files: File[];
+    currentModels: DtdlInterface[];
+    translate: TFunction;
+}
+interface IImportError {
+    title: string;
+    message: string;
+}
+interface IImportFileResult {
+    models: DtdlInterface[];
+    errors: IImportError[];
+    status: Status;
+}
+
+const IMPORT_LOC_KEYS = {
+    ERRORS: {
+        FileFormatNotSupportedMessage:
+            'OAT.ImportErrors.fileFormatNotSupportedMessage',
+        FileInvalidJson: 'OAT.ImportErrors.fileInvalidJSON',
+        FileFormatNotSupportedTitle:
+            'OAT.ImportErrors.fileFormatNotSupportedTitle',
+        InvalidJson: 'OAT.ImportErrors.invalidJSON',
+        IssueWithFile: 'OAT.ImportErrors.issueWithFile',
+        ModelAlreadyExists: 'OAT.ImportErrors.modelAlreadyExists'
+    }
+};
+export const parseFilesToModels = async (
+    args: IImportFileArgs
+): Promise<IImportFileResult> => {
+    const { files, currentModels = [], translate } = args;
+    const result: IImportFileResult = {
+        errors: [],
+        models: [],
+        status: 'Success'
+    };
+    try {
+        if (files?.length === 0) {
+            logDebugConsole(
+                'warn',
+                `[IMPORT] No files provided, aborting.`,
+                files
+            );
+            return result;
+        }
+
+        logDebugConsole(
+            'debug',
+            `[IMPORT] [START] Files upload. (${files.length} files) {files}`,
+            files
+        );
+        const validFiles = getValidFiles(files);
+        if (validFiles.failedFileNames.length > 0) {
+            result.errors = [
+                {
+                    title: translate(
+                        IMPORT_LOC_KEYS.ERRORS.FileFormatNotSupportedTitle
+                    ),
+                    message: translate(
+                        IMPORT_LOC_KEYS.ERRORS.FileFormatNotSupportedMessage,
+                        {
+                            fileNames: validFiles.failedFileNames
+                                .map((x) => `'${x}'`)
+                                .join('\n')
+                        }
+                    )
+                }
+            ];
+            result.status = 'Failed';
+        } else {
+            const parseResult = await parseFilesToModelsInternal(
+                validFiles.validFiles,
+                currentModels,
+                translate
+            );
+            result.errors = parseResult.errors;
+            result.models = parseResult.models;
+            result.status =
+                parseResult.errors?.length > 0 ? 'Failed' : 'Success';
+        }
+        logDebugConsole(
+            'debug',
+            '[IMPORT] [END] Files upload. {result}',
+            result
+        );
+        return result;
+    } catch (error) {
+        result.status = 'Failed';
+        result.errors.push({
+            title: 'Unexpected exception',
+            message: 'Exception: ' + error
+        });
+        logDebugConsole(
+            'debug',
+            '[IMPORT] [END] Files upload. {result}',
+            result
+        );
+        return result;
+    }
+};
+
+const getValidFiles = (
+    files: File[]
+): { validFiles: File[]; failedFileNames: string[] } => {
+    const newFiles = [];
+    const failedFileNames = [];
+
+    for (const file of files) {
+        if (file.type === 'application/json') {
+            newFiles.push(file);
+        } else {
+            failedFileNames.push(file.name);
+        }
+    }
+    return { validFiles: newFiles, failedFileNames: failedFileNames };
+};
+
+interface IParseFilesResult {
+    models: DtdlInterface[];
+    errors: IImportError[];
+}
+const parseFilesToModelsInternal = async (
+    files: Array<File>,
+    currentModels: DtdlInterface[],
+    translate: TFunction
+): Promise<IParseFilesResult> => {
+    const result: IParseFilesResult = {
+        errors: [],
+        models: []
+    };
+    if (files.length === 0) {
+        logDebugConsole('warn', '[IMPORT] No files to parse, skipping');
+        return result;
+    }
+
+    logDebugConsole('debug', '[IMPORT] [START] Parsing files. {files}', files);
+    const newModels: DtdlInterface[] = [];
+    const filesErrors: string[] = [];
+
+    for (const current of files) {
+        console.log(current);
+        const content = await current.text();
+        const model = safeJsonParse<DtdlInterface>(content);
+
+        if (!model) {
+            filesErrors.push(
+                translate(IMPORT_LOC_KEYS.ERRORS.FileInvalidJson, {
+                    fileName: current.name
+                })
+            );
+            break;
+        }
+
+        // manual validations
+        if (currentModels.find((x) => x['@id'] === model['@id'])) {
+            filesErrors.push(
+                translate(IMPORT_LOC_KEYS.ERRORS.ModelAlreadyExists, {
+                    modelId: model['@id']
+                })
+            );
+        } else {
+            newModels.push(model);
+        }
+    }
+
+    // run the parser for full validations
+    const combinedModels = [...currentModels, ...newModels];
+    const error = await parseModels(combinedModels);
+    if (error) {
+        filesErrors.push(
+            translate(IMPORT_LOC_KEYS.ERRORS.IssueWithFile, {
+                error
+            })
+        );
+    }
+
+    if (filesErrors.length === 0) {
+        logDebugConsole(
+            'debug',
+            '[IMPORT] Files parsed. {models}',
+            combinedModels
+        );
+        result.models = combinedModels;
+    } else {
+        let accumulatedError = '';
+        for (const error of filesErrors) {
+            accumulatedError += `${error}\n`;
+        }
+
+        logDebugConsole(
+            'error',
+            '[IMPORT] Errors while parsing. {error}',
+            accumulatedError
+        );
+        result.errors.push({
+            title: translate(IMPORT_LOC_KEYS.ERRORS.InvalidJson),
+            message: accumulatedError
+        });
+    }
+    logDebugConsole('debug', '[IMPORT] [END] Parsing files. {files}', files);
+    return result;
+};

--- a/src/Models/Services/OatPublicUtils.ts
+++ b/src/Models/Services/OatPublicUtils.ts
@@ -1,6 +1,5 @@
 import { createParser, ModelParsingOption } from 'azure-iot-dtdl-parser';
 import JSZip from 'jszip';
-import { TFunction } from 'react-i18next';
 import { DtdlInterface } from '../Constants/dtdlInterfaces';
 import { convertModelToDtdl, safeJsonParse } from './OatUtils';
 import { getDebugLogger } from './Utils';
@@ -35,6 +34,8 @@ export async function parseModels(models: DtdlInterface[]): Promise<string> {
     }
 }
 
+// defined our own type since the i18next type was breaking rollup for some reason
+type TranslateFunction = (key: string, args?: Record<string, string>) => string;
 type ImportStatus = 'Success' | 'Failed';
 export interface IImportLocalizationKeys {
     FileFormatNotSupportedMessage: string;
@@ -51,7 +52,7 @@ interface IImportFileArgs {
     /** the existing models in the ontology to merge with */
     currentModels: DtdlInterface[];
     /** localization translation function */
-    translate: TFunction<string>;
+    translate: TranslateFunction;
     localizationKeys: IImportLocalizationKeys;
 }
 interface IImportError {
@@ -168,7 +169,7 @@ interface IParseFilesResult {
 const getModelsFromFiles = async (
     files: Array<File>,
     currentModels: DtdlInterface[],
-    translate: TFunction<string>,
+    translate: TranslateFunction,
     localizationKeys: IImportLocalizationKeys
 ): Promise<IParseFilesResult> => {
     const result: IParseFilesResult = {
@@ -250,7 +251,7 @@ interface IExportModelsArgs {
     /** the existing models in the ontology to merge with */
     models: DtdlInterface[];
     /** localization translation function */
-    translate: TFunction<string>;
+    translate: TranslateFunction;
     /** the keys to use for localized strings */
     localizationKeys: IExportLocalizationKeys;
 }

--- a/src/Models/Services/OatPublicUtils.ts
+++ b/src/Models/Services/OatPublicUtils.ts
@@ -51,7 +51,7 @@ interface IImportFileArgs {
     /** the existing models in the ontology to merge with */
     currentModels: DtdlInterface[];
     /** localization translation function */
-    translate: TFunction;
+    translate: TFunction<string>;
     localizationKeys: IImportLocalizationKeys;
 }
 interface IImportError {
@@ -168,7 +168,7 @@ interface IParseFilesResult {
 const getModelsFromFiles = async (
     files: Array<File>,
     currentModels: DtdlInterface[],
-    translate: TFunction,
+    translate: TFunction<string>,
     localizationKeys: IImportLocalizationKeys
 ): Promise<IParseFilesResult> => {
     const result: IParseFilesResult = {
@@ -240,6 +240,7 @@ const getModelsFromFiles = async (
 // #endregion
 
 // #region Export
+
 type ExportStatus = 'Success' | 'Failed';
 export interface IExportLocalizationKeys {
     ExceptionTitle: string;
@@ -249,7 +250,7 @@ interface IExportModelsArgs {
     /** the existing models in the ontology to merge with */
     models: DtdlInterface[];
     /** localization translation function */
-    translate: TFunction;
+    translate: TFunction<string>;
     /** the keys to use for localized strings */
     localizationKeys: IExportLocalizationKeys;
 }

--- a/src/Models/Services/OatUtils.ts
+++ b/src/Models/Services/OatUtils.ts
@@ -48,34 +48,6 @@ export const storeOntologiesToStorage = (files: IOATFile[]) => {
 
 //#endregion
 
-// Get fileName from DTMI
-export const getFileNameFromDTMI = (dtmi: string) => {
-    // Get id path - Get section between last ":" and ";"
-    const initialPosition = dtmi.lastIndexOf(':') + 1;
-    const finalPosition = dtmi.lastIndexOf(';');
-
-    if (initialPosition !== 0 && finalPosition !== -1) {
-        const idPath = dtmi.substring(initialPosition, finalPosition);
-        const idVersion = dtmi.substring(
-            dtmi.lastIndexOf(';') + 1,
-            dtmi.length
-        );
-        return `${idPath}-${idVersion}`;
-    }
-};
-
-// Get directoryPath from DTMI
-export const getDirectoryPathFromDTMI = (dtmi: string) => {
-    const initialPosition = dtmi.indexOf(':') + 1;
-    const finalPosition = dtmi.lastIndexOf(':');
-
-    if (initialPosition !== 0 && finalPosition !== -1) {
-        const directoryPath = dtmi.substring(initialPosition, finalPosition);
-        // Scheme - replace ":" with "\"
-        return directoryPath.replace(':', '\\');
-    }
-};
-
 /**
  * Tries to parse a string to an object of type `T`. Returns null and eats any exception thrown in case of an error.
  * @param value string value to parse

--- a/src/Models/Services/Utils.ts
+++ b/src/Models/Services/Utils.ts
@@ -538,25 +538,6 @@ export function rgbToHex(r, g, b) {
     return '#' + componentToHex(r) + componentToHex(g) + componentToHex(b);
 }
 
-export async function parseModels(models: DtdlInterface[]) {
-    const modelParser = createParser(
-        ModelParsingOption.PermitAnyTopLevelElement
-    );
-    try {
-        await modelParser.parse([JSON.stringify(models)]);
-        return '';
-    } catch (err) {
-        console.error('Error while parsing models {input, error}', models, err);
-        if (err.name === 'ParsingException') {
-            return err._parsingErrors
-                .map((e) => `${e.cause} ${e.action}`)
-                .join('\n');
-        }
-
-        return err.message;
-    }
-}
-
 /**
  * Sorts a list alphabetically ignoring casing
  * @example listItems.sort(sortCaseInsensitiveAlphabetically())

--- a/src/Models/Services/Utils.ts
+++ b/src/Models/Services/Utils.ts
@@ -1005,3 +1005,15 @@ export function capitalizeFirstLetter(str: string) {
         return str;
     }
 }
+
+/** downloads a file as a blob to the user's machine */
+export function downloadFile(blob: Blob, fileName: string) {
+    const blobURL = window.URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.setAttribute('href', blobURL);
+    link.setAttribute('download', fileName);
+    link.innerHTML = '';
+    document.body.appendChild(link);
+    link.click();
+    link.parentNode.removeChild(link);
+}

--- a/src/Models/Services/__tests__/OatPublicUtils.test.ts
+++ b/src/Models/Services/__tests__/OatPublicUtils.test.ts
@@ -1,6 +1,6 @@
 import { cleanup } from '@testing-library/react-hooks';
 import { getMockModelItem } from '../../Context/OatPageContext/OatPageContext.mock';
-import { IMPORT_LOC_KEYS, parseFilesToModels } from '../OatPublicUtils';
+import { parseFilesToModels } from '../OatPublicUtils';
 
 afterEach(cleanup);
 

--- a/src/Models/Services/__tests__/OatPublicUtils.test.ts
+++ b/src/Models/Services/__tests__/OatPublicUtils.test.ts
@@ -1,0 +1,81 @@
+import { cleanup } from '@testing-library/react-hooks';
+import { getMockModelItem } from '../../Context/OatPageContext/OatPageContext.mock';
+import { parseFilesToModels } from '../OatPublicUtils';
+
+afterEach(cleanup);
+
+jest.mock('azure-iot-dtdl-parser', () => {
+    const originalModule = jest.requireActual('azure-iot-dtdl-parser');
+    return {
+        ...originalModule,
+        createParser: jest.fn().mockImplementation(() => {
+            return {
+                parse: () => Promise.resolve()
+            };
+        })
+    };
+});
+
+describe('OatPublicUtils', () => {
+    const mockTranslate = (key: string, args: any) => {
+        return `${key}:${JSON.stringify(args)}`;
+    };
+    const DEFAULT_MODEL_ID = 'dtmi:test-model-1;1';
+    const DEFAULT_FILE_NAME = 'test-file-1';
+    const getMockFile = (modelId?: string, fileName?: string): File => {
+        const name = fileName ?? DEFAULT_FILE_NAME;
+        const content = JSON.stringify(
+            getMockModelItem(modelId ?? DEFAULT_MODEL_ID)
+        );
+        const file = new File([], name, {
+            type: 'application/json'
+        });
+        file.text = () => Promise.resolve(content);
+        return file;
+    };
+    describe('parseFilesToModels', () => {
+        test('empty file list is success with no models or errors', async () => {
+            // ARRANGE
+            const files = [];
+            // ACT
+            const result = await parseFilesToModels({
+                files: files,
+                currentModels: [],
+                translate: mockTranslate
+            });
+            // ASSERT
+            expect(result.status).toEqual('Success');
+            expect(result.errors).toEqual([]);
+            expect(result.models).toEqual([]);
+        });
+        test('single file parses successfully', async () => {
+            // ARRANGE
+            const files = [getMockFile()];
+            // ACT
+            const result = await parseFilesToModels({
+                files: files,
+                currentModels: [],
+                translate: mockTranslate
+            });
+            // ASSERT
+            expect(result.status).toEqual('Success');
+            expect(result.errors).toEqual([]);
+            expect(result.models.length).toEqual(1);
+            expect(result.models[0]['@id']).toEqual(DEFAULT_MODEL_ID);
+        });
+        xtest('do it', async () => {
+            // ARRANGE
+            const files = [];
+            // ACT
+            const result = await parseFilesToModels({
+                files: files,
+                currentModels: [],
+                translate: mockTranslate
+            });
+            // ASSERT
+            expect(result.status).toEqual('Success');
+            expect(result.errors).toEqual([]);
+            expect(result.models).toEqual([]);
+        });
+    });
+});

--- a/src/Models/Services/index.ts
+++ b/src/Models/Services/index.ts
@@ -3,3 +3,4 @@ export { default as TelemetryService } from './TelemetryService/TelemetryService
 export * as Telemetry from './TelemetryService/Telemetry';
 export * as TelemetryTypes from './TelemetryService/TelemetryService.types';
 export * as Utils from './Utils';
+export * as OatPublicUtils from './OatPublicUtils';

--- a/src/Resources/Locales/cs.json
+++ b/src/Resources/Locales/cs.json
@@ -917,7 +917,6 @@
     "sync": "synchronizovat",
     "import": "Dovoz",
     "export": "Vývoz",
-    "file": "Soubor",
     "new": "Nový",
     "open": "Otevřený",
     "saveAs": "Uložit jako",
@@ -937,17 +936,11 @@
     "enterANamespace": "Zadání oboru názvů",
     "errorNamespace": "Název může obsahovat pouze znaky a-z, A-Z, 0-9 a podtržítko. První znak nemusí být číslice a poslední znak nemusí být podtržítko.",
     "settings": "Nastavení",
-    "errorInvalidJSON": "Neplatný JSON",
-    "errorFileFormatNotSupported": "Problém s {{fileName}}: Formát není podporován",
     "errorSingleFileHoldsRelationships": "Problém s {{fileName}}: Model obsahuje relace, které nejsou importovány",
-    "errorFormatNoSupported": "Formát souboru není podporován",
-    "errorIssueWithFile": "Problém s {{fileName}}: {{error}}",
     "undo": "Odčinit",
     "redo": "Předělat",
     "folderUpload": "Nahrání složky",
     "fileUpload": "Nahrání souboru",
-    "errorImportedModelAlreadyExists": "Problém s {{modelId}}: Model se stejným @id již existuje",
-    "errorFileInvalidJSON": "Problém s {{fileName}}: Neplatný JSON",
     "deleteProjectMessage": "Opravdu chcete odstranit {{projectName}}?",
     "errorSameName": "Projekt se stejným názvem již existuje. Chcete ji přepsat?",
     "fileOpenModal": {
@@ -1416,6 +1409,14 @@
     },
     "Common": {
       "untargeted": "Necílené"
+    },
+    "ImportErrors": {
+      "fileFormatNotSupportedMessage": "Podporují se jenom soubory JSON. Nelze importovat následující soubory: \n{{fileNames}}.",
+      "fileFormatNotSupportedTitle": "Formát souboru není podporován",
+      "fileInvalidJSON": "Nelze importovat '{{fileName}}', obsahuje neplatný JSON.",
+      "invalidJSON": "Neplatný kód JSON",
+      "issueWithFile": "Problém se souborem: {{error}}",
+      "modelAlreadyExists": "Model s @id ({{modelId}}) již existuje"
     }
   }
 }

--- a/src/Resources/Locales/de.json
+++ b/src/Resources/Locales/de.json
@@ -917,7 +917,6 @@
     "sync": "synchronisieren",
     "import": "Importieren",
     "export": "Exportieren",
-    "file": "Datei",
     "new": "Neu",
     "open": "Offen",
     "saveAs": "Speichern unter",
@@ -934,10 +933,6 @@
     "namespace": "Namespace",
     "enterANamespace": "Eingeben eines Namespaces",
     "settings": "Einstellungen",
-    "errorInvalidJSON": "Ungültiges JSON",
-    "errorFileFormatNotSupported": "{{file}}-Format wird nicht unterstützt",
-    "errorFormatNoSupported": "Dateiformat nicht unterstützt",
-    "errorIssueWithFile": "Problem mit {{fileName}}: {{error}}",
     "errorNamespace": "Der Namespace darf nur Buchstaben, Ziffern und Unterstriche enthalten.",
     "undo": "Aufmachen",
     "redo": "Noch einmal machen",
@@ -946,8 +941,6 @@
     "fileUpload": "Datei-Upload",
     "selectFile": "Datei auswählen",
     "errorSingleFileHoldsRelationships": "Problem mit {{fileName}}: Das Modell enthält Beziehungen, die nicht importiert werden",
-    "errorImportedModelAlreadyExists": "Problem mit {{modelId}}: Modell mit der gleichen @id bereits vorhanden",
-    "errorFileInvalidJSON": "Problem mit {{fileName}}: Ungültiges JSON",
     "deleteProjectMessage": "Möchten Sie {{projectName}} wirklich löschen?",
     "errorSameName": "Das gleichnamige Projekt existiert bereits. Möchten Sie es überschreiben?",
     "fileOpenModal": {
@@ -1416,6 +1409,14 @@
     },
     "Common": {
       "untargeted": "Nicht zielgerichtet"
+    },
+    "ImportErrors": {
+      "fileFormatNotSupportedMessage": "Es werden nur JSON-Dateien unterstützt. Die folgenden Dateien können nicht importiert werden: \n{{fileNames}}.",
+      "fileFormatNotSupportedTitle": "Dateiformat wird nicht unterstützt",
+      "fileInvalidJSON": "'{{fileName}}' kann nicht importiert werden, es enthält ungültiges JSON.",
+      "invalidJSON": "Ungültiges JSON",
+      "issueWithFile": "Problem mit der Datei: {{error}}",
+      "modelAlreadyExists": "Modell mit @id ({{modelId}}) ist bereits vorhanden"
     }
   }
 }

--- a/src/Resources/Locales/en.json
+++ b/src/Resources/Locales/en.json
@@ -922,7 +922,9 @@
     },
     "OAT": {
         "Common": {
-            "untargeted": "Untargeted"
+            "untargeted": "Untargeted",
+            "unhandledExceptionTitle": "Unexpected error",
+            "unhandledExceptionMessage": "Something unexpected happened. Please try again."
         },
         "ModelList": {
             "searchModels": "Search models",

--- a/src/Resources/Locales/en.json
+++ b/src/Resources/Locales/en.json
@@ -933,6 +933,8 @@
             "noModelsButtonText": "Add a model"
         },
         "ImportErrors": {
+            "exceptionTitle": "Unexpected issue",
+            "exceptionMessage": "Something unexpected happened. Please try again.",
             "fileFormatNotSupportedMessage": "Only JSON files are supported. Unable to import the following files: \n{{fileNames}}.",
             "fileFormatNotSupportedTitle": "File format not supported",
             "fileInvalidJSON": "Unable to import '{{fileName}}', it contains invalid JSON.",

--- a/src/Resources/Locales/en.json
+++ b/src/Resources/Locales/en.json
@@ -938,9 +938,8 @@
             "fileFormatNotSupportedMessage": "Only JSON files are supported. Unable to import the following files: \n{{fileNames}}.",
             "fileFormatNotSupportedTitle": "File format not supported",
             "fileInvalidJSON": "Unable to import '{{fileName}}', it contains invalid JSON.",
-            "invalidJSON": "Invalid JSON",
-            "issueWithFile": "Issue with file: {{error}}",
-            "modelAlreadyExists": "Model with @id ({{modelId}}) already exists"
+            "importFailedTitle": "Import failed",
+            "issueWithFile": "Issue with file: {{error}}"
         }
     },
     "OATCommon": {

--- a/src/Resources/Locales/en.json
+++ b/src/Resources/Locales/en.json
@@ -931,6 +931,14 @@
             "noModelsTitle": "You don't have any models yet",
             "noModelsMessage": "Start designing your ontology by adding a model or importing your existing ontology",
             "noModelsButtonText": "Add a model"
+        },
+        "ImportErrors": {
+            "fileFormatNotSupportedMessage": "Only JSON files are supported. Unable to import the following files: \n{{fileNames}}.",
+            "fileFormatNotSupportedTitle": "File format not supported",
+            "fileInvalidJSON": "Unable to import '{{fileName}}', it contains invalid JSON.",
+            "invalidJSON": "Invalid JSON",
+            "issueWithFile": "Issue with file: {{error}}",
+            "modelAlreadyExists": "Model with @id ({{modelId}}) already exists"
         }
     },
     "OATCommon": {
@@ -944,7 +952,6 @@
         "configure": "Configure",
         "delete": "Delete",
         "export": "Export",
-        "file": "file",
         "import": "Import",
         "importFile": "Import file",
         "importFolder": "Import folder",
@@ -973,13 +980,7 @@
         "enterANamespace": "Enter a namespace",
         "errorNamespace": "The name may only contain the characters a-z, A-Z, 0-9, and underscore. The first character may not be a digit, and the last character may not be an underscore.",
         "settings": "Settings",
-        "errorInvalidJSON": "Invalid JSON",
-        "errorFileInvalidJSON": "Issue with {{fileName}}: Invalid JSON",
-        "errorFileFormatNotSupported": "Issue with {{fileName}}: Format not supported",
         "errorSingleFileHoldsRelationships": "Issue with {{fileName}}: Model holds relationships which are not being imported",
-        "errorFormatNoSupported": "File format not supported",
-        "errorIssueWithFile": "Issue with {{fileName}}: {{error}}",
-        "errorImportedModelAlreadyExists": "Issue with {{modelId}}: Model with the same @id already exists",
         "undo": "Undo",
         "redo": "Redo",
         "folderUpload": "Folder upload",

--- a/src/Resources/Locales/en.json
+++ b/src/Resources/Locales/en.json
@@ -939,7 +939,7 @@
             "fileFormatNotSupportedTitle": "File format not supported",
             "fileInvalidJSON": "Unable to import '{{fileName}}', it contains invalid JSON.",
             "importFailedTitle": "Import failed",
-            "issueWithFile": "Issue with file: {{error}}"
+            "importFailedMessage": "There was an error during import. Resolve them and try again.\n {{error}}"
         }
     },
     "OATCommon": {

--- a/src/Resources/Locales/en.json
+++ b/src/Resources/Locales/en.json
@@ -933,7 +933,7 @@
             "noModelsButtonText": "Add a model"
         },
         "ImportErrors": {
-            "exceptionTitle": "Unexpected issue",
+            "exceptionTitle": "Unexpected error",
             "exceptionMessage": "Something unexpected happened. Please try again.",
             "fileFormatNotSupportedMessage": "Only JSON files are supported. Unable to import the following files: \n{{fileNames}}.",
             "fileFormatNotSupportedTitle": "File format not supported",

--- a/src/Resources/Locales/es.json
+++ b/src/Resources/Locales/es.json
@@ -917,7 +917,6 @@
     "sync": "Sincronizar",
     "import": "Importación",
     "export": "Exportar",
-    "file": "Archivo",
     "new": "Nuevo",
     "open": "Abrir",
     "saveAs": "Guardar como",
@@ -934,10 +933,6 @@
     "namespace": "Namespace",
     "enterANamespace": "Introducir un espacio de nombres",
     "settings": "Configuración",
-    "errorInvalidJSON": "JSON no válido",
-    "errorFileFormatNotSupported": "Formato {{archivo}} no compatible",
-    "errorFormatNoSupported": "Formato de archivo no compatible",
-    "errorIssueWithFile": "Problema con {{fileName}}: {{error}}",
     "errorNamespace": "El espacio de nombres solo puede contener letras, dígitos y guiones bajos.",
     "undo": "Deshacer",
     "redo": "Rehacer",
@@ -946,8 +941,6 @@
     "fileUpload": "Carga de archivos",
     "selectFile": "Seleccionar archivo",
     "errorSingleFileHoldsRelationships": "Problema con {{fileName}}: el modelo contiene relaciones que no se están importando",
-    "errorImportedModelAlreadyExists": "Problema con {{modelId}}: ya existe un modelo con el mismo @id",
-    "errorFileInvalidJSON": "Problema con {{fileName}}: JSON no válido",
     "deleteProjectMessage": "¿Está seguro de que desea eliminar {{projectName}}?",
     "errorSameName": "El proyecto con el mismo nombre ya existe. ¿Te gustaría sobrescribirlo?",
     "fileOpenModal": {
@@ -1416,6 +1409,14 @@
     },
     "Common": {
       "untargeted": "Sin objetivo"
+    },
+    "ImportErrors": {
+      "fileFormatNotSupportedMessage": "Solo se admiten archivos JSON. No se pueden importar los siguientes archivos: \n{{fileNames}}.",
+      "fileFormatNotSupportedTitle": "Formato de archivo no compatible",
+      "fileInvalidJSON": "No se puede importar '{{fileName}}', contiene JSON no válido.",
+      "invalidJSON": "JSON no válido",
+      "issueWithFile": "Problema con el archivo: {{error}}",
+      "modelAlreadyExists": "El modelo con @id ({{modelId}}) ya existe"
     }
   }
 }

--- a/src/Resources/Locales/fr.json
+++ b/src/Resources/Locales/fr.json
@@ -917,7 +917,6 @@
     "sync": "Synchronisation",
     "import": "Importation",
     "export": "Exportation",
-    "file": "Lime",
     "new": "Nouveau",
     "open": "Ouvrir",
     "saveAs": "Enregistrer sous",
@@ -934,10 +933,6 @@
     "namespace": "Espace de noms",
     "enterANamespace": "Entrer un espace de noms",
     "settings": "Paramètres",
-    "errorInvalidJSON": "JSON non valide",
-    "errorFileFormatNotSupported": "Le format {{file}} n’est pas pris en charge",
-    "errorFormatNoSupported": "Format de fichier non pris en charge",
-    "errorIssueWithFile": "Problème avec {{fileName}} : {{error}}",
     "errorNamespace": "L’espace de noms ne peut contenir que des lettres, des chiffres et des traits de soulignement.",
     "undo": "Défaire",
     "redo": "Refaire",
@@ -946,8 +941,6 @@
     "fileUpload": "Téléchargement de fichiers",
     "selectFile": "Sélectionner un fichier",
     "errorSingleFileHoldsRelationships": "Problème avec {{fileName}} : le modèle contient des relations qui ne sont pas importées",
-    "errorImportedModelAlreadyExists": "Problème avec {{modelId}} : Modèle avec le même @id existe déjà",
-    "errorFileInvalidJSON": "Problème avec {{fileName}} : JSON non valide",
     "deleteProjectMessage": "Voulez-vous vraiment supprimer {{projectName}} ?",
     "errorSameName": "Le projet portant le même nom existe déjà. Voulez-vous l’écraser?",
     "fileOpenModal": {
@@ -1416,6 +1409,14 @@
     },
     "Common": {
       "untargeted": "Non ciblé"
+    },
+    "ImportErrors": {
+      "fileFormatNotSupportedMessage": "Seuls les fichiers JSON sont pris en charge. Impossible d’importer les fichiers suivants : \n{{fileNames}}.",
+      "fileFormatNotSupportedTitle": "Format de fichier non pris en charge",
+      "fileInvalidJSON": "Impossible d'importer '{{fileName}}', il contient du JSON non valide.",
+      "invalidJSON": "JSON non valide",
+      "issueWithFile": "Problème avec le fichier : {{error}}",
+      "modelAlreadyExists": "Le modèle avec @id ({{modelId}}) existe déjà"
     }
   }
 }

--- a/src/Resources/Locales/hu.json
+++ b/src/Resources/Locales/hu.json
@@ -917,7 +917,6 @@
     "sync": "szinkronizál",
     "import": "Importál",
     "export": "Kivitel",
-    "file": "Fájl",
     "new": "Új",
     "open": "Nyitott",
     "saveAs": "Mentés másként",
@@ -934,10 +933,6 @@
     "namespace": "Namespace",
     "enterANamespace": "Névtér megadása",
     "settings": "Beállítások",
-    "errorInvalidJSON": "Érvénytelen JSON",
-    "errorFileFormatNotSupported": "{{file}} formátum nem támogatott",
-    "errorFormatNoSupported": "A fájlformátum nem támogatott",
-    "errorIssueWithFile": "Probléma a következővel: {{fileName}}: {{error}}",
     "errorNamespace": "A névtér csak betűket, számjegyeket és aláhúzásjeleket tartalmazhat.",
     "undo": "Kigombol",
     "redo": "Újra kifest",
@@ -946,8 +941,6 @@
     "fileUpload": "Fájlfeltöltés",
     "selectFile": "Fájl kiválasztása",
     "errorSingleFileHoldsRelationships": "Probléma a {{fájlnév}} sablonnal: A modell olyan kapcsolatokat tartalmaz, amelyek importálása nem történik meg",
-    "errorImportedModelAlreadyExists": "Probléma a {{modelId}} sablonnal: Az azonos @id rendelkező modell már létezik",
-    "errorFileInvalidJSON": "Probléma a következővel: {{fileName}}: Érvénytelen JSON",
     "deleteProjectMessage": "Biztosan törölni szeretnéd a {{projectName}} sablont?",
     "errorSameName": "Az azonos nevű projekt már létezik. Szeretnéd felülírni?",
     "fileOpenModal": {
@@ -1416,6 +1409,14 @@
     },
     "Common": {
       "untargeted": "Nem célzott"
+    },
+    "ImportErrors": {
+      "fileFormatNotSupportedMessage": "Csak a JSON-fájlok támogatottak. Nem lehet importálni a következő fájlokat: \n{{fájlnevek}} sablont.",
+      "fileFormatNotSupportedTitle": "A fájlformátum nem támogatott",
+      "fileInvalidJSON": "A(z) \"{{fileName}}\" nem importálható, érvénytelen JSON-t tartalmaz.",
+      "invalidJSON": "Érvénytelen JSON",
+      "issueWithFile": "Probléma a fájllal: {{error}}",
+      "modelAlreadyExists": "A @id ({{modelId}}) modellel már létezik"
     }
   }
 }

--- a/src/Resources/Locales/it.json
+++ b/src/Resources/Locales/it.json
@@ -917,7 +917,6 @@
     "sync": "Sincronizzazione",
     "import": "Importazione",
     "export": "Esportazione",
-    "file": "File",
     "new": "Nuovo",
     "open": "Aperto",
     "saveAs": "Salva con nome",
@@ -934,10 +933,6 @@
     "namespace": "Namespace",
     "enterANamespace": "Immettere uno spazio dei nomi",
     "settings": "Impostazioni",
-    "errorInvalidJSON": "JSON non valido",
-    "errorFileFormatNotSupported": "Formato {{file}} non supportato",
-    "errorFormatNoSupported": "Formato di file non supportato",
-    "errorIssueWithFile": "Problema con {{nomefile}}: {{errore}}",
     "errorNamespace": "Lo spazio dei nomi può contenere solo lettere, cifre e caratteri di sottolineatura.",
     "undo": "Disfare",
     "redo": "Rifare",
@@ -946,8 +941,6 @@
     "fileUpload": "Caricamento file",
     "selectFile": "Seleziona file",
     "errorSingleFileHoldsRelationships": "Problema con {{nomefile}}: il modello contiene relazioni che non vengono importate",
-    "errorImportedModelAlreadyExists": "Problema con {{modelId}}: il modello con lo stesso @id esiste già",
-    "errorFileInvalidJSON": "Problema con {{nomefile}}: JSON non valido",
     "deleteProjectMessage": "Sei sicuro di voler eliminare {{nomeprogetto}}?",
     "errorSameName": "Il progetto con lo stesso nome esiste già. Vuoi sovrascriverlo?",
     "fileOpenModal": {
@@ -1416,6 +1409,14 @@
     },
     "Common": {
       "untargeted": "Non mirato"
+    },
+    "ImportErrors": {
+      "fileFormatNotSupportedMessage": "Sono supportati solo i file JSON. Impossibile importare i seguenti file: \n{{fileNames}}.",
+      "fileFormatNotSupportedTitle": "Formato di file non supportato",
+      "fileInvalidJSON": "Impossibile importare '{{fileName}}', contiene JSON non valido.",
+      "invalidJSON": "JSON non valido",
+      "issueWithFile": "Problema con il file: {{errore}}",
+      "modelAlreadyExists": "Il modello con @id ({{modelId}}) esiste già"
     }
   }
 }

--- a/src/Resources/Locales/ja.json
+++ b/src/Resources/Locales/ja.json
@@ -917,7 +917,6 @@
     "sync": "同期",
     "import": "輸入",
     "export": "輸出",
-    "file": "ファイル",
     "new": "新機能",
     "open": "開ける",
     "saveAs": "名前を付けて保存",
@@ -934,10 +933,6 @@
     "namespace": "名前空間",
     "enterANamespace": "名前空間を入力する",
     "settings": "設定",
-    "errorInvalidJSON": "無効な JSON",
-    "errorFileFormatNotSupported": "{{ファイル}}形式はサポートされていません",
-    "errorFormatNoSupported": "サポートされていないファイル形式",
-    "errorIssueWithFile": "{{ファイル名}}に関する問題: {{エラー}}",
     "errorNamespace": "名前空間には、文字、数字、およびアンダースコアのみを含めることができます。",
     "undo": "外す",
     "redo": "やり直す",
@@ -946,8 +941,6 @@
     "fileUpload": "ファイルのアップロード",
     "selectFile": "ファイルの選択",
     "errorSingleFileHoldsRelationships": "{{fileName}}の問題:モデルはインポートされていない関係を保持しています",
-    "errorImportedModelAlreadyExists": "{{modelId}} の問題: 同じ@idを持つモデルが既に存在します",
-    "errorFileInvalidJSON": "{{ファイル名}}の問題: 無効な JSON",
     "deleteProjectMessage": "{{プロジェクト名}} を削除してもよろしいですか?",
     "errorSameName": "同じ名前のプロジェクトはすでに存在します。上書きしますか?",
     "fileOpenModal": {
@@ -1416,6 +1409,14 @@
     },
     "Common": {
       "untargeted": "ターゲットなし"
+    },
+    "ImportErrors": {
+      "fileFormatNotSupportedMessage": "JSON ファイルのみがサポートされています。次のファイルをインポートできません。\n{{ファイル名}}.",
+      "fileFormatNotSupportedTitle": "サポートされていないファイル形式",
+      "fileInvalidJSON": "'{{ファイル名}}' をインポートできません。無効な JSON が含まれています。",
+      "invalidJSON": "無効な JSON",
+      "issueWithFile": "ファイルに関する問題: {{エラー}}",
+      "modelAlreadyExists": "@id ({{modelId}}) を持つモデルが既に存在します"
     }
   }
 }

--- a/src/Resources/Locales/ko.json
+++ b/src/Resources/Locales/ko.json
@@ -917,7 +917,6 @@
     "sync": "동기화",
     "import": "수입",
     "export": "수출",
-    "file": "파일",
     "new": "새로운",
     "open": "열다",
     "saveAs": "다른 이름으로 저장",
@@ -934,10 +933,6 @@
     "namespace": "Namespace",
     "enterANamespace": "네임스페이스 입력",
     "settings": "설정",
-    "errorInvalidJSON": "잘못된 JSON",
-    "errorFileFormatNotSupported": "{{file}} 형식이 지원되지 않음",
-    "errorFormatNoSupported": "지원되지 않는 파일 형식",
-    "errorIssueWithFile": "{{fileName}}의 문제: {{error}}",
     "errorNamespace": "네임스페이스에는 문자, 숫자 및 밑줄만 포함될 수 있습니다.",
     "undo": "취소",
     "redo": "다시",
@@ -946,8 +941,6 @@
     "fileUpload": "파일 업로드",
     "selectFile": "파일 선택",
     "errorSingleFileHoldsRelationships": "{{fileName}} 문제: 모델이 가져오지 않는 관계를 보유합니다.",
-    "errorImportedModelAlreadyExists": "{{modelId}} 문제: 동일한 @id를 가진 모델이 이미 존재합니다.",
-    "errorFileInvalidJSON": "{{fileName}} 문제 : 잘못된 JSON",
     "deleteProjectMessage": "{{프로젝트 이름}}을(를) 삭제하시겠습니까?",
     "errorSameName": "이름이 같은 프로젝트가 이미 있습니다. 덮어쓰시겠습니까?",
     "fileOpenModal": {
@@ -1416,6 +1409,14 @@
     },
     "Common": {
       "untargeted": "타겟팅되지 않음"
+    },
+    "ImportErrors": {
+      "fileFormatNotSupportedMessage": "JSON 파일만 지원됩니다. 다음 파일을 가져올 수 없습니다. \n{{파일 이름}}.",
+      "fileFormatNotSupportedTitle": "지원되지 않는 파일 형식",
+      "fileInvalidJSON": "'{{파일 이름}}'을 가져올 수 없으며 잘못된 JSON이 포함되어 있습니다.",
+      "invalidJSON": "잘못된 JSON",
+      "issueWithFile": "파일 문제: {{오류}}",
+      "modelAlreadyExists": "@id 모델({{modelId}})이 이미 존재합니다."
     }
   }
 }

--- a/src/Resources/Locales/nl.json
+++ b/src/Resources/Locales/nl.json
@@ -917,7 +917,6 @@
     "sync": "Sync",
     "import": "Importeren",
     "export": "Exporteren",
-    "file": "Bestand",
     "new": "Nieuw",
     "open": "Openen",
     "saveAs": "Opslaan als",
@@ -934,10 +933,6 @@
     "namespace": "Namespace",
     "enterANamespace": "Een naamruimte invoeren",
     "settings": "Instellingen",
-    "errorInvalidJSON": "Ongeldige JSON",
-    "errorFileFormatNotSupported": "{{file}} indeling niet ondersteund",
-    "errorFormatNoSupported": "Bestandsindeling niet ondersteund",
-    "errorIssueWithFile": "Probleem met {{bestandsnaam}}: {{error}}",
     "errorNamespace": "Naamruimte mag alleen letters, cijfers en onderstrepingstekens bevatten.",
     "undo": "Ongedaan maken",
     "redo": "Opnieuw",
@@ -946,8 +941,6 @@
     "fileUpload": "Bestand uploaden",
     "selectFile": "Selecteer bestand",
     "errorSingleFileHoldsRelationships": "Probleem met {{bestandsnaam}}: model bevat relaties die niet worden geïmporteerd",
-    "errorImportedModelAlreadyExists": "Probleem met {{modelId}}: model met dezelfde @id bestaat al",
-    "errorFileInvalidJSON": "Probleem met {{bestandsnaam}}: ongeldige JSON",
     "deleteProjectMessage": "Weet u zeker dat u {{projectName}} wilt verwijderen?",
     "errorSameName": "Project met dezelfde naam bestaat al. Wil je het overschrijven?",
     "fileOpenModal": {
@@ -1416,6 +1409,14 @@
     },
     "Common": {
       "untargeted": "Ongericht"
+    },
+    "ImportErrors": {
+      "fileFormatNotSupportedMessage": "Alleen JSON-bestanden worden ondersteund. Kan de volgende bestanden niet importeren: \n{{bestandsnaam}}.",
+      "fileFormatNotSupportedTitle": "Bestandsindeling wordt niet ondersteund",
+      "fileInvalidJSON": "Het kan '{{bestandsnaam}}' niet importeren en bevat ongeldige JSON.",
+      "invalidJSON": "Ongeldige JSON",
+      "issueWithFile": "Probleem met bestand: {{error}}",
+      "modelAlreadyExists": "Model met @id ({{modelId}}) bestaat al"
     }
   }
 }

--- a/src/Resources/Locales/pl.json
+++ b/src/Resources/Locales/pl.json
@@ -917,7 +917,6 @@
     "sync": "synchronizować",
     "import": "Import",
     "export": "Eksport",
-    "file": "Plik",
     "new": "Nowy",
     "open": "Otwierać",
     "saveAs": "Zapisz jako",
@@ -934,10 +933,6 @@
     "namespace": "Namespace",
     "enterANamespace": "Wprowadzanie przestrzeni nazw",
     "settings": "Ustawienia",
-    "errorInvalidJSON": "Nieprawidłowy kod JSON",
-    "errorFileFormatNotSupported": "Format {{file}} nie jest obsługiwany",
-    "errorFormatNoSupported": "Format pliku nie jest obsługiwany",
-    "errorIssueWithFile": "Problem z {{fileName}}: {{error}}",
     "errorNamespace": "Przestrzeń nazw może zawierać tylko litery, cyfry i podkreślenia.",
     "undo": "Cofnąć",
     "redo": "Ponowić",
@@ -946,8 +941,6 @@
     "fileUpload": "Przesyłanie plików",
     "selectFile": "Wybierz plik",
     "errorSingleFileHoldsRelationships": "Problem z {{fileName}}: Model przechowuje relacje, które nie są importowane",
-    "errorImportedModelAlreadyExists": "Problem z {{modelId}}: Model z tym samym @id już istnieje",
-    "errorFileInvalidJSON": "Problem z {{fileName}}: Nieprawidłowy kod JSON",
     "deleteProjectMessage": "Czy na pewno chcesz usunąć {{projectName}}?",
     "errorSameName": "Projekt o tej samej nazwie już istnieje. Chcesz go nadpisać?",
     "fileOpenModal": {
@@ -1416,6 +1409,14 @@
     },
     "Common": {
       "untargeted": "Nieukierunkowane"
+    },
+    "ImportErrors": {
+      "fileFormatNotSupportedMessage": "Obsługiwane są tylko pliki JSON. Nie można zaimportować następujących plików: \n{{fileNames}}.",
+      "fileFormatNotSupportedTitle": "Format pliku nie jest obsługiwany",
+      "fileInvalidJSON": "Nie można zaimportować pliku \"{{fileName}}\", ponieważ zawiera nieprawidłowy kod JSON.",
+      "invalidJSON": "Nieprawidłowy JSON",
+      "issueWithFile": "Problem z plikiem: {{error}}",
+      "modelAlreadyExists": "Model z @id ({{modelId}}) już istnieje"
     }
   }
 }

--- a/src/Resources/Locales/pt-pt.json
+++ b/src/Resources/Locales/pt-pt.json
@@ -917,7 +917,6 @@
     "sync": "sincronização",
     "import": "Importação",
     "export": "Exportação",
-    "file": "Arquivo",
     "new": "Novo",
     "open": "Aberto",
     "saveAs": "Salvar como",
@@ -934,10 +933,6 @@
     "namespace": "Espaço de nome",
     "enterANamespace": "Insira um espaço de nome",
     "settings": "Configurações",
-    "errorInvalidJSON": "JSON inválido",
-    "errorFileFormatNotSupported": "{{file}} formato não suportado",
-    "errorFormatNoSupported": "Formato de ficheiro não suportado",
-    "errorIssueWithFile": "Problema com {{fileName}} {{error}}",
     "errorNamespace": "O espaço de nomes só pode conter letras, dígitos e sublinhados.",
     "undo": "Desfazer",
     "redo": "Redo",
@@ -946,8 +941,6 @@
     "fileUpload": "Upload de arquivo",
     "selectFile": "Selecione ficheiro",
     "errorSingleFileHoldsRelationships": "Problema com {{fileName}}: Modelo detém relações que não estão a ser importadas",
-    "errorImportedModelAlreadyExists": "Problema com {{modelId}}: Modelo com o mesmo @id já existe",
-    "errorFileInvalidJSON": "Emissão com {{fileName}}: Invalid JSON",
     "deleteProjectMessage": "Tem a certeza de que pretende eliminar {{projectName}}",
     "errorSameName": "Projeto com o mesmo nome já existe. Gostaria de exagerar?",
     "fileOpenModal": {
@@ -1416,6 +1409,14 @@
     },
     "Common": {
       "untargeted": "Sem alvos"
+    },
+    "ImportErrors": {
+      "fileFormatNotSupportedMessage": "Apenas os ficheiros JSON são suportados. Não é possível importar os seguintes ficheiros: \n{{fileNames}} .",
+      "fileFormatNotSupportedTitle": "Formato de ficheiro não suportado",
+      "fileInvalidJSON": "Incapaz de importar '{fileName}', contém JSON inválido.",
+      "invalidJSON": "JSON inválido",
+      "issueWithFile": "Emissão com ficheiro: {{error}}",
+      "modelAlreadyExists": "Modelo com @id ({modelId}} já existe"
     }
   }
 }

--- a/src/Resources/Locales/pt.json
+++ b/src/Resources/Locales/pt.json
@@ -917,7 +917,6 @@
     "sync": "sincronizar",
     "import": "Importação",
     "export": "Exportação",
-    "file": "Arquivo",
     "new": "Novo",
     "open": "Abrir",
     "saveAs": "Salvar como",
@@ -934,10 +933,6 @@
     "namespace": "Namespace",
     "enterANamespace": "Digite um namespace",
     "settings": "Configurações",
-    "errorInvalidJSON": "JSON inválido",
-    "errorFileFormatNotSupported": "{{file}} formato não suportado",
-    "errorFormatNoSupported": "Formato de arquivo não suportado",
-    "errorIssueWithFile": "Problema com {{fileName}}: {{error}}",
     "errorNamespace": "O namespace só pode conter letras, dígitos e sublinhados.",
     "undo": "Desfazer",
     "redo": "Refazer",
@@ -946,8 +941,6 @@
     "fileUpload": "Upload de arquivo",
     "selectFile": "Selecione arquivo",
     "errorSingleFileHoldsRelationships": "Problema com {{fileName}}: O modelo mantém relacionamentos que não estão sendo importados",
-    "errorImportedModelAlreadyExists": "Problema com {{modelId}}: Modelo com o mesmo @id já existe",
-    "errorFileInvalidJSON": "Problema com {{fileName}}: JSON inválido",
     "deleteProjectMessage": "Tem certeza de que deseja excluir {{projectName}}?",
     "errorSameName": "Projeto com mesmo nome já existe. Gostaria de substituir?",
     "fileOpenModal": {
@@ -1416,6 +1409,14 @@
     },
     "Common": {
       "untargeted": "Não direcionado"
+    },
+    "ImportErrors": {
+      "fileFormatNotSupportedMessage": "Somente arquivos JSON são suportados. Não é possível importar os seguintes arquivos: \n{{fileNames}}.",
+      "fileFormatNotSupportedTitle": "Formato de arquivo não suportado",
+      "fileInvalidJSON": "Não é possível importar '{{fileName}}', ele contém JSON inválido.",
+      "invalidJSON": "JSON inválido",
+      "issueWithFile": "Problema com o arquivo: {{error}}",
+      "modelAlreadyExists": "Modelo com @id ({{modelId}}) já existe"
     }
   }
 }

--- a/src/Resources/Locales/ru.json
+++ b/src/Resources/Locales/ru.json
@@ -917,7 +917,6 @@
     "sync": "синхронизировать",
     "import": "Импорт",
     "export": "Экспорт",
-    "file": "Файл",
     "new": "Новые функции",
     "open": "Открытый",
     "saveAs": "Сохранить как",
@@ -934,10 +933,6 @@
     "namespace": "Пространство имен",
     "enterANamespace": "Ввод пространства имен",
     "settings": "Параметры",
-    "errorInvalidJSON": "Недопустимый JSON",
-    "errorFileFormatNotSupported": "Формат {{file}} не поддерживается",
-    "errorFormatNoSupported": "Формат файла не поддерживается",
-    "errorIssueWithFile": "Проблема с {{имя_файла}}: {{ошибка}}",
     "errorNamespace": "Пространство имен может содержать только буквы, цифры и подчеркивания.",
     "undo": "Отменить",
     "redo": "Повторить",
@@ -946,8 +941,6 @@
     "fileUpload": "Загрузка файла",
     "selectFile": "Выберите файл",
     "errorSingleFileHoldsRelationships": "Проблема с {{имя_файла}}: модель содержит связи, которые не импортируются",
-    "errorImportedModelAlreadyExists": "Проблема с {{modelId}}: модель с тем же @id уже существует",
-    "errorFileInvalidJSON": "Проблема с {{имя_файла}}: Недопустимый JSON",
     "deleteProjectMessage": "Вы уверены, что хотите удалить {{имя_проекта}}?",
     "errorSameName": "Проект с таким же названием уже существует. Вы хотите перезаписать его?",
     "fileOpenModal": {
@@ -1416,6 +1409,14 @@
     },
     "Common": {
       "untargeted": "Нецелевой"
+    },
+    "ImportErrors": {
+      "fileFormatNotSupportedMessage": "Поддерживаются только JSON-файлы. Не удается импортировать следующие файлы: \n{{Именафайлов}}.",
+      "fileFormatNotSupportedTitle": "Формат файла не поддерживается",
+      "fileInvalidJSON": "Не удается импортировать '{{имя_файла}}', он содержит недопустимый JSON.",
+      "invalidJSON": "Недопустимый JSON",
+      "issueWithFile": "Проблема с файлом: {{error}}",
+      "modelAlreadyExists": "Модель с @id ({{modelId}}) уже существует"
     }
   }
 }

--- a/src/Resources/Locales/sv.json
+++ b/src/Resources/Locales/sv.json
@@ -917,7 +917,6 @@
     "sync": "synkronisering",
     "import": "Import",
     "export": "Export",
-    "file": "Fil",
     "new": "Ny",
     "open": "Öppna",
     "saveAs": "Spara som",
@@ -934,10 +933,6 @@
     "namespace": "Namespace",
     "enterANamespace": "Ange ett namnområde",
     "settings": "Inställningar",
-    "errorInvalidJSON": "Ogiltig JSON",
-    "errorFileFormatNotSupported": "{{file}}-format stöds inte",
-    "errorFormatNoSupported": "Filformat stöds inte",
-    "errorIssueWithFile": "Problem med {{fileName}}: {{error}}",
     "errorNamespace": "Namnområdet får bara innehålla bokstäver, siffror och understreck.",
     "undo": "Ångra",
     "redo": "Göra om",
@@ -946,8 +941,6 @@
     "fileUpload": "Filuppladdning",
     "selectFile": "Välj fil",
     "errorSingleFileHoldsRelationships": "Problem med {{fileName}}: Modellen innehåller relationer som inte importeras",
-    "errorImportedModelAlreadyExists": "Problem med {{modelId}}: Modell med samma @id redan finns",
-    "errorFileInvalidJSON": "Problem med {{fileName}}: Ogiltig JSON",
     "deleteProjectMessage": "Är du säker på att du vill ta bort {{projectName}}?",
     "errorSameName": "Projekt med samma namn finns redan. Vill du skriva över det?",
     "fileOpenModal": {
@@ -1416,6 +1409,14 @@
     },
     "Common": {
       "untargeted": "Oriktad"
+    },
+    "ImportErrors": {
+      "fileFormatNotSupportedMessage": "Endast JSON-filer stöds. Det går inte att importera följande filer: \n{{fileNames}}.",
+      "fileFormatNotSupportedTitle": "Filformatet stöds inte",
+      "fileInvalidJSON": "Det går inte att importera {{fileName}}, den innehåller ogiltig JSON.",
+      "invalidJSON": "Ogiltig JSON",
+      "issueWithFile": "Problem med filen: {{error}}",
+      "modelAlreadyExists": "Modell med @id ({{modelId}}) finns redan"
     }
   }
 }

--- a/src/Resources/Locales/tr.json
+++ b/src/Resources/Locales/tr.json
@@ -917,7 +917,6 @@
     "sync": "Eşitleme",
     "import": "Ithalat",
     "export": "Ihracat",
-    "file": "Dosya",
     "new": "Yeni",
     "open": "Açık",
     "saveAs": "Farklı kaydet",
@@ -934,10 +933,6 @@
     "namespace": "Namespace",
     "enterANamespace": "Ad alanı girme",
     "settings": "Ayarlar",
-    "errorInvalidJSON": "Geçersiz JSON",
-    "errorFileFormatNotSupported": "{{dosya}} biçimi desteklenmiyor",
-    "errorFormatNoSupported": "Dosya biçimi Desteklenmiyor",
-    "errorIssueWithFile": "{{fileName}} ile ilgili sorun: {{error}}",
     "errorNamespace": "Ad alanı yalnızca harfler, rakamlar ve alt çizgiler içerebilir.",
     "undo": "Geri almak",
     "redo": "Yinele",
@@ -946,8 +941,6 @@
     "fileUpload": "Dosya yükleme",
     "selectFile": "Dosya seç",
     "errorSingleFileHoldsRelationships": "{{fileName}} ile ilgili sorun: Model, içe aktarılmayan ilişkileri tutuyor",
-    "errorImportedModelAlreadyExists": "{{modelId}} ile ilgili sorun: Aynı @id sahip model zaten var",
-    "errorFileInvalidJSON": "{{fileName}} ile ilgili sorun: Geçersiz JSON",
     "deleteProjectMessage": "{{projectName}} silmek istediğinizden emin misiniz?",
     "errorSameName": "Aynı ada sahip proje zaten var. Üzerine yazmak ister misiniz?",
     "fileOpenModal": {
@@ -1416,6 +1409,14 @@
     },
     "Common": {
       "untargeted": "Hedefsiz"
+    },
+    "ImportErrors": {
+      "fileFormatNotSupportedMessage": "Yalnızca JSON dosyaları desteklenir. Aşağıdaki dosyalar içe aktarılamıyor: \n{{fileNames}}.",
+      "fileFormatNotSupportedTitle": "Dosya biçimi desteklenmiyor",
+      "fileInvalidJSON": "'{{fileName}}' içe aktarılamıyor, geçersiz JSON içeriyor.",
+      "invalidJSON": "Geçersiz JSON",
+      "issueWithFile": "Dosyayla ilgili sorun: {{error}}",
+      "modelAlreadyExists": "@id sahip model ({{modelId}}) zaten var"
     }
   }
 }

--- a/src/Resources/Locales/zh-Hans.json
+++ b/src/Resources/Locales/zh-Hans.json
@@ -917,7 +917,6 @@
     "sync": "同步",
     "import": "进口",
     "export": "出口",
-    "file": "文件",
     "new": "新增功能",
     "open": "打开",
     "saveAs": "另存为",
@@ -934,10 +933,6 @@
     "namespace": "Namespace",
     "enterANamespace": "输入命名空间",
     "settings": "设置",
-    "errorInvalidJSON": "无效的 JSON",
-    "errorFileFormatNotSupported": "{{文件}} 格式不受支持",
-    "errorFormatNoSupported": "不支持的文件格式",
-    "errorIssueWithFile": "{{文件名}} 的问题：{{错误}}",
     "errorNamespace": "命名空间只能包含字母、数字和下划线。",
     "undo": "撤消",
     "redo": "重做",
@@ -946,8 +941,6 @@
     "fileUpload": "文件上传",
     "selectFile": "选择文件",
     "errorSingleFileHoldsRelationships": "{{文件名}} 的问题：模型保留未导入的关系",
-    "errorImportedModelAlreadyExists": "{{modelId}} 的问题：具有相同@id的模型已存在",
-    "errorFileInvalidJSON": "{{文件名}} 的问题：无效的 JSON",
     "deleteProjectMessage": "是否确实要删除 {{项目名称}}？",
     "errorSameName": "具有相同名称的项目已存在。是否要覆盖它？",
     "fileOpenModal": {
@@ -1416,6 +1409,14 @@
     },
     "Common": {
       "untargeted": "非目标"
+    },
+    "ImportErrors": {
+      "fileFormatNotSupportedMessage": "仅支持 JSON 文件。无法导入以下文件：\n{{文件名}}.",
+      "fileFormatNotSupportedTitle": "不支持文件格式",
+      "fileInvalidJSON": "无法导入“{{文件名}}”，它包含无效的 JSON。",
+      "invalidJSON": "无效的 JSON",
+      "issueWithFile": "文件问题：{{错误}}",
+      "modelAlreadyExists": "具有@id （{{modelId}}） 的模型已存在"
     }
   }
 }


### PR DESCRIPTION
### Summary of changes 🔍 
Pulling out the import, export and parsing logic to a public utility file. It doesn't change the functionality, just moves it to a common place so we can iterate and expose to the ADT Explorer as well in the future.

### Testing 🧪
- import a file
- import a folder
- Import a file that already exists in the ontology, see the errors
- Import a file that is not a JSON file
- Import a file that is a JSON file but the contents don't parse properly
- export ontology 
