### PR TITLE
mockData arg fix for Mock Adapter

### DIFF
--- a/src/Components/ADT3DSceneBuilder/ADT3DSceneBuilder.BehaviorForm.stories.tsx
+++ b/src/Components/ADT3DSceneBuilder/ADT3DSceneBuilder.BehaviorForm.stories.tsx
@@ -36,9 +36,11 @@ const Template: SceneBuilderStory = (
                 locale={context.globals.locale}
                 adapter={
                     new MockAdapter({
-                        mockData: context.parameters.data
-                            ? deepCopy(context.parameters.data)
-                            : trucksMockVConfig
+                        mockData: {
+                            schemaConfig: context.parameters.data
+                                ? deepCopy(context.parameters.data)
+                                : trucksMockVConfig
+                        }
                     })
                 }
                 sceneId="58e02362287440d9a5bf3f8d6d6bfcf9"

--- a/src/Components/ADT3DSceneBuilder/ADT3DSceneBuilder.BehaviorForm.stories.tsx
+++ b/src/Components/ADT3DSceneBuilder/ADT3DSceneBuilder.BehaviorForm.stories.tsx
@@ -37,7 +37,7 @@ const Template: SceneBuilderStory = (
                 adapter={
                     new MockAdapter({
                         mockData: {
-                            schemaConfig: context.parameters.data
+                            scenesConfig: context.parameters.data
                                 ? deepCopy(context.parameters.data)
                                 : trucksMockVConfig
                         }

--- a/src/Components/ADT3DSceneBuilder/ADT3DSceneBuilder.BehaviorList.stories.tsx
+++ b/src/Components/ADT3DSceneBuilder/ADT3DSceneBuilder.BehaviorList.stories.tsx
@@ -41,9 +41,11 @@ const Template: SceneBuilderStory = (
                 locale={context.globals.locale}
                 adapter={
                     new MockAdapter({
-                        mockData: context.parameters.data
-                            ? deepCopy(context.parameters.data)
-                            : trucksMockVConfig
+                        mockData: {
+                            schemaConfig: context.parameters.data
+                                ? deepCopy(context.parameters.data)
+                                : trucksMockVConfig
+                        }
                     })
                 }
                 sceneId="58e02362287440d9a5bf3f8d6d6bfcf9"

--- a/src/Components/ADT3DSceneBuilder/ADT3DSceneBuilder.BehaviorList.stories.tsx
+++ b/src/Components/ADT3DSceneBuilder/ADT3DSceneBuilder.BehaviorList.stories.tsx
@@ -42,7 +42,7 @@ const Template: SceneBuilderStory = (
                 adapter={
                     new MockAdapter({
                         mockData: {
-                            schemaConfig: context.parameters.data
+                            scenesConfig: context.parameters.data
                                 ? deepCopy(context.parameters.data)
                                 : trucksMockVConfig
                         }

--- a/src/Components/ADT3DSceneBuilder/ADT3DSceneBuilder.BehaviorTwinAliasList.stories.tsx
+++ b/src/Components/ADT3DSceneBuilder/ADT3DSceneBuilder.BehaviorTwinAliasList.stories.tsx
@@ -32,7 +32,7 @@ const Template: SceneBuilderStory = (
                 adapter={
                     new MockAdapter({
                         mockData: {
-                            schemaConfig: context.parameters.data
+                            scenesConfig: context.parameters.data
                                 ? deepCopy(context.parameters.data)
                                 : trucksMockVConfig
                         }

--- a/src/Components/ADT3DSceneBuilder/ADT3DSceneBuilder.BehaviorTwinAliasList.stories.tsx
+++ b/src/Components/ADT3DSceneBuilder/ADT3DSceneBuilder.BehaviorTwinAliasList.stories.tsx
@@ -31,9 +31,11 @@ const Template: SceneBuilderStory = (
                 locale={context.globals.locale}
                 adapter={
                     new MockAdapter({
-                        mockData: context.parameters.data
-                            ? deepCopy(context.parameters.data)
-                            : trucksMockVConfig
+                        mockData: {
+                            schemaConfig: context.parameters.data
+                                ? deepCopy(context.parameters.data)
+                                : trucksMockVConfig
+                        }
                     })
                 }
                 sceneId="58e02362287440d9a5bf3f8d6d6bfcf9"

--- a/src/Components/ADT3DSceneBuilder/ADT3DSceneBuilder.ElementTwinAliasList.stories.tsx
+++ b/src/Components/ADT3DSceneBuilder/ADT3DSceneBuilder.ElementTwinAliasList.stories.tsx
@@ -36,9 +36,11 @@ const Template: SceneBuilderStory = (
                 locale={context.globals.locale}
                 adapter={
                     new MockAdapter({
-                        mockData: context.parameters.data
-                            ? deepCopy(context.parameters.data)
-                            : trucksMockVConfig
+                        mockData: {
+                            schemaConfig: context.parameters.data
+                                ? deepCopy(context.parameters.data)
+                                : trucksMockVConfig
+                        }
                     })
                 }
                 sceneId="58e02362287440d9a5bf3f8d6d6bfcf9"

--- a/src/Components/ADT3DSceneBuilder/ADT3DSceneBuilder.ElementTwinAliasList.stories.tsx
+++ b/src/Components/ADT3DSceneBuilder/ADT3DSceneBuilder.ElementTwinAliasList.stories.tsx
@@ -37,7 +37,7 @@ const Template: SceneBuilderStory = (
                 adapter={
                     new MockAdapter({
                         mockData: {
-                            schemaConfig: context.parameters.data
+                            scenesConfig: context.parameters.data
                                 ? deepCopy(context.parameters.data)
                                 : trucksMockVConfig
                         }

--- a/src/Components/ADT3DSceneBuilder/ADT3DSceneBuilder.Elements.stories.tsx
+++ b/src/Components/ADT3DSceneBuilder/ADT3DSceneBuilder.Elements.stories.tsx
@@ -41,9 +41,11 @@ const Template: SceneBuilderStory = (
             locale={context.globals.locale}
             adapter={
                 new MockAdapter({
-                    mockData: context.parameters.data
-                        ? deepCopy(context.parameters.data)
-                        : trucksMockVConfig
+                    mockData: {
+                        schemaConfig: context.parameters.data
+                            ? deepCopy(context.parameters.data)
+                            : trucksMockVConfig
+                    }
                 })
             }
             sceneId="58e02362287440d9a5bf3f8d6d6bfcf9"

--- a/src/Components/ADT3DSceneBuilder/ADT3DSceneBuilder.Elements.stories.tsx
+++ b/src/Components/ADT3DSceneBuilder/ADT3DSceneBuilder.Elements.stories.tsx
@@ -42,7 +42,7 @@ const Template: SceneBuilderStory = (
             adapter={
                 new MockAdapter({
                     mockData: {
-                        schemaConfig: context.parameters.data
+                        scenesConfig: context.parameters.data
                             ? deepCopy(context.parameters.data)
                             : trucksMockVConfig
                     }

--- a/src/Components/ADT3DSceneBuilder/ADT3DSceneBuilder.VisualRuleList.stories.tsx
+++ b/src/Components/ADT3DSceneBuilder/ADT3DSceneBuilder.VisualRuleList.stories.tsx
@@ -32,7 +32,7 @@ const Template: SceneBuilderStory = (
                 adapter={
                     new MockAdapter({
                         mockData: {
-                            schemaConfig: context.parameters.data
+                            scenesConfig: context.parameters.data
                                 ? deepCopy(context.parameters.data)
                                 : trucksMockVConfig
                         }

--- a/src/Components/ADT3DSceneBuilder/ADT3DSceneBuilder.VisualRuleList.stories.tsx
+++ b/src/Components/ADT3DSceneBuilder/ADT3DSceneBuilder.VisualRuleList.stories.tsx
@@ -31,9 +31,11 @@ const Template: SceneBuilderStory = (
                 locale={context.globals.locale}
                 adapter={
                     new MockAdapter({
-                        mockData: context.parameters.data
-                            ? deepCopy(context.parameters.data)
-                            : trucksMockVConfig
+                        mockData: {
+                            schemaConfig: context.parameters.data
+                                ? deepCopy(context.parameters.data)
+                                : trucksMockVConfig
+                        }
                     })
                 }
                 sceneId="58e02362287440d9a5bf3f8d6d6bfcf9"

--- a/src/Components/ADT3DSceneBuilder/ADT3DSceneBuilder.WidgetsForm.stories.tsx
+++ b/src/Components/ADT3DSceneBuilder/ADT3DSceneBuilder.WidgetsForm.stories.tsx
@@ -74,7 +74,7 @@ const Template: SceneBuilderStory = (
                     adapter={
                         new MockAdapter({
                             mockData: {
-                                schemaConfig: context.parameters.data
+                                scenesConfig: context.parameters.data
                                     ? deepCopy(context.parameters.data)
                                     : trucksMockVConfig
                             }

--- a/src/Components/ADT3DSceneBuilder/ADT3DSceneBuilder.WidgetsForm.stories.tsx
+++ b/src/Components/ADT3DSceneBuilder/ADT3DSceneBuilder.WidgetsForm.stories.tsx
@@ -73,9 +73,11 @@ const Template: SceneBuilderStory = (
                     locale={context.globals.locale}
                     adapter={
                         new MockAdapter({
-                            mockData: context.parameters.data
-                                ? deepCopy(context.parameters.data)
-                                : trucksMockVConfig
+                            mockData: {
+                                schemaConfig: context.parameters.data
+                                    ? deepCopy(context.parameters.data)
+                                    : trucksMockVConfig
+                            }
                         })
                     }
                     sceneId="58e02362287440d9a5bf3f8d6d6bfcf9"

--- a/src/Components/ADT3DSceneBuilder/ADT3DSceneBuilder.WidgetsList.stories.tsx
+++ b/src/Components/ADT3DSceneBuilder/ADT3DSceneBuilder.WidgetsList.stories.tsx
@@ -36,7 +36,7 @@ const Template: SceneBuilderStory = (
                 adapter={
                     new MockAdapter({
                         mockData: {
-                            schema: context.parameters.data
+                            schemaConfig: context.parameters.data
                                 ? deepCopy(context.parameters.data)
                                 : trucksMockVConfig
                         }

--- a/src/Components/ADT3DSceneBuilder/ADT3DSceneBuilder.WidgetsList.stories.tsx
+++ b/src/Components/ADT3DSceneBuilder/ADT3DSceneBuilder.WidgetsList.stories.tsx
@@ -35,9 +35,11 @@ const Template: SceneBuilderStory = (
                 locale={context.globals.locale}
                 adapter={
                     new MockAdapter({
-                        mockData: context.parameters.data
-                            ? deepCopy(context.parameters.data)
-                            : trucksMockVConfig
+                        mockData: {
+                            schema: context.parameters.data
+                                ? deepCopy(context.parameters.data)
+                                : trucksMockVConfig
+                        }
                     })
                 }
                 sceneId="58e02362287440d9a5bf3f8d6d6bfcf9"

--- a/src/Components/ADT3DSceneBuilder/ADT3DSceneBuilder.WidgetsList.stories.tsx
+++ b/src/Components/ADT3DSceneBuilder/ADT3DSceneBuilder.WidgetsList.stories.tsx
@@ -36,7 +36,7 @@ const Template: SceneBuilderStory = (
                 adapter={
                     new MockAdapter({
                         mockData: {
-                            schemaConfig: context.parameters.data
+                            scenesConfig: context.parameters.data
                                 ? deepCopy(context.parameters.data)
                                 : trucksMockVConfig
                         }

--- a/src/Components/ADT3DSceneBuilder/Internal/Behaviors/Twins/BehaviorTwinAliasForm.stories.tsx
+++ b/src/Components/ADT3DSceneBuilder/Internal/Behaviors/Twins/BehaviorTwinAliasForm.stories.tsx
@@ -32,7 +32,7 @@ const Template: SceneBuilderStory = (
                 adapter={
                     new MockAdapter({
                         mockData: {
-                            schemaConfig: context.parameters.data
+                            scenesConfig: context.parameters.data
                                 ? deepCopy(context.parameters.data)
                                 : trucksMockVConfig
                         }

--- a/src/Components/ADT3DSceneBuilder/Internal/Behaviors/Twins/BehaviorTwinAliasForm.stories.tsx
+++ b/src/Components/ADT3DSceneBuilder/Internal/Behaviors/Twins/BehaviorTwinAliasForm.stories.tsx
@@ -31,9 +31,11 @@ const Template: SceneBuilderStory = (
                 locale={context.globals.locale}
                 adapter={
                     new MockAdapter({
-                        mockData: context.parameters.data
-                            ? deepCopy(context.parameters.data)
-                            : trucksMockVConfig
+                        mockData: {
+                            schemaConfig: context.parameters.data
+                                ? deepCopy(context.parameters.data)
+                                : trucksMockVConfig
+                        }
                     })
                 }
                 sceneId="58e02362287440d9a5bf3f8d6d6bfcf9"

--- a/src/Components/ADT3DSceneBuilder/Internal/Behaviors/Widgets/WidgetBuilders/DataHistoryWidgetBuilder/DataHistoryWidgetBuilder.stories.tsx
+++ b/src/Components/ADT3DSceneBuilder/Internal/Behaviors/Widgets/WidgetBuilders/DataHistoryWidgetBuilder/DataHistoryWidgetBuilder.stories.tsx
@@ -77,7 +77,7 @@ const Template: SceneBuilderStory = (
                     adapter={
                         new MockAdapter({
                             mockData: {
-                                schemaConfig: context.parameters.data
+                                scenesConfig: context.parameters.data
                                     ? deepCopy(context.parameters.data)
                                     : trucksMockVConfig
                             }

--- a/src/Components/ADT3DSceneBuilder/Internal/Behaviors/Widgets/WidgetBuilders/DataHistoryWidgetBuilder/DataHistoryWidgetBuilder.stories.tsx
+++ b/src/Components/ADT3DSceneBuilder/Internal/Behaviors/Widgets/WidgetBuilders/DataHistoryWidgetBuilder/DataHistoryWidgetBuilder.stories.tsx
@@ -76,9 +76,11 @@ const Template: SceneBuilderStory = (
                     locale={context.globals.locale}
                     adapter={
                         new MockAdapter({
-                            mockData: context.parameters.data
-                                ? deepCopy(context.parameters.data)
-                                : trucksMockVConfig
+                            mockData: {
+                                schemaConfig: context.parameters.data
+                                    ? deepCopy(context.parameters.data)
+                                    : trucksMockVConfig
+                            }
                         })
                     }
                     sceneId="58e02362287440d9a5bf3f8d6d6bfcf9"

--- a/src/Components/ADT3DSceneBuilder/Internal/Elements/Internal/ElementTwinAliasForm.stories.tsx
+++ b/src/Components/ADT3DSceneBuilder/Internal/Elements/Internal/ElementTwinAliasForm.stories.tsx
@@ -32,7 +32,7 @@ const Template: SceneBuilderStory = (
                 adapter={
                     new MockAdapter({
                         mockData: {
-                            schemaConfig: context.parameters.data
+                            scenesConfig: context.parameters.data
                                 ? deepCopy(context.parameters.data)
                                 : trucksMockVConfig
                         }

--- a/src/Components/ADT3DSceneBuilder/Internal/Elements/Internal/ElementTwinAliasForm.stories.tsx
+++ b/src/Components/ADT3DSceneBuilder/Internal/Elements/Internal/ElementTwinAliasForm.stories.tsx
@@ -31,9 +31,11 @@ const Template: SceneBuilderStory = (
                 locale={context.globals.locale}
                 adapter={
                     new MockAdapter({
-                        mockData: context.parameters.data
-                            ? deepCopy(context.parameters.data)
-                            : trucksMockVConfig
+                        mockData: {
+                            schemaConfig: context.parameters.data
+                                ? deepCopy(context.parameters.data)
+                                : trucksMockVConfig
+                        }
                     })
                 }
                 sceneId="58e02362287440d9a5bf3f8d6d6bfcf9"

--- a/src/Components/DataHistoryExplorer/DataHistoryExplorer.stories.tsx
+++ b/src/Components/DataHistoryExplorer/DataHistoryExplorer.stories.tsx
@@ -72,11 +72,13 @@ LargeData.args = {
         }
     ],
     adapter: new MockAdapter({
-        mockData: getMockTimeSeriesDataArrayInLocalTime(
-            2,
-            500000,
-            undefined,
-            isChromatic()
-        )
+        mockData: {
+            timeSeriesDataList: getMockTimeSeriesDataArrayInLocalTime(
+                2,
+                500000,
+                undefined,
+                isChromatic()
+            )
+        }
     })
 } as IDataHistoryExplorerProps;

--- a/src/Components/PropertyInspector/PropertyInspectorCallout/PropertyInspectorCallout.stories.tsx
+++ b/src/Components/PropertyInspector/PropertyInspectorCallout/PropertyInspectorCallout.stories.tsx
@@ -27,7 +27,7 @@ const Template: PropertyInspectorCalloutStory = (args) => {
 export const Base = Template.bind({}) as PropertyInspectorCalloutStory;
 Base.args = {
     twinId: mockTwin[0].$dtId,
-    adapter: new MockAdapter({ mockData: mockTwin })
+    adapter: new MockAdapter({ mockData: { twins: mockTwin } })
 } as IPropertyInspectorCalloutProps;
 
 export const WithDataHistory = Template.bind(

--- a/src/Models/Constants/Interfaces.ts
+++ b/src/Models/Constants/Interfaces.ts
@@ -39,7 +39,8 @@ import {
     AdapterMethodParamsForSearchADTTwins,
     AdapterMethodParamsForGetAzureResources,
     AzureAccessPermissionRoleGroups,
-    AdapterMethodParamsForSearchTwinsByQuery
+    AdapterMethodParamsForSearchTwinsByQuery,
+    TimeSeriesData
 } from './Types';
 import {
     ADTModel_ImgPropertyPositions_PropertyName,
@@ -206,7 +207,11 @@ export interface IMockAdapter {
     /** If unset, random data is generated, if explicitly set, MockAdapter will use value for mocked data.
      *  To mock empty data, explicitly set { mockData: null }
      */
-    mockData?: any;
+    mockData?: {
+        schemaConfig?: I3DScenesConfig;
+        twins?: Array<IADTTwin>;
+        timeSeriesDataList?: Array<Array<TimeSeriesData>>;
+    };
 
     /** Mocked network timeout period, defaults to 0ms */
     networkTimeoutMillis?: number;

--- a/src/Models/Constants/Interfaces.ts
+++ b/src/Models/Constants/Interfaces.ts
@@ -207,11 +207,7 @@ export interface IMockAdapter {
     /** If unset, random data is generated, if explicitly set, MockAdapter will use value for mocked data.
      *  To mock empty data, explicitly set { mockData: null }
      */
-    mockData?: {
-        schemaConfig?: I3DScenesConfig;
-        twins?: Array<IADTTwin>;
-        timeSeriesDataList?: Array<Array<TimeSeriesData>>;
-    };
+    mockData?: IMockData;
 
     /** Mocked network timeout period, defaults to 0ms */
     networkTimeoutMillis?: number;
@@ -221,6 +217,13 @@ export interface IMockAdapter {
 
     /** Toggles seeding of random data (data remains constants between builds), defaults to true */
     isDataStatic?: boolean;
+}
+
+export interface IMockData {
+    scenesConfig?: I3DScenesConfig;
+    twins?: Array<IADTTwin>;
+    models?: DtdlInterface[];
+    timeSeriesDataList?: Array<Array<TimeSeriesData>>;
 }
 
 export interface IMockError {

--- a/src/Models/SharedUtils/DataHistoryUtils.ts
+++ b/src/Models/SharedUtils/DataHistoryUtils.ts
@@ -24,7 +24,6 @@ import { TelemetryEvent } from '../Services/TelemetryService/Telemetry';
 import TelemetryService from '../Services/TelemetryService/TelemetryService';
 import { CustomProperties } from '../Services/TelemetryService/TelemetryService.types';
 import {
-    isDefined,
     objectHasOwnProperty,
     sortAscendingOrDescending
 } from '../Services/Utils';
@@ -267,8 +266,3 @@ export const sendDataHistoryExplorerUserTelemetry = (
         })
     );
 };
-
-export const isTimeSeriesData = (data: any): data is TimeSeriesData =>
-    isDefined(data) &&
-    objectHasOwnProperty(data, 'timestamp') &&
-    objectHasOwnProperty(data, 'value');

--- a/src/Pages/ADT3DScenePage/ADT3DScenePage.stories.tsx
+++ b/src/Pages/ADT3DScenePage/ADT3DScenePage.stories.tsx
@@ -255,7 +255,7 @@ export const Mock3DScenePageSchemaErrors = (
     _args,
     { globals: { theme, locale } }
 ) => {
-    const invalidConfig = deepCopy(mockConfig);
+    const invalidConfig = deepCopy(mockConfig) as I3DScenesConfig;
     invalidConfig.configuration.scenes[0]['invalidPropTest'] = 'uh oh';
 
     return (
@@ -267,7 +267,7 @@ export const Mock3DScenePageSchemaErrors = (
                 adapter={
                     new MockAdapter({
                         mockData: {
-                            scenesConfig: mockConfig as I3DScenesConfig
+                            scenesConfig: invalidConfig
                         }
                     })
                 }

--- a/src/Pages/ADT3DScenePage/ADT3DScenePage.stories.tsx
+++ b/src/Pages/ADT3DScenePage/ADT3DScenePage.stories.tsx
@@ -49,7 +49,7 @@ export const Mock3DScenePage = (_args, { globals: { theme, locale } }) => {
                 adapter={
                     new MockAdapter({
                         mockData: {
-                            schemaConfig: mockConfig as I3DScenesConfig
+                            scenesConfig: mockConfig as I3DScenesConfig
                         }
                     })
                 }
@@ -84,7 +84,7 @@ export const DeeplinkedViewer = (_args, { globals: { theme, locale } }) => {
                     adapter={
                         new MockAdapter({
                             mockData: {
-                                schemaConfig: mockConfig as I3DScenesConfig
+                                scenesConfig: mockConfig as I3DScenesConfig
                             }
                         })
                     }
@@ -120,7 +120,7 @@ export const DeeplinkedBuilder = (_args, { globals: { theme, locale } }) => {
                     adapter={
                         new MockAdapter({
                             mockData: {
-                                schemaConfig: mockConfig as I3DScenesConfig
+                                scenesConfig: mockConfig as I3DScenesConfig
                             }
                         })
                     }
@@ -191,7 +191,7 @@ const ThemeCustomizationContent: React.FC<{ theme; locale }> = ({
                     adapter={
                         new MockAdapter({
                             mockData: {
-                                schemaConfig: mockConfig as I3DScenesConfig
+                                scenesConfig: mockConfig as I3DScenesConfig
                             }
                         })
                     }
@@ -267,7 +267,7 @@ export const Mock3DScenePageSchemaErrors = (
                 adapter={
                     new MockAdapter({
                         mockData: {
-                            schemaConfig: mockConfig as I3DScenesConfig
+                            scenesConfig: mockConfig as I3DScenesConfig
                         }
                     })
                 }
@@ -283,9 +283,11 @@ export const Mock3DScenePageDemoEnvs = (
     { globals: { theme, locale } }
 ) => {
     const adapter = new MockAdapter();
-    adapter.scenesConfig = demoEnvsConfig as I3DScenesConfig;
-    adapter.mockTwins = demoEnvsTwins as IADTTwin[];
-    adapter.mockModels = demoEnvsModels as DtdlInterface[];
+    adapter.mockData = {
+        scenesConfig: demoEnvsConfig as I3DScenesConfig,
+        twins: demoEnvsTwins as IADTTwin[],
+        models: demoEnvsModels as DtdlInterface[]
+    };
 
     return (
         <div style={cardStyle}>

--- a/src/Pages/ADT3DScenePage/ADT3DScenePage.stories.tsx
+++ b/src/Pages/ADT3DScenePage/ADT3DScenePage.stories.tsx
@@ -46,7 +46,13 @@ export const Mock3DScenePage = (_args, { globals: { theme, locale } }) => {
                 title={'3D Scene Page'}
                 theme={theme}
                 locale={locale}
-                adapter={new MockAdapter({ mockData: mockConfig })}
+                adapter={
+                    new MockAdapter({
+                        mockData: {
+                            schemaConfig: mockConfig as I3DScenesConfig
+                        }
+                    })
+                }
                 enableTwinPropertyInspectorPatchMode
             />
         </div>
@@ -75,7 +81,13 @@ export const DeeplinkedViewer = (_args, { globals: { theme, locale } }) => {
                     title={'3D Scene Page'}
                     theme={theme}
                     locale={locale}
-                    adapter={new MockAdapter({ mockData: mockConfig })}
+                    adapter={
+                        new MockAdapter({
+                            mockData: {
+                                schemaConfig: mockConfig as I3DScenesConfig
+                            }
+                        })
+                    }
                     enableTwinPropertyInspectorPatchMode
                 />
             </DeeplinkContextProvider>
@@ -105,7 +117,13 @@ export const DeeplinkedBuilder = (_args, { globals: { theme, locale } }) => {
                     title={'3D Scene Page'}
                     theme={theme}
                     locale={locale}
-                    adapter={new MockAdapter({ mockData: mockConfig })}
+                    adapter={
+                        new MockAdapter({
+                            mockData: {
+                                schemaConfig: mockConfig as I3DScenesConfig
+                            }
+                        })
+                    }
                 />
             </DeeplinkContextProvider>
         </div>
@@ -170,7 +188,13 @@ const ThemeCustomizationContent: React.FC<{ theme; locale }> = ({
                     title={'3D Scene Page'}
                     theme={theme}
                     locale={locale}
-                    adapter={new MockAdapter({ mockData: mockConfig })}
+                    adapter={
+                        new MockAdapter({
+                            mockData: {
+                                schemaConfig: mockConfig as I3DScenesConfig
+                            }
+                        })
+                    }
                 />
             </Stack>
             <Stack horizontal tokens={{ childrenGap: 8 }}>
@@ -240,7 +264,13 @@ export const Mock3DScenePageSchemaErrors = (
                 title={'3D Scene Page'}
                 theme={theme}
                 locale={locale}
-                adapter={new MockAdapter({ mockData: invalidConfig })}
+                adapter={
+                    new MockAdapter({
+                        mockData: {
+                            schemaConfig: mockConfig as I3DScenesConfig
+                        }
+                    })
+                }
             />
         </div>
     );


### PR DESCRIPTION
### Summary of changes 🔍 
Strictly typed the mockData with subfields for sceneConfig, timeSeriesDataList, models and twins. So, now, consumer can set only the corresponding field when initializing a new instance of the MockAdapter and the internal class variables are going to be updated accordingly.

![image](https://user-images.githubusercontent.com/45217314/221277808-08eb1dba-7831-49ba-b416-fa28dfb35757.png)
![image](https://user-images.githubusercontent.com/45217314/221278040-62ce7b70-0139-4426-9d08-3b32b056e7ba.png)


### Testing 🧪
You can test it all the stories changed in this PR.

### Checklist ✔️
- [ ] Linked associated issue (if present)
- [x] Added relevant labels
- [x] Requested developer reviews
- [ ] Request UI review from design / PM
- [x] Verify all code checks are passing