### PR TITLE
Added CORS condition to Blob adapter

### DIFF
--- a/.storybook/middleware.js
+++ b/.storybook/middleware.js
@@ -10,7 +10,8 @@ const retryNumber = 3;
 
 module.exports = function (app) {
     // Set to false when you want to test CORS in Storybook
-    const useProxy = true;
+    const useAdtProxy = true;
+    const useBlobProxy = true;
     const validAdtHostSuffixes = ['.digitaltwins.azure.net'];
     const isValidAdtHostUrl = (urlPrefix) =>
         /^[a-zA-z0-9]{1}[a-zA-Z0-9-]{1,60}[a-zA-Z0-9]{1}(\.api)\.[a-zA-Z0-9]{1,}$/.test(
@@ -108,7 +109,7 @@ module.exports = function (app) {
         });
     };
 
-    if (useProxy) {
+    if (useAdtProxy) {
         app.use('/proxy/adt', createAdtProxyMiddlewareObject('/proxy/adt'));
     }
 
@@ -178,7 +179,9 @@ module.exports = function (app) {
         }
     });
 
-    app.use('/proxy/blob', (req, res, next) =>
-        blobProxy.call(blobProxy, req, res, next)
-    );
+    if (useBlobProxy) {
+        app.use('/proxy/blob', (req, res, next) =>
+            blobProxy.call(blobProxy, req, res, next)
+        );
+    }
 };

