### PR TITLE
[Data History Explorer]: fix mock data

### DIFF
--- a/src/Adapters/MockAdapter.ts
+++ b/src/Adapters/MockAdapter.ts
@@ -86,7 +86,10 @@ import ViewerConfigUtility from '../Models/Classes/ViewerConfigUtility';
 import ADTInstanceTimeSeriesConnectionData from '../Models/Classes/AdapterDataClasses/ADTInstanceTimeSeriesConnectionData';
 import { handleMigrations } from './BlobAdapterUtility';
 import ADXTimeSeriesData from '../Models/Classes/AdapterDataClasses/ADXTimeSeriesData';
-import { getMockTimeSeriesDataArrayInLocalTime } from '../Models/SharedUtils/DataHistoryUtils';
+import {
+    getMockTimeSeriesDataArrayInLocalTime,
+    isTimeSeriesData
+} from '../Models/SharedUtils/DataHistoryUtils';
 
 export default class MockAdapter
     implements
@@ -1049,7 +1052,17 @@ export default class MockAdapter
         useStaticData?: boolean
     ) {
         let mockData: Array<ADXTimeSeries> = [];
-        let mockTimeSeriesData: Array<Array<TimeSeriesData>> = this.mockData;
+        let mockTimeSeriesData: Array<Array<TimeSeriesData>>;
+        if (
+            this.mockData &&
+            Array.isArray(this.mockData) &&
+            this.mockData.every(
+                (arr) => Array.isArray(arr) && arr.every(isTimeSeriesData)
+            )
+        ) {
+            mockTimeSeriesData = this.mockData;
+        }
+
         try {
             await this.mockNetwork();
             try {

--- a/src/Components/HighChartsWrapper/HighChartsWrapper.tsx
+++ b/src/Components/HighChartsWrapper/HighChartsWrapper.tsx
@@ -57,7 +57,7 @@ const HighChartsWrapper: React.FC<IHighChartsWrapperProps> = (props) => {
                         ({
                             name: sD.name,
                             data: sD.data
-                                .map((d) => [
+                                ?.map((d) => [
                                     typeof d.timestamp === 'string'
                                         ? new Date(d.timestamp).getTime()
                                         : d.timestamp, // by default, if timestamp is date string convert it to number since highcharts only accept number type for series
@@ -67,7 +67,7 @@ const HighChartsWrapper: React.FC<IHighChartsWrapperProps> = (props) => {
                             type: 'line', // by default, show series in line chart type
                             color: sD.color || getHighChartColorByIdx(idx), // by default, set color to use it for labels in legend to match series color
                             marker: {
-                                enabled: sD.data.length === 1 // by default, do not mark data points if there is more than 1, only show on hover
+                                enabled: sD.data?.length === 1 // by default, do not mark data points if there is more than 1, only show on hover
                             },
                             tooltip: {
                                 ...(sD.tooltipSuffix && {

--- a/src/Models/SharedUtils/DataHistoryUtils.ts
+++ b/src/Models/SharedUtils/DataHistoryUtils.ts
@@ -24,6 +24,7 @@ import { TelemetryEvent } from '../Services/TelemetryService/Telemetry';
 import TelemetryService from '../Services/TelemetryService/TelemetryService';
 import { CustomProperties } from '../Services/TelemetryService/TelemetryService.types';
 import {
+    isDefined,
     objectHasOwnProperty,
     sortAscendingOrDescending
 } from '../Services/Utils';
@@ -266,3 +267,8 @@ export const sendDataHistoryExplorerUserTelemetry = (
         })
     );
 };
+
+export const isTimeSeriesData = (data: any): data is TimeSeriesData =>
+    isDefined(data) &&
+    objectHasOwnProperty(data, 'timestamp') &&
+    objectHasOwnProperty(data, 'value');


### PR DESCRIPTION
### Summary of changes 🔍 
Added check for adapter's mockData type to be returned from getTimeSeriesData method. Ideally we should specify what is the mockData is for.


### Testing 🧪
You can test it in DataHistoryExplorer LargeData mock story since it is using mockData assigned when the new MockAdapter is initialized vs in any story which uses data history where mockData is initialized as a different type for the MockAdapter like ADT3DScenePage mock stories with mock scenes config:
![image](https://user-images.githubusercontent.com/45217314/220791606-13da8a4a-b120-41d0-8de3-5cc23233a5d7.png)
![image](https://user-images.githubusercontent.com/45217314/220792084-94eb662e-8acc-4dde-ade8-9b002fb290a4.png)
![image](https://user-images.githubusercontent.com/45217314/220792401-c401e0f0-8f1e-4cd3-975c-c147d38c0dd2.png)


### Checklist ✔️
- [ ] Linked associated issue (if present)
- [x] Added relevant labels
- [x] Requested developer reviews
- [ ] Request UI review from design / PM
- [x] Verify all code checks are passing