### PR TITLE
fix: OAT: Small cleanup items

### DIFF
--- a/src/Components/OATHeader/OATHeader.styles.ts
+++ b/src/Components/OATHeader/OATHeader.styles.ts
@@ -19,7 +19,8 @@ export const getStyles = (props: IOATHeaderStyleProps): IOATHeaderStyles => {
             classNames.root,
             {
                 height: OAT_HEADER_HEIGHT,
-                backgroundColor: theme.semanticColors.bodyBackground
+                backgroundColor: theme.semanticColors.bodyBackground,
+                padding: '8px 8px 0 8px'
             } as IStyle
         ],
         projectName: [

--- a/src/Components/OATPropertyEditor/Editor.styles.ts
+++ b/src/Components/OATPropertyEditor/Editor.styles.ts
@@ -2,8 +2,10 @@ import { CardboardClassNamePrefix } from '../..';
 import {
     getControlBackgroundColor,
     PANEL_VERTICAL_SPACING,
-    PROPERTY_EDITOR_WIDTH
+    PROPERTY_EDITOR_WIDTH,
+    PROPERTY_EDITOR_WIDTH_EXPANDED
 } from '../../Models/Constants/OatStyleConstants';
+import { IOatPropertyEditorTabKey } from '../../Pages/OATEditorPage/Internal/Classes/OatTypes';
 import { IEditorStyleProps, IEditorStyles } from './Editor.types';
 
 export const OatEditorPivotHeaderHeight = 36;
@@ -18,7 +20,7 @@ const classNames = {
 
 // export const Editor_CLASS_NAMES = classNames;
 export const getStyles = (props: IEditorStyleProps): IEditorStyles => {
-    const { theme } = props;
+    const { selectedTab, theme } = props;
     return {
         root: [
             classNames.root,
@@ -32,7 +34,10 @@ export const getStyles = (props: IEditorStyleProps): IEditorStyles => {
                 justifyContent: 'center',
                 padding: 16,
                 position: 'relative',
-                width: PROPERTY_EDITOR_WIDTH
+                width:
+                    selectedTab === IOatPropertyEditorTabKey.DTDL
+                        ? PROPERTY_EDITOR_WIDTH_EXPANDED
+                        : PROPERTY_EDITOR_WIDTH
             }
         ],
         modal: [

--- a/src/Components/OATPropertyEditor/Editor.tsx
+++ b/src/Components/OATPropertyEditor/Editor.tsx
@@ -135,7 +135,7 @@ const Editor: React.FC<IEditorProps> = (props) => {
                         />
                     </PivotItem>
                     <PivotItem
-                        headerText={t('OATPropertyEditor.json')}
+                        headerText={t('OATPropertyEditor.jsonEditorTabName')}
                         className={classNames.pivotItem}
                         itemKey={IOatPropertyEditorTabKey.Json}
                         // remove pivot height - padding

--- a/src/Components/OATPropertyEditor/Editor.tsx
+++ b/src/Components/OATPropertyEditor/Editor.tsx
@@ -50,7 +50,8 @@ const Editor: React.FC<IEditorProps> = (props) => {
 
     // styles
     const classNames = getClassNames(styles, {
-        theme: useExtendedTheme()
+        theme: useExtendedTheme(),
+        selectedTab: oatPageState.selectedPropertyEditorTab
     });
 
     // state
@@ -137,7 +138,7 @@ const Editor: React.FC<IEditorProps> = (props) => {
                     <PivotItem
                         headerText={t('OATPropertyEditor.jsonEditorTabName')}
                         className={classNames.pivotItem}
-                        itemKey={IOatPropertyEditorTabKey.Json}
+                        itemKey={IOatPropertyEditorTabKey.DTDL}
                         // remove pivot height - padding
                         style={{
                             height: `calc(100vh - ${PANEL_VERTICAL_SPACING}px - 32px - 36px)` // 32px=padding, 36px=tab headers

--- a/src/Components/OATPropertyEditor/Editor.types.ts
+++ b/src/Components/OATPropertyEditor/Editor.types.ts
@@ -5,6 +5,7 @@ import { DtdlInterface, DtdlInterfaceContent } from '../..';
 import { IStyleFunctionOrObject, IStyle } from '@fluentui/react';
 import { IExtendedTheme } from '../../Theming/Theme.types';
 import { IllustrationMessageStyles } from '../IllustrationMessage/IllustrationMessage.types';
+import { IOatPropertyEditorTabKey } from '../../Pages/OATEditorPage/Internal/Classes/OatTypes';
 
 export type IEditorProps = {
     editorDispatch?: React.Dispatch<React.SetStateAction<IAction>>;
@@ -20,6 +21,7 @@ export type IEditorProps = {
 };
 
 export interface IEditorStyleProps {
+    selectedTab: IOatPropertyEditorTabKey;
     theme: IExtendedTheme;
 }
 export interface IEditorStyles {

--- a/src/Components/OATPropertyEditor/Internal/EditorJsonTab/EditorJsonTab.tsx
+++ b/src/Components/OATPropertyEditor/Internal/EditorJsonTab/EditorJsonTab.tsx
@@ -7,11 +7,11 @@ import {
 import { getStyles } from './EditorJsonTab.styles';
 import { classNamesFunction, styled } from '@fluentui/react';
 import { useExtendedTheme } from '../../../../Models/Hooks/useExtendedTheme';
-import JSONEditor from '../JSONEditor';
 import {
     isDTDLModel,
     isDTDLRelationshipReference
 } from '../../../../Models/Services/DtdlUtils';
+import JSONEditor from '../JSONEditor/JSONEditor';
 
 const getClassNames = classNamesFunction<
     IEditorJsonTabStyleProps,
@@ -45,7 +45,9 @@ const EditorJsonTab: React.FC<IEditorJsonTabProps> = (props) => {
 
     return (
         <div className={classNames.root}>
-            {isSupportedModelType && <JSONEditor theme={selectedThemeName} />}
+            {isSupportedModelType && (
+                <JSONEditor selectedTheme={selectedThemeName} />
+            )}
         </div>
     );
 };

--- a/src/Components/OATPropertyEditor/Internal/JSONEditor.types.ts
+++ b/src/Components/OATPropertyEditor/Internal/JSONEditor.types.ts
@@ -1,5 +1,0 @@
-import { Theme } from '../../../Models/Constants/Enums';
-
-export type JSONEditorProps = {
-    theme?: Theme;
-};

--- a/src/Components/OATPropertyEditor/Internal/JSONEditor/JSONEditor.stories.tsx
+++ b/src/Components/OATPropertyEditor/Internal/JSONEditor/JSONEditor.stories.tsx
@@ -3,6 +3,8 @@ import { ComponentStory } from '@storybook/react';
 import { getDefaultStoryDecorator } from '../../../../Models/Services/StoryUtilities';
 import JSONEditor from './JSONEditor';
 import { IJSONEditorProps } from './JSONEditor.types';
+import { OatPageContextProvider } from '../../../../Models/Context/OatPageContext/OatPageContext';
+import { CommandHistoryContextProvider } from '../../../../Pages/OATEditorPage/Internal/Context/CommandHistoryContext';
 
 const wrapperStyle = { width: '100%', height: '600px', padding: 8 };
 
@@ -15,7 +17,13 @@ export default {
 type JSONEditorStory = ComponentStory<typeof JSONEditor>;
 
 const Template: JSONEditorStory = (args) => {
-    return <JSONEditor {...args} />;
+    return (
+        <OatPageContextProvider disableLocalStorage={true}>
+            <CommandHistoryContextProvider>
+                <JSONEditor {...args} />
+            </CommandHistoryContextProvider>
+        </OatPageContextProvider>
+    );
 };
 
 export const Base = Template.bind({}) as JSONEditorStory;

--- a/src/Components/OATPropertyEditor/Internal/JSONEditor/JSONEditor.stories.tsx
+++ b/src/Components/OATPropertyEditor/Internal/JSONEditor/JSONEditor.stories.tsx
@@ -9,7 +9,7 @@ import { CommandHistoryContextProvider } from '../../../../Pages/OATEditorPage/I
 const wrapperStyle = { width: '100%', height: '600px', padding: 8 };
 
 export default {
-    title: 'Components - OAT/OATPropertyEditor/JSONEditor',
+    title: 'Components - OAT/OATPropertyEditor/EditorJsonTab/JSONEditor',
     component: JSONEditor,
     decorators: [getDefaultStoryDecorator<IJSONEditorProps>(wrapperStyle)]
 };

--- a/src/Components/OATPropertyEditor/Internal/JSONEditor/JSONEditor.stories.tsx
+++ b/src/Components/OATPropertyEditor/Internal/JSONEditor/JSONEditor.stories.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { ComponentStory } from '@storybook/react';
+import { getDefaultStoryDecorator } from '../../../../Models/Services/StoryUtilities';
+import JSONEditor from './JSONEditor';
+import { IJSONEditorProps } from './JSONEditor.types';
+
+const wrapperStyle = { width: '100%', height: '600px', padding: 8 };
+
+export default {
+    title: 'Components/JSONEditor',
+    component: JSONEditor,
+    decorators: [getDefaultStoryDecorator<IJSONEditorProps>(wrapperStyle)]
+};
+
+type JSONEditorStory = ComponentStory<typeof JSONEditor>;
+
+const Template: JSONEditorStory = (args) => {
+    return <JSONEditor {...args} />;
+};
+
+export const Base = Template.bind({}) as JSONEditorStory;
+Base.args = {} as IJSONEditorProps;

--- a/src/Components/OATPropertyEditor/Internal/JSONEditor/JSONEditor.stories.tsx
+++ b/src/Components/OATPropertyEditor/Internal/JSONEditor/JSONEditor.stories.tsx
@@ -9,7 +9,7 @@ import { CommandHistoryContextProvider } from '../../../../Pages/OATEditorPage/I
 const wrapperStyle = { width: '100%', height: '600px', padding: 8 };
 
 export default {
-    title: 'Components/JSONEditor',
+    title: 'Components - OAT/OATPropertyEditor/JSONEditor',
     component: JSONEditor,
     decorators: [getDefaultStoryDecorator<IJSONEditorProps>(wrapperStyle)]
 };

--- a/src/Components/OATPropertyEditor/Internal/JSONEditor/JSONEditor.styles.ts
+++ b/src/Components/OATPropertyEditor/Internal/JSONEditor/JSONEditor.styles.ts
@@ -1,0 +1,15 @@
+import { IJSONEditorStyleProps, IJSONEditorStyles } from './JSONEditor.types';
+import { CardboardClassNamePrefix } from '../../../../Models/Constants/Constants';
+
+const classPrefix = `${CardboardClassNamePrefix}-jsoneditor`;
+const classNames = {
+    root: `${classPrefix}-root`
+};
+
+// export const JSONEDITOR_CLASS_NAMES = classNames;
+export const getStyles = (_props: IJSONEditorStyleProps): IJSONEditorStyles => {
+    return {
+        root: [classNames.root, { height: '100%' }],
+        subComponentStyles: {}
+    };
+};

--- a/src/Components/OATPropertyEditor/Internal/JSONEditor/JSONEditor.tsx
+++ b/src/Components/OATPropertyEditor/Internal/JSONEditor/JSONEditor.tsx
@@ -204,11 +204,11 @@ const JSONEditor: React.FC<IJSONEditorProps> = (props) => {
                 }
                 beforeMount={setEditorTheme}
                 height={'100%'}
-                // className={}
                 options={{
                     minimap: {
                         enabled: false
-                    }
+                    },
+                    readOnly: true
                 }}
             />
             {oatPageState.modified && (

--- a/src/Components/OATPropertyEditor/Internal/JSONEditor/JSONEditor.tsx
+++ b/src/Components/OATPropertyEditor/Internal/JSONEditor/JSONEditor.tsx
@@ -129,7 +129,7 @@ const JSONEditor: React.FC<IJSONEditorProps> = (props) => {
         const newModel = isJsonStringValid(content);
         const validJson = await parseModels([
             ...oatPageState.currentOntologyModels,
-            content
+            newModel
         ]);
 
         const save = () => {

--- a/src/Components/OATPropertyEditor/Internal/JSONEditor/JSONEditor.types.ts
+++ b/src/Components/OATPropertyEditor/Internal/JSONEditor/JSONEditor.types.ts
@@ -1,0 +1,26 @@
+import { IStyle, IStyleFunctionOrObject } from '@fluentui/react';
+import { Theme } from '../../../../Models/Constants/Enums';
+import { IExtendedTheme } from '../../../../Theming/Theme.types';
+
+export interface IJSONEditorProps {
+    selectedTheme?: Theme;
+    /**
+     * Call to provide customized styling that will layer on top of the variant rules.
+     */
+    styles?: IStyleFunctionOrObject<IJSONEditorStyleProps, IJSONEditorStyles>;
+}
+
+export interface IJSONEditorStyleProps {
+    theme: IExtendedTheme;
+}
+export interface IJSONEditorStyles {
+    root: IStyle;
+
+    /**
+     * SubComponent styles.
+     */
+    subComponentStyles?: IJSONEditorSubComponentStyles;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface IJSONEditorSubComponentStyles {}

--- a/src/Components/OATPropertyEditor/OATPropertyEditor.styles.ts
+++ b/src/Components/OATPropertyEditor/OATPropertyEditor.styles.ts
@@ -3,8 +3,7 @@ import {
     mergeStyleSets,
     useTheme,
     FontSizes,
-    IButtonStyles,
-    ISeparatorStyles
+    IButtonStyles
 } from '@fluentui/react';
 import { CardboardClassNamePrefix } from '../../Models/Constants';
 import { useExtendedTheme } from '../../Models/Hooks/useExtendedTheme';
@@ -225,41 +224,6 @@ export const getPropertyEditorTextFieldStyles = () => {
     };
 };
 
-/* Property Selector */
-
-export const getPropertySelectorStyles = () => {
-    const theme = useTheme();
-    return {
-        root: {
-            display: 'flex',
-            flexDirection: 'row',
-            backgroundColor: theme.semanticColors.listBackground,
-            borderRadius: '4px',
-            borderBottom: `1px solid ${theme.semanticColors.variantBorder}`,
-            zIndex: 100,
-            boxShadow: '0px 5px 10px 1px rgba(0,0,0,0.05)',
-            position: 'absolute',
-            left: '-50%',
-            bottom: '100%'
-        }
-    };
-};
-
-export const getPropertySelectorSeparatorStyles = () => {
-    const theme = useTheme();
-    return {
-        root: {
-            width: '100%',
-            height: 'fill-available',
-            padding: 0,
-            margin: '2px 0px',
-            ':after': {
-                backgroundColor: theme.semanticColors.variantBorder
-            }
-        }
-    } as Partial<ISeparatorStyles>;
-};
-
 /* Template Column */
 
 export const getTemplateColumnStyles = () => {
@@ -302,31 +266,4 @@ export const getRadioGroupRowStyles = () => {
             }
         }
     };
-};
-
-export const getModalTextFieldStyles = () => {
-    return {
-        root: {
-            width: '100%',
-            minWidth: '100%'
-        }
-    };
-};
-
-export const getCancelButtonStyles = () => {
-    return {
-        root: {
-            zIndex: '202',
-            marginRight: '8px',
-            float: 'right'
-        }
-    } as IButtonStyles;
-};
-export const getSaveButtonStyles = () => {
-    return {
-        root: {
-            zIndex: '202',
-            float: 'right'
-        }
-    } as IButtonStyles;
 };

--- a/src/Models/Constants/OatStyleConstants.ts
+++ b/src/Models/Constants/OatStyleConstants.ts
@@ -1,7 +1,7 @@
 import { IStyle } from '@fluentui/react';
 import { IExtendedTheme } from '../../Theming/Theme.types';
 
-export const OAT_HEADER_HEIGHT = 76;
+export const OAT_HEADER_HEIGHT = 84;
 export const PROPERTY_EDITOR_WIDTH = 400;
 
 export const CONTROLS_SIDE_OFFSET = 16;

--- a/src/Models/Constants/OatStyleConstants.ts
+++ b/src/Models/Constants/OatStyleConstants.ts
@@ -3,6 +3,7 @@ import { IExtendedTheme } from '../../Theming/Theme.types';
 
 export const OAT_HEADER_HEIGHT = 84;
 export const PROPERTY_EDITOR_WIDTH = 400;
+export const PROPERTY_EDITOR_WIDTH_EXPANDED = 500;
 
 export const CONTROLS_SIDE_OFFSET = 16;
 export const CONTROLS_BOTTOM_OFFSET = 30;

--- a/src/Pages/OATEditorPage/Internal/Classes/OatTypes.ts
+++ b/src/Pages/OATEditorPage/Internal/Classes/OatTypes.ts
@@ -8,7 +8,7 @@ export interface IOATFile {
 }
 export enum IOatPropertyEditorTabKey {
     Properties = 'PROPERTIES',
-    Json = 'JSON'
+    DTDL = 'JSON'
 }
 
 interface ViewportHelperFunctionOptions {

--- a/src/Resources/Locales/cs.json
+++ b/src/Resources/Locales/cs.json
@@ -1419,7 +1419,6 @@
     "id": "Id",
     "info": "Informace",
     "integer": "celé číslo",
-    "json": "JSON",
     "key": "Klíč",
     "linestring": "Řetězec řádků",
     "long": "dlouhý",
@@ -1488,6 +1487,7 @@
         "changeChildTypeLabelForEnum": "Změna typu výčtu",
         "editMetadataLabel": "Upravit metadata"
       }
-    }
+    },
+    "jsonEditorTabName": "DTDL"
   }
 }

--- a/src/Resources/Locales/de.json
+++ b/src/Resources/Locales/de.json
@@ -1419,7 +1419,6 @@
     "id": "Id",
     "info": "Info",
     "integer": "ganze Zahl",
-    "json": "JSON",
     "key": "Schlüssel",
     "linestring": "Zeilenzeichenfolge",
     "long": "lang",
@@ -1488,6 +1487,7 @@
         "changeChildTypeLabelForEnum": "Ändern des Enumerationswerttyps",
         "editMetadataLabel": "Metadaten bearbeiten"
       }
-    }
+    },
+    "jsonEditorTabName": "DTDL"
   }
 }

--- a/src/Resources/Locales/en.json
+++ b/src/Resources/Locales/en.json
@@ -1123,7 +1123,6 @@
         "id": "Id",
         "info": "Info",
         "integer": "integer",
-        "json": "JSON",
         "jsonEditorTabName": "DTDL",
         "key": "Key",
         "linestring": "linestring",

--- a/src/Resources/Locales/en.json
+++ b/src/Resources/Locales/en.json
@@ -1124,6 +1124,7 @@
         "info": "Info",
         "integer": "integer",
         "json": "JSON",
+        "jsonEditorTabName": "DTDL",
         "key": "Key",
         "linestring": "linestring",
         "long": "long",

--- a/src/Resources/Locales/es.json
+++ b/src/Resources/Locales/es.json
@@ -1419,7 +1419,6 @@
     "id": "Identificación",
     "info": "Información",
     "integer": "entero",
-    "json": "JSON",
     "key": "Llave",
     "linestring": "cadena de línea",
     "long": "largo",
@@ -1488,6 +1487,7 @@
         "changeChildTypeLabelForEnum": "Cambiar el tipo de valor de enumeración",
         "editMetadataLabel": "Editar metadatos"
       }
-    }
+    },
+    "jsonEditorTabName": "DTDL"
   }
 }

--- a/src/Resources/Locales/fr.json
+++ b/src/Resources/Locales/fr.json
@@ -1419,7 +1419,6 @@
     "id": "Id",
     "info": "Info",
     "integer": "entier",
-    "json": "JSON",
     "key": "Me?",
     "linestring": "chaîne de ligne",
     "long": "long",
@@ -1488,6 +1487,7 @@
         "changeChildTypeLabelForEnum": "Modifier le type de valeur énumération",
         "editMetadataLabel": "Modifier les métadonnées"
       }
-    }
+    },
+    "jsonEditorTabName": "DTDL"
   }
 }

--- a/src/Resources/Locales/hu.json
+++ b/src/Resources/Locales/hu.json
@@ -1419,7 +1419,6 @@
     "id": "Azonosító",
     "info": "Infó",
     "integer": "egész szám",
-    "json": "JSON",
     "key": "Kulcs",
     "linestring": "vonallánc",
     "long": "hosszú",
@@ -1488,6 +1487,7 @@
         "changeChildTypeLabelForEnum": "A felsorolás értéktípusának módosítása",
         "editMetadataLabel": "Metaadatok szerkesztése"
       }
-    }
+    },
+    "jsonEditorTabName": "DTDL"
   }
 }

--- a/src/Resources/Locales/it.json
+++ b/src/Resources/Locales/it.json
@@ -1419,7 +1419,6 @@
     "id": "Id",
     "info": "Informazioni",
     "integer": "numero intero",
-    "json": "JSON",
     "key": "Chiave",
     "linestring": "linestring",
     "long": "lungo",
@@ -1488,6 +1487,7 @@
         "changeChildTypeLabelForEnum": "Modificare il tipo di valore di enumerazione",
         "editMetadataLabel": "Modificare i metadati"
       }
-    }
+    },
+    "jsonEditorTabName": "DTDL"
   }
 }

--- a/src/Resources/Locales/ja.json
+++ b/src/Resources/Locales/ja.json
@@ -1419,7 +1419,6 @@
     "id": "身分証明書",
     "info": "情報",
     "integer": "整数",
-    "json": "ティッカー",
     "key": "鍵",
     "linestring": "ラインストリング",
     "long": "長い",
@@ -1488,6 +1487,7 @@
         "changeChildTypeLabelForEnum": "列挙値の型を変更する",
         "editMetadataLabel": "メタデータの編集"
       }
-    }
+    },
+    "jsonEditorTabName": "ティッカー"
   }
 }

--- a/src/Resources/Locales/ko.json
+++ b/src/Resources/Locales/ko.json
@@ -1419,7 +1419,6 @@
     "id": "아이디",
     "info": "정보",
     "integer": "정수",
-    "json": "증권 시세 표시기",
     "key": "열쇠",
     "linestring": "라인 문자열",
     "long": "오래",
@@ -1488,6 +1487,7 @@
         "changeChildTypeLabelForEnum": "열거형 값 형식 변경",
         "editMetadataLabel": "메타데이터 편집"
       }
-    }
+    },
+    "jsonEditorTabName": "증권 시세 표시기"
   }
 }

--- a/src/Resources/Locales/nl.json
+++ b/src/Resources/Locales/nl.json
@@ -1419,7 +1419,6 @@
     "id": "Legitimatiebewijs",
     "info": "Info",
     "integer": "geheel getal",