--- a/src/Adapters/ADT3DSceneAdapter.ts
+++ b/src/Adapters/ADT3DSceneAdapter.ts
@@ -46,7 +46,7 @@ export default class ADT3DSceneAdapter {
         uniqueObjectId?: string,
         adtProxyServerPath = '/proxy/adt',
         blobProxyServerPath = '/proxy/blob',
-        useProxy = true,
+        useAdtProxy = true,
         useBlobProxy = true
     ) {
         this.adtHostUrl = adtHostUrl;
@@ -67,8 +67,9 @@ export default class ADT3DSceneAdapter {
          * Check if class has been initialized with CORS enabled or if origin matches dev or prod explorer urls,
          * override if CORS is forced by feature flag
          *  */
-        this.useProxy =
-            (useProxy || !validateExplorerOrigin(window.origin)) && !forceCORS;
+        this.useAdtProxy =
+            (useAdtProxy || !validateExplorerOrigin(window.origin)) &&
+            !forceCORS;
 
         this.useBlobProxy =
             (useBlobProxy || !validateExplorerOrigin(window.origin)) &&

--- a/src/Adapters/ADT3DSceneAdapter.ts
+++ b/src/Adapters/ADT3DSceneAdapter.ts
@@ -33,6 +33,10 @@ import {
 import ADTInstanceTimeSeriesConnectionData from '../Models/Classes/AdapterDataClasses/ADTInstanceTimeSeriesConnectionData';
 import ADTDataHistoryAdapter from './ADTDataHistoryAdapter';
 
+const forceCORS =
+    localStorage.getItem(LOCAL_STORAGE_KEYS.FeatureFlags.Proxy.forceCORS) ===
+    'true';
+
 export default class ADT3DSceneAdapter {
     constructor(
         authService: IAuthService,
@@ -64,16 +68,11 @@ export default class ADT3DSceneAdapter {
          * override if CORS is forced by feature flag
          *  */
         this.useProxy =
-            (useProxy || !validateExplorerOrigin(window.origin)) &&
-            localStorage.getItem(
-                LOCAL_STORAGE_KEYS.FeatureFlags.Proxy.forceCORS
-            ) !== 'true';
+            (useProxy || !validateExplorerOrigin(window.origin)) && !forceCORS;
 
         this.useBlobProxy =
             (useBlobProxy || !validateExplorerOrigin(window.origin)) &&
-            localStorage.getItem(
-                LOCAL_STORAGE_KEYS.FeatureFlags.Proxy.forceCORS
-            ) !== 'true';
+            !forceCORS;
 
         if (blobContainerUrl) {
             try {

--- a/src/Adapters/ADT3DSceneAdapter.ts
+++ b/src/Adapters/ADT3DSceneAdapter.ts
@@ -65,11 +65,9 @@ export default class ADT3DSceneAdapter {
          *  */
         this.useProxy =
             (useProxy || !validateExplorerOrigin(window.origin)) &&
-            !(
-                localStorage.getItem(
-                    LOCAL_STORAGE_KEYS.FeatureFlags.Proxy.forceCORS
-                ) === 'true'
-            );
+            localStorage.getItem(
+                LOCAL_STORAGE_KEYS.FeatureFlags.Proxy.forceCORS
+            ) !== 'true';
 
         this.useBlobProxy =
             (useBlobProxy || !validateExplorerOrigin(window.origin)) &&

--- a/src/Adapters/ADT3DSceneAdapter.ts
+++ b/src/Adapters/ADT3DSceneAdapter.ts
@@ -60,14 +60,15 @@ export default class ADT3DSceneAdapter {
         );
         /**
          * Check if class has been initialized with CORS enabled or if origin matches dev or prod explorer urls,
-         * override if proxy is forced by feature flag
+         * override if CORS is forced by feature flag
          *  */
         this.useProxy =
-            useProxy ||
-            validateExplorerOrigin(window.origin) ||
-            localStorage.getItem(
-                LOCAL_STORAGE_KEYS.FeatureFlags.Proxy.forceProxy
-            ) === 'true';
+            (useProxy || !validateExplorerOrigin(window.origin)) &&
+            !(
+                localStorage.getItem(
+                    LOCAL_STORAGE_KEYS.FeatureFlags.Proxy.forceCORS
+                ) === 'true'
+            );
 
         if (blobContainerUrl) {
             try {

--- a/src/Adapters/ADT3DSceneAdapter.ts
+++ b/src/Adapters/ADT3DSceneAdapter.ts
@@ -71,11 +71,9 @@ export default class ADT3DSceneAdapter {
 
         this.useBlobProxy =
             (useBlobProxy || !validateExplorerOrigin(window.origin)) &&
-            !(
-                localStorage.getItem(
-                    LOCAL_STORAGE_KEYS.FeatureFlags.Proxy.forceCORS
-                ) === 'true'
-            );
+            localStorage.getItem(
+                LOCAL_STORAGE_KEYS.FeatureFlags.Proxy.forceCORS
+            ) !== 'true';
 
         if (blobContainerUrl) {
             try {

--- a/src/Adapters/ADT3DSceneAdapter.ts
+++ b/src/Adapters/ADT3DSceneAdapter.ts
@@ -42,7 +42,8 @@ export default class ADT3DSceneAdapter {
         uniqueObjectId?: string,
         adtProxyServerPath = '/proxy/adt',
         blobProxyServerPath = '/proxy/blob',
-        useProxy = true
+        useProxy = true,
+        useBlobProxy = true
     ) {
         this.adtHostUrl = adtHostUrl;
         this.authService = this.blobAuthService = this.adxAuthService = authService;
@@ -64,6 +65,14 @@ export default class ADT3DSceneAdapter {
          *  */
         this.useProxy =
             (useProxy || !validateExplorerOrigin(window.origin)) &&
+            !(
+                localStorage.getItem(
+                    LOCAL_STORAGE_KEYS.FeatureFlags.Proxy.forceCORS
+                ) === 'true'
+            );
+
+        this.useBlobProxy =
+            (useBlobProxy || !validateExplorerOrigin(window.origin)) &&
             !(
                 localStorage.getItem(
                     LOCAL_STORAGE_KEYS.FeatureFlags.Proxy.forceCORS

--- a/src/Adapters/ADTAdapter.ts
+++ b/src/Adapters/ADTAdapter.ts
@@ -119,14 +119,15 @@ export default class ADTAdapter implements IADTAdapter {
         );
         /**
          * Check if class has been initialized with CORS enabled or if origin matches dev or prod explorer urls,
-         * override if proxy is forced by feature flag
+         * override if CORS is forced by feature flag
          *  */
         this.useProxy =
-            useProxy ||
-            !validateExplorerOrigin(window.origin) ||
-            localStorage.getItem(
-                LOCAL_STORAGE_KEYS.FeatureFlags.Proxy.forceProxy
-            ) === 'true';
+            (useProxy || !validateExplorerOrigin(window.origin)) &&
+            !(
+                localStorage.getItem(
+                    LOCAL_STORAGE_KEYS.FeatureFlags.Proxy.forceCORS
+                ) === 'true'
+            );
 
         this.authService.login();
         this.axiosInstance = axios.create({

--- a/src/Adapters/ADTAdapter.ts
+++ b/src/Adapters/ADTAdapter.ts
@@ -123,11 +123,9 @@ export default class ADTAdapter implements IADTAdapter {
          *  */
         this.useProxy =
             (useProxy || !validateExplorerOrigin(window.origin)) &&
-            !(
-                localStorage.getItem(
-                    LOCAL_STORAGE_KEYS.FeatureFlags.Proxy.forceCORS
-                ) === 'true'
-            );
+            localStorage.getItem(
+                LOCAL_STORAGE_KEYS.FeatureFlags.Proxy.forceCORS
+            ) !== 'true';
 
         this.authService.login();
         this.axiosInstance = axios.create({

--- a/src/Adapters/ADTAdapter.ts
+++ b/src/Adapters/ADTAdapter.ts
@@ -95,7 +95,7 @@ export default class ADTAdapter implements IADTAdapter {
     protected adtTwinCache: AdapterEntityCache<ADTTwinData>;
     protected adtModelsCache: AdapterEntityCache<ADTAllModelsData>;
     protected adtTwinToModelMappingCache: AdapterEntityCache<ADTTwinToModelMappingData>;
-    protected useProxy: boolean;
+    protected useAdtProxy: boolean;
 
     constructor(
         adtHostUrl: string,
@@ -103,7 +103,7 @@ export default class ADTAdapter implements IADTAdapter {
         tenantId?: string,
         uniqueObjectId?: string,
         adtProxyServerPath = '/proxy/adt',
-        useProxy = true
+        useAdtProxy = true
     ) {
         this.setAdtHostUrl(adtHostUrl); // this should be the host name of the instace
         this.adtProxyServerPath = adtProxyServerPath;
@@ -124,11 +124,14 @@ export default class ADTAdapter implements IADTAdapter {
          * Check if class has been initialized with CORS enabled or if origin matches dev or prod explorer urls,
          * override if CORS is forced by feature flag
          *  */
-        this.useProxy =
-            (useProxy || !validateExplorerOrigin(window.origin)) && !forceCORS;
+        this.useAdtProxy =
+            (useAdtProxy || !validateExplorerOrigin(window.origin)) &&
+            !forceCORS;
         this.authService.login();
         this.axiosInstance = axios.create({
-            baseURL: this.useProxy ? this.adtProxyServerPath : this.adtHostUrl
+            baseURL: this.useAdtProxy
+                ? this.adtProxyServerPath
+                : this.adtHostUrl
         });
         axiosRetry(this.axiosInstance, {
             retries: 3,
@@ -145,7 +148,7 @@ export default class ADTAdapter implements IADTAdapter {
     }
 
     generateUrl(path: string) {
-        if (this.useProxy) {
+        if (this.useAdtProxy) {
             return `${this.adtProxyServerPath}${path}`;
         } else {
             return `https://${this.adtHostUrl}${path}`;
@@ -153,7 +156,7 @@ export default class ADTAdapter implements IADTAdapter {
     }
 
     generateHeaders(headers: AxiosObjParam = {}) {
-        if (this.useProxy) {
+        if (this.useAdtProxy) {
             return {
                 ...headers,
                 'x-adt-host': this.adtHostUrl

--- a/src/Adapters/ADTAdapter.ts
+++ b/src/Adapters/ADTAdapter.ts
@@ -77,6 +77,9 @@ import queryString from 'query-string';
 
 const debugLogging = false;
 const logDebugConsole = getDebugLogger('ADTAdapter', debugLogging);
+const forceCORS =
+    localStorage.getItem(LOCAL_STORAGE_KEYS.FeatureFlags.Proxy.forceCORS) ===
+    'true';
 
 export default class ADTAdapter implements IADTAdapter {
     public tenantId: string;
@@ -122,11 +125,7 @@ export default class ADTAdapter implements IADTAdapter {
          * override if CORS is forced by feature flag
          *  */
         this.useProxy =
-            (useProxy || !validateExplorerOrigin(window.origin)) &&
-            localStorage.getItem(
-                LOCAL_STORAGE_KEYS.FeatureFlags.Proxy.forceCORS
-            ) !== 'true';
-
+            (useProxy || !validateExplorerOrigin(window.origin)) && !forceCORS;
         this.authService.login();
         this.axiosInstance = axios.create({
             baseURL: this.useProxy ? this.adtProxyServerPath : this.adtHostUrl

--- a/src/Adapters/ADTDataHistoryAdapter.ts
+++ b/src/Adapters/ADTDataHistoryAdapter.ts
@@ -57,14 +57,15 @@ export default class ADTDataHistoryAdapter implements IADTDataHistoryAdapter {
         );
         /**
          * Check if class has been initialized with CORS enabled or if origin matches dev or prod explorer urls,
-         * override if proxy is forced by feature flag
+         * override if CORS is forced by feature flag
          *  */
         this.useProxy =
-            useProxy ||
-            !validateExplorerOrigin(window.origin) ||
-            localStorage.getItem(
-                LOCAL_STORAGE_KEYS.FeatureFlags.Proxy.forceProxy
-            ) === 'true';
+            (useProxy || !validateExplorerOrigin(window.origin)) &&
+            !(
+                localStorage.getItem(
+                    LOCAL_STORAGE_KEYS.FeatureFlags.Proxy.forceCORS
+                ) === 'true'
+            );
 
         this.authService.login();
         // Fetch & cache models on mount (makes first use of models faster as models should already be cached)

--- a/src/Adapters/ADTDataHistoryAdapter.ts
+++ b/src/Adapters/ADTDataHistoryAdapter.ts
@@ -27,6 +27,9 @@ import AzureManagementAdapter from './AzureManagementAdapter';
 
 const debugLogging = false;
 const logDebugConsole = getDebugLogger('ADTDataHistoryAdapter', debugLogging);
+const forceCORS =
+    localStorage.getItem(LOCAL_STORAGE_KEYS.FeatureFlags.Proxy.forceCORS) ===
+    'true';
 
 export default class ADTDataHistoryAdapter implements IADTDataHistoryAdapter {
     constructor(
@@ -60,10 +63,7 @@ export default class ADTDataHistoryAdapter implements IADTDataHistoryAdapter {
          * override if CORS is forced by feature flag
          *  */
         this.useProxy =
-            (useProxy || !validateExplorerOrigin(window.origin)) &&
-            localStorage.getItem(
-                LOCAL_STORAGE_KEYS.FeatureFlags.Proxy.forceCORS
-            ) !== 'true';
+            (useProxy || !validateExplorerOrigin(window.origin)) && !forceCORS;
 
         this.authService.login();
         // Fetch & cache models on mount (makes first use of models faster as models should already be cached)

--- a/src/Adapters/ADTDataHistoryAdapter.ts
+++ b/src/Adapters/ADTDataHistoryAdapter.ts
@@ -61,11 +61,9 @@ export default class ADTDataHistoryAdapter implements IADTDataHistoryAdapter {
          *  */
         this.useProxy =
             (useProxy || !validateExplorerOrigin(window.origin)) &&
-            !(
-                localStorage.getItem(
-                    LOCAL_STORAGE_KEYS.FeatureFlags.Proxy.forceCORS
-                ) === 'true'
-            );
+            localStorage.getItem(
+                LOCAL_STORAGE_KEYS.FeatureFlags.Proxy.forceCORS
+            ) !== 'true';
 
         this.authService.login();
         // Fetch & cache models on mount (makes first use of models faster as models should already be cached)

--- a/src/Adapters/ADTDataHistoryAdapter.ts
+++ b/src/Adapters/ADTDataHistoryAdapter.ts
@@ -39,7 +39,7 @@ export default class ADTDataHistoryAdapter implements IADTDataHistoryAdapter {
         tenantId?: string,
         uniqueObjectId?: string,
         adtProxyServerPath = '/proxy/adt',
-        useProxy = true
+        useAdtProxy = true
     ) {
         this.adtHostUrl = adtHostUrl;
         this.adxConnectionInformation = adxConnectionInformation;
@@ -62,8 +62,9 @@ export default class ADTDataHistoryAdapter implements IADTDataHistoryAdapter {
          * Check if class has been initialized with CORS enabled or if origin matches dev or prod explorer urls,
          * override if CORS is forced by feature flag
          *  */
-        this.useProxy =
-            (useProxy || !validateExplorerOrigin(window.origin)) && !forceCORS;
+        this.useAdtProxy =
+            (useAdtProxy || !validateExplorerOrigin(window.origin)) &&
+            !forceCORS;
 
         this.authService.login();
         // Fetch & cache models on mount (makes first use of models faster as models should already be cached)

--- a/src/Adapters/BlobAdapter.ts
+++ b/src/Adapters/BlobAdapter.ts
@@ -33,6 +33,10 @@ import { handleMigrations, LogConfigFileTelemetry } from './BlobAdapterUtility';
 import { AxiosObjParam } from '../Models/Constants/Types';
 import { getStorageAccountUrlFromContainerUrl } from '../Components/EnvironmentPicker/EnvironmentPickerManager';
 
+const forceCORS =
+    localStorage.getItem(LOCAL_STORAGE_KEYS.FeatureFlags.Proxy.forceCORS) ===
+    'true';
+
 export default class BlobAdapter implements IBlobAdapter {
     protected storageAccountName: string;
     protected storageAccountHostName: string;
@@ -58,9 +62,7 @@ export default class BlobAdapter implements IBlobAdapter {
          *  */
         this.useBlobProxy =
             (useBlobProxy || !validateExplorerOrigin(window.origin)) &&
-            localStorage.getItem(
-                LOCAL_STORAGE_KEYS.FeatureFlags.Proxy.forceCORS
-            ) !== 'true';
+            !forceCORS;
     }
 
     getBlobContainerURL() {

--- a/src/Adapters/BlobAdapter.ts
+++ b/src/Adapters/BlobAdapter.ts
@@ -58,11 +58,9 @@ export default class BlobAdapter implements IBlobAdapter {
          *  */
         this.useBlobProxy =
             (useBlobProxy || !validateExplorerOrigin(window.origin)) &&
-            !(
-                localStorage.getItem(
-                    LOCAL_STORAGE_KEYS.FeatureFlags.Proxy.forceCORS
-                ) === 'true'
-            );
+            localStorage.getItem(
+                LOCAL_STORAGE_KEYS.FeatureFlags.Proxy.forceCORS
+            ) !== 'true';
     }
 
     getBlobContainerURL() {

--- a/src/Adapters/BlobAdapter.ts
+++ b/src/Adapters/BlobAdapter.ts
@@ -70,11 +70,9 @@ export default class BlobAdapter implements IBlobAdapter {
             : '';
     }
 
-    generateUrl(path: string, noContainerName?: boolean) {
+    generateUrl(path: string) {
         if (this.useProxy) {
             return `${this.blobProxyServerPath}${path}`;
-        } else if (noContainerName) {
-            return `https://${this.storageAccountHostName}`;
         } else {
             return `${this.getBlobContainerURL()}${path}`;
         }
@@ -109,7 +107,7 @@ export default class BlobAdapter implements IBlobAdapter {
                 await axios({
                     method: 'put',
                     url: this.generateUrl(
-                        `/3DScenesConfiguration_corrupted_${todayDate}.json`
+                        `/${this.containerName}/3DScenesConfiguration_corrupted_${todayDate}.json`
                     ),
                     headers: this.generateHeaders(headers)
                 });
@@ -160,7 +158,9 @@ export default class BlobAdapter implements IBlobAdapter {
                     const scenesBlob = await axios({
                         method: 'GET',
                         url: this.generateUrl(
-                            `/${ADT3DSceneConfigFileNameInBlobStore}.json?cachebust=${new Date().valueOf()}`
+                            `/${
+                                this.containerName
+                            }/${ADT3DSceneConfigFileNameInBlobStore}.json?cachebust=${new Date().valueOf()}`
                         ),
                         headers: this.generateHeaders(headers)
                     });
@@ -229,7 +229,7 @@ export default class BlobAdapter implements IBlobAdapter {
             {
                 method: 'put',
                 url: this.generateUrl(
-                    `/${ADT3DSceneConfigFileNameInBlobStore}.json`
+                    `/${this.containerName}/${ADT3DSceneConfigFileNameInBlobStore}.json`
                 ),
                 headers: this.generateHeaders(headers),
                 data: config
@@ -257,7 +257,7 @@ export default class BlobAdapter implements IBlobAdapter {
             try {
                 const filesData = await axios({
                     method: 'GET',
-                    url: this.generateUrl(''),
+                    url: this.generateUrl(`/${this.containerName}`),
                     headers: this.generateHeaders(headers),
                     params: {
                         restype: 'container',
@@ -318,7 +318,7 @@ export default class BlobAdapter implements IBlobAdapter {
             StorageBlobsData,
             {
                 method: 'put',
-                url: this.generateUrl(`/${file.name}`),
+                url: this.generateUrl(`/${this.containerName}/${file.name}`),
                 headers: this.generateHeaders(headers),
                 data: file
             },
@@ -456,7 +456,7 @@ export default class BlobAdapter implements IBlobAdapter {
             StorageBlobServiceCorsRulesData,
             {
                 method: 'get',
-                url: this.generateUrl('', true),
+                url: this.generateUrl(''),
                 headers: this.generateHeaders(headers),
                 params: {
                     restype: 'service',
@@ -499,7 +499,7 @@ export default class BlobAdapter implements IBlobAdapter {
             StorageBlobServiceCorsRulesData,
             {
                 method: 'put',
-                url: this.generateUrl('', true),
+                url: this.generateUrl(''),
                 headers: this.generateHeaders(headers),
                 params: {
                     restype: 'service',

--- a/src/Adapters/BlobAdapter.ts
+++ b/src/Adapters/BlobAdapter.ts
@@ -39,13 +39,13 @@ export default class BlobAdapter implements IBlobAdapter {
     protected containerResourceId: string; // resource scope
     protected blobAuthService: IAuthService;
     protected blobProxyServerPath: string;
-    protected useProxy: boolean;
+    protected useBlobProxy: boolean;
 
     constructor(
         blobContainerUrl: string,
         authService: IAuthService,
         blobProxyServerPath = '/proxy/blob',
-        useProxy = true
+        useBlobProxy = true
     ) {
         this.setBlobContainerPath(blobContainerUrl);
         this.blobAuthService = authService;
@@ -55,8 +55,8 @@ export default class BlobAdapter implements IBlobAdapter {
          * Check if class has been initialized with CORS enabled or if origin matches dev or prod explorer urls,
          * override if CORS is forced by feature flag
          *  */
-        this.useProxy =
-            (useProxy || !validateExplorerOrigin(window.origin)) &&
+        this.useBlobProxy =
+            (useBlobProxy || !validateExplorerOrigin(window.origin)) &&
             !(
                 localStorage.getItem(
                     LOCAL_STORAGE_KEYS.FeatureFlags.Proxy.forceCORS
@@ -71,7 +71,7 @@ export default class BlobAdapter implements IBlobAdapter {
     }
 
     generateUrl(path: string) {
-        if (this.useProxy) {
+        if (this.useBlobProxy) {
             return `${this.blobProxyServerPath}${path}`;
         } else {
             return `${this.getBlobContainerURL()}${path}`;
@@ -79,7 +79,7 @@ export default class BlobAdapter implements IBlobAdapter {
     }
 
     generateHeaders(headers: AxiosObjParam = {}) {
-        if (this.useProxy) {
+        if (this.useBlobProxy) {
             return {
                 ...headers,
                 'x-blob-host': this.storageAccountHostName

--- a/src/Models/Constants/Constants.ts
+++ b/src/Models/Constants/Constants.ts
@@ -93,7 +93,7 @@ export const LOCAL_STORAGE_KEYS = {
             showExplorer: 'cardboard.feature.dataHistoryExplorer' // enables data history explorer feature if supported
         },
         Proxy: {
-            forceProxy: 'cardboard.feature.forceProxy' // force proxy to run instead of CORS
+            forceCORS: 'cardboard.feature.forceCORS' // force CORS to run instead of proxy
         }
     },
     Environment: {

--- a/src/Pages/ADT3DScenePage/ADT3DScenePage.tsx
+++ b/src/Pages/ADT3DScenePage/ADT3DScenePage.tsx
@@ -480,7 +480,6 @@ const ADT3DScenePageBase: React.FC<IADT3DScenePageProps> = ({
     // does not have required CORS rules in its properties, then set the errors to render ScenePageErrorHandlingWrapper component,
     // otherwise if there is no issues, clear the errors and with CORS fetch scenes config
     useEffect(() => {
-        // Check why this gets CORS error
         if (getCorsPropertiesAdapterData?.adapterResult.getErrors()) {
             if (!deeplinkState.storageUrl || deeplinkState.storageUrl === '') {
                 dispatch({
@@ -495,7 +494,6 @@ const ADT3DScenePageBase: React.FC<IADT3DScenePageProps> = ({
                 // But may not have read access to CORS properties (which results in 403)
                 // This means that users who cannot read CORS configuration may not be able to load 3D models if CORS is misconfigured
                 if (errors?.[0]?.type === ComponentErrorType.CORSError) {
-                    // Check why it gets to this point
                     errorCallbackSetRef.current = false;
                     dispatch({
                         type: ADT3DScenePageActionTypes.SET_ERRORS,

--- a/src/Pages/ADT3DScenePage/ADT3DScenePage.tsx
+++ b/src/Pages/ADT3DScenePage/ADT3DScenePage.tsx
@@ -480,6 +480,7 @@ const ADT3DScenePageBase: React.FC<IADT3DScenePageProps> = ({
     // does not have required CORS rules in its properties, then set the errors to render ScenePageErrorHandlingWrapper component,
     // otherwise if there is no issues, clear the errors and with CORS fetch scenes config
     useEffect(() => {
+        // Check why this gets CORS error
         if (getCorsPropertiesAdapterData?.adapterResult.getErrors()) {
             if (!deeplinkState.storageUrl || deeplinkState.storageUrl === '') {
                 dispatch({
@@ -494,6 +495,7 @@ const ADT3DScenePageBase: React.FC<IADT3DScenePageProps> = ({
                 // But may not have read access to CORS properties (which results in 403)
                 // This means that users who cannot read CORS configuration may not be able to load 3D models if CORS is misconfigured
                 if (errors?.[0]?.type === ComponentErrorType.CORSError) {
+                    // Check why it gets to this point
                     errorCallbackSetRef.current = false;
                     dispatch({
                         type: ADT3DScenePageActionTypes.SET_ERRORS,


### PR DESCRIPTION
### Summary of changes 🔍 
Blob adapter required some changes to be able to make CORS enabled requests. This PR addresses that need and also modifies the existing CORS conditionals to fix forcing CORS with a local storage flag.

### Testing 🧪
Setting `useBlobProxy` enabled
1. Modify either `BlobAdapter` or `ADT3DScenesAdapter` to set `useBlobProxy` to true by default.
2. Run the project locally to be able to make requests.
3. Load containers from storage accounts that have CORS enabled.

Setting `forceProxy` flag
1. Set `useBlobProxy` to false.
2. Run this command in your console `localStorage.setItem('cardboard.feature.forceCORS', 'true')`.
3. Run the project locally to be able to make requests.
4. Load containers from storage accounts that have CORS enabled.

### Checklist ✔️
- [ ] Linked associated issue (if present)
- [ ] Added relevant labels
- [ ] Requested developer reviews
- [ ] Request UI review from design / PM
- [ ] Verify all code checks are passing