### PR TITLE
ESLint: Add ESLint console rule & fix warnings in PRs

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,6 +14,15 @@
     ],
     "rules": {
         "iot-cardboard-js/debug-logging-disabled": "warn",
+        "no-console": [
+            "warn",
+            {
+                "allow": [
+                    "warn",
+                    "error"
+                ]
+            }
+        ],
         "no-debugger": "warn",
         "no-multiple-empty-lines": "warn",
         "react-hooks/exhaustive-deps": "warn",

--- a/.eslintrc.prod.json
+++ b/.eslintrc.prod.json
@@ -2,6 +2,7 @@
     "extends": "./.eslintrc.json",
     "rules": {
         "iot-cardboard-js/debug-logging-disabled": "error",
+        "no-console": "off",
         "no-debugger": "error",
         "no-multiple-empty-lines": "error",
         "react-hooks/exhaustive-deps": "off",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -44,7 +44,8 @@ const commonPlugins = [
     resolve(),
     commonjs(),
     eslint({
-        throwOnError: true
+        throwOnError: true,
+        configFile: '.eslintrc.prod.json',
     }),
     typescript(),
     json(),


### PR DESCRIPTION
### Summary of changes 🔍 
Adding a rule to warn about console use on local but ignore it in the build like to do today. We will warn on `log` only and ignore `warn` and `error`.

![image](https://user-images.githubusercontent.com/57726991/220778146-9aa2b95e-13fb-4466-9276-d7ed015f09b3.png)