-    "json": "JSON",
     "key": "Sleutel",
     "linestring": "lijnenring",
     "long": "lang",
@@ -1488,6 +1487,7 @@
         "changeChildTypeLabelForEnum": "Type opsommingswaarde wijzigen",
         "editMetadataLabel": "Metagegevens bewerken"
       }
-    }
+    },
+    "jsonEditorTabName": "DTDL"
   }
 }

--- a/src/Resources/Locales/pl.json
+++ b/src/Resources/Locales/pl.json
@@ -1419,7 +1419,6 @@
     "id": "Id",
     "info": "Informacji",
     "integer": "liczba całkowita",
-    "json": "JSON",
     "key": "Klucz",
     "linestring": "Ciąg liniowy",
     "long": "długi",
@@ -1488,6 +1487,7 @@
         "changeChildTypeLabelForEnum": "Zmienianie typu wartości wyliczenia",
         "editMetadataLabel": "Edytowanie metadanych"
       }
-    }
+    },
+    "jsonEditorTabName": "DTDL"
   }
 }

--- a/src/Resources/Locales/pt-pt.json
+++ b/src/Resources/Locales/pt-pt.json
@@ -1419,7 +1419,6 @@
     "id": "Id",
     "info": "Informação",
     "integer": "inteiro",
-    "json": "JSON",
     "key": "Chave",
     "linestring": "linestring",
     "long": "Longo",
@@ -1488,6 +1487,7 @@
         "changeChildTypeLabelForEnum": "Alterar o tipo de valor enum",
         "editMetadataLabel": "Editar metadados"
       }
-    }
+    },
+    "jsonEditorTabName": "DTDL"
   }
 }

--- a/src/Resources/Locales/pt.json
+++ b/src/Resources/Locales/pt.json
@@ -1419,7 +1419,6 @@
     "id": "Id",
     "info": "Informação",
     "integer": "inteiro",
-    "json": "JSON",
     "key": "Chave",
     "linestring": "linestring",
     "long": "Longas",
@@ -1488,6 +1487,7 @@
         "changeChildTypeLabelForEnum": "Alterar o tipo de valor de enum",
         "editMetadataLabel": "Editar metadados"
       }
-    }
+    },
+    "jsonEditorTabName": "DTDL"
   }
 }

--- a/src/Resources/Locales/ru.json
+++ b/src/Resources/Locales/ru.json
@@ -1419,7 +1419,6 @@
     "id": "Идентификатор",
     "info": "Информация",
     "integer": "целое число",
-    "json": "JSON",
     "key": "Ключ",
     "linestring": "линейная струна",
     "long": "длинный",
@@ -1488,6 +1487,7 @@
         "changeChildTypeLabelForEnum": "Изменение типа значения перечисления",
         "editMetadataLabel": "Редактирование метаданных"
       }
-    }
+    },
+    "jsonEditorTabName": "DTDL"
   }
 }

--- a/src/Resources/Locales/sv.json
+++ b/src/Resources/Locales/sv.json
@@ -1419,7 +1419,6 @@
     "id": "Id",
     "info": "Information",
     "integer": "heltal",
-    "json": "JSON",
     "key": "Nyckel",
     "linestring": "linjesträng",
     "long": "lång",
@@ -1488,6 +1487,7 @@
         "changeChildTypeLabelForEnum": "Ändra uppräkningsvärdetyp",
         "editMetadataLabel": "Redigera metadata"
       }
-    }
+    },
+    "jsonEditorTabName": "DTDL"
   }
 }

--- a/src/Resources/Locales/tr.json
+++ b/src/Resources/Locales/tr.json
@@ -1419,7 +1419,6 @@
     "id": "Kimliği",
     "info": "Bilgi",
     "integer": "tam sayı",
-    "json": "cesaret",
     "key": "Anahtar",
     "linestring": "linestring",
     "long": "uzun",
@@ -1488,6 +1487,7 @@
         "changeChildTypeLabelForEnum": "Enum değer türünü değiştirme",
         "editMetadataLabel": "Meta verileri düzenleme"
       }
-    }
+    },
+    "jsonEditorTabName": "cesaret"
   }
 }

--- a/src/Resources/Locales/zh-Hans.json
+++ b/src/Resources/Locales/zh-Hans.json
@@ -1419,7 +1419,6 @@
     "id": "编号",
     "info": "信息",
     "integer": "整数",
-    "json": "杰伦",
     "key": "钥匙",
     "linestring": "线串",
     "long": "长",
@@ -1488,6 +1487,7 @@
         "changeChildTypeLabelForEnum": "更改枚举值类型",
         "editMetadataLabel": "编辑元数据"
       }
-    }
+    },
+    "jsonEditorTabName": "DTDL"
   }
 }


### PR DESCRIPTION
### Summary of changes 🔍 
- Add some padding around the header component so that it's not tight to the edge in the hosted experience
- Rename the JSON editor component and conform to templates
- Change tab name for JSON editor to 'DTDL'

![image](https://user-images.githubusercontent.com/57726991/219229685-6ea23878-20b9-4264-8338-87dc2df39cc9.png)

![image](https://user-images.githubusercontent.com/57726991/219230049-086a4acd-956e-4040-8946-d7ed9a6a4923.png)
