### PR TITLE
OAT: Give maps custom icon and remove menu

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -32,7 +32,7 @@
         "@typescript-eslint/no-var-requires": 0,
         "@typescript-eslint/no-explicit-any": 0,
         "@typescript-eslint/no-unused-vars": [
-            "error",
+            "warn",
             {
                 "argsIgnorePattern": "^_"
             }

--- a/src/Components/OATPropertyEditor/Internal/PropertyList/Internal/PropertyListItem/Internal/PropertyIcon/PropertyIcon.tsx
+++ b/src/Components/OATPropertyEditor/Internal/PropertyList/Internal/PropertyListItem/Internal/PropertyIcon/PropertyIcon.tsx
@@ -18,7 +18,7 @@ const getClassNames = classNamesFunction<
 >();
 
 const PropertyIcon: React.FC<IPropertyIconProps> = (props) => {
-    const { schema, styles } = props;
+    const { overrideIcon, schema, styles } = props;
 
     // contexts
 
@@ -38,6 +38,13 @@ const PropertyIcon: React.FC<IPropertyIconProps> = (props) => {
 
     // data
     const { iconSource, iconTitle, iconType } = useMemo(() => {
+        if (overrideIcon) {
+            return {
+                iconSource: overrideIcon.name,
+                iconTitle: overrideIcon.title,
+                iconType: 'Fluent'
+            };
+        }
         const iconData = PROPERTY_ICON_DATA.get(getSchemaType(schema));
         return {
             iconSource:
@@ -47,7 +54,7 @@ const PropertyIcon: React.FC<IPropertyIconProps> = (props) => {
             iconTitle: iconData?.title ? t(iconData.title) : '',
             iconType: iconData?.source
         };
-    }, [schema, t]);
+    }, [overrideIcon, schema, t]);
 
     return (
         <div className={classNames.root}>

--- a/src/Components/OATPropertyEditor/Internal/PropertyList/Internal/PropertyListItem/Internal/PropertyIcon/PropertyIcon.types.ts
+++ b/src/Components/OATPropertyEditor/Internal/PropertyList/Internal/PropertyListItem/Internal/PropertyIcon/PropertyIcon.types.ts
@@ -4,6 +4,7 @@ import { IExtendedTheme } from '../../../../../../../../Theming/Theme.types';
 
 export interface IPropertyIconProps {
     schema: DTDLSchema;
+    overrideIcon?: { name: string; title: string };
     /**
      * Call to provide customized styling that will layer on top of the variant rules.
      */

--- a/src/Components/OATPropertyEditor/Internal/PropertyList/Internal/PropertyListItem/Internal/PropertyListItemChildHost/Internal/PropertyListItemArrayChild/PropertyListItemArrayChild.tsx
+++ b/src/Components/OATPropertyEditor/Internal/PropertyList/Internal/PropertyListItem/Internal/PropertyListItemChildHost/Internal/PropertyListItemArrayChild/PropertyListItemArrayChild.tsx
@@ -55,7 +55,7 @@ const PropertyListItemArrayChild: React.FC<IPropertyListItemArrayChildProps> = (
                     ),
                     schema: item
                 }}
-                disableInput={true}
+                optionDisableInput={true}
                 onCopy={undefined}
                 onReorderItem={undefined}
                 onUpdateName={undefined}

--- a/src/Components/OATPropertyEditor/Internal/PropertyList/Internal/PropertyListItem/Internal/PropertyListItemChildHost/Internal/PropertyListItemMapChild/PropertyListItemMapChild.tsx
+++ b/src/Components/OATPropertyEditor/Internal/PropertyList/Internal/PropertyListItem/Internal/PropertyListItemChildHost/Internal/PropertyListItemMapChild/PropertyListItemMapChild.tsx
@@ -9,11 +9,17 @@ import { classNamesFunction, styled } from '@fluentui/react';
 import { useExtendedTheme } from '../../../../../../../../../../Models/Hooks/useExtendedTheme';
 import PropertyListItem from '../../../../PropertyListItem';
 import { deepCopy } from '../../../../../../../../../../Models/Services/Utils';
+import { useTranslation } from 'react-i18next';
+import PropertyIcon from '../../../PropertyIcon/PropertyIcon';
 
 const getClassNames = classNamesFunction<
     IPropertyListItemMapChildStyleProps,
     IPropertyListItemMapChildStyles
 >();
+
+const LOC_KEYS = {
+    mapKeyIconTitle: 'OAT.PropertyEditor.PropertyList.mapKeyName'
+};
 
 const PropertyListItemMapChild: React.FC<IPropertyListItemMapChildProps> = (
     props
@@ -33,6 +39,7 @@ const PropertyListItemMapChild: React.FC<IPropertyListItemMapChildProps> = (
     // state
 
     // hooks
+    const { t } = useTranslation();
 
     // callbacks
 
@@ -60,6 +67,16 @@ const PropertyListItemMapChild: React.FC<IPropertyListItemMapChildProps> = (
                     onUpdateKey(keyCopy);
                 }}
                 onUpdateSchema={undefined} // not allowed to change, always string
+                optionHideMenu={true}
+                optionRenderCustomMenuIcon={() => (
+                    <PropertyIcon
+                        schema={undefined}
+                        overrideIcon={{
+                            name: 'Permissions',
+                            title: t(LOC_KEYS.mapKeyIconTitle)
+                        }}
+                    />
+                )}
                 parentModelContext={parentModelContext}
             />
             <PropertyListItem

--- a/src/Components/OATPropertyEditor/Internal/PropertyList/Internal/PropertyListItem/PropertyListItem.stories.tsx
+++ b/src/Components/OATPropertyEditor/Internal/PropertyList/Internal/PropertyListItem/PropertyListItem.stories.tsx
@@ -46,7 +46,7 @@ const DEFAULT_ARGS: Partial<IPropertyListItemProps> = {
 };
 const Template: PropertyListItemStory = (args) => {
     return (
-        <div style={{ marginLeft: 32 }}>
+        <div style={{ ma rginLeft: 32 }}>
             <OatPageContextProvider
                 disableLocalStorage={true}
                 initialState={{

--- a/src/Components/OATPropertyEditor/Internal/PropertyList/Internal/PropertyListItem/PropertyListItem.stories.tsx
+++ b/src/Components/OATPropertyEditor/Internal/PropertyList/Internal/PropertyListItem/PropertyListItem.stories.tsx
@@ -19,6 +19,7 @@ import {
     DTDL_CONTEXT_VERSION_3
 } from '../../../../../../Models/Classes/DTDL';
 import { userEvent, within } from '@storybook/testing-library';
+import PropertyIcon from './Internal/PropertyIcon/PropertyIcon';
 
 const wrapperStyle = {
     width: '400px',
@@ -58,12 +59,12 @@ const Template: PropertyListItemStory = (args) => {
     );
 };
 
-export const OpenMenu = Template.bind({}) as PropertyListItemStory;
-OpenMenu.args = {
+export const MenuOpen = Template.bind({}) as PropertyListItemStory;
+MenuOpen.args = {
     ...DEFAULT_ARGS,
     item: getMockProperty({ type: 'boolean' })
 } as IPropertyListItemProps;
-OpenMenu.play = async ({ canvasElement }) => {
+MenuOpen.play = async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const tab = await canvas.findByTestId(
         'context-menu-property-list-0-moreMenu'
@@ -71,6 +72,30 @@ OpenMenu.play = async ({ canvasElement }) => {
     userEvent.click(tab);
     await sleep(10);
 };
+
+export const MenuHidden = Template.bind({}) as PropertyListItemStory;
+MenuHidden.args = {
+    ...DEFAULT_ARGS,
+    item: getMockProperty({ type: 'boolean' }),
+    optionHideMenu: true
+} as IPropertyListItemProps;
+
+export const CustomIconName = Template.bind({}) as PropertyListItemStory;
+CustomIconName.args = {
+    ...DEFAULT_ARGS,
+    item: getMockProperty({ type: 'boolean' }),
+    optionRenderCustomMenuIcon: () => {
+        return (
+            <PropertyIcon
+                schema={undefined}
+                overrideIcon={{
+                    name: 'Permissions',
+                    title: 'key'
+                }}
+            />
+        );
+    }
+} as IPropertyListItemProps;
 
 export const PrimitiveBoolean = Template.bind({}) as PropertyListItemStory;
 PrimitiveBoolean.args = {

--- a/src/Components/OATPropertyEditor/Internal/PropertyList/Internal/PropertyListItem/PropertyListItem.stories.tsx
+++ b/src/Components/OATPropertyEditor/Internal/PropertyList/Internal/PropertyListItem/PropertyListItem.stories.tsx
@@ -46,7 +46,7 @@ const DEFAULT_ARGS: Partial<IPropertyListItemProps> = {
 };
 const Template: PropertyListItemStory = (args) => {
     return (
-        <div style={{ ma rginLeft: 32 }}>
+        <div style={{ marginLeft: 32 }}>
             <OatPageContextProvider
                 disableLocalStorage={true}
                 initialState={{

--- a/src/Components/OATPropertyEditor/Internal/PropertyList/Internal/PropertyListItem/PropertyListItem.tsx
+++ b/src/Components/OATPropertyEditor/Internal/PropertyList/Internal/PropertyListItem/PropertyListItem.tsx
@@ -51,7 +51,7 @@ const getClassNames = classNamesFunction<
 const PropertyListItem: React.FC<IPropertyListItemProps> = (props) => {
     const {
         parentModelContext,
-        disableInput,
+        optionDisableInput,
         indexKey,
         item,
         isFirstItem,
@@ -62,6 +62,8 @@ const PropertyListItem: React.FC<IPropertyListItemProps> = (props) => {
         onUpdateSchema,
         onRemove,
         onReorderItem,
+        optionHideMenu,
+        optionRenderCustomMenuIcon,
         styles
     } = props;
 
@@ -344,18 +346,22 @@ const PropertyListItem: React.FC<IPropertyListItemProps> = (props) => {
                 )}
                 <Stack.Item grow>
                     <TextField
-                        disabled={disableInput}
+                        disabled={optionDisableInput}
                         readOnly={!onSaveName}
                         onRenderInput={(props, defaultRenderer) => {
                             return (
                                 <>
-                                    <PropertyIcon
-                                        schema={item.schema}
-                                        styles={
-                                            classNames.subComponentStyles
-                                                .inputIcon
-                                        }
-                                    />
+                                    {optionRenderCustomMenuIcon ? (
+                                        optionRenderCustomMenuIcon(item)
+                                    ) : (
+                                        <PropertyIcon
+                                            schema={item.schema}
+                                            styles={
+                                                classNames.subComponentStyles
+                                                    .inputIcon
+                                            }
+                                        />
+                                    )}
                                     {defaultRenderer(props)}
                                 </>
                             );
@@ -381,14 +387,18 @@ const PropertyListItem: React.FC<IPropertyListItemProps> = (props) => {
                 {!supportsAddingChildren && (
                     <span className={classNames.buttonSpacer} />
                 )}
-                <OverflowMenu
-                    index={indexKey}
-                    isFocusable={true}
-                    menuKey={'property-list'}
-                    menuProps={{
-                        items: overflowMenuItems
-                    }}
-                />
+                {optionHideMenu ? (
+                    <span className={classNames.buttonSpacer} />
+                ) : (
+                    <OverflowMenu
+                        index={indexKey}
+                        isFocusable={true}
+                        menuKey={'property-list'}
+                        menuProps={{
+                            items: overflowMenuItems
+                        }}
+                    />
+                )}
             </Stack>
             {isExpanded && hasComplexSchemaType(item) && (
                 <PropertyListItemChildHost

--- a/src/Components/OATPropertyEditor/Internal/PropertyList/Internal/PropertyListItem/PropertyListItem.types.ts
+++ b/src/Components/OATPropertyEditor/Internal/PropertyList/Internal/PropertyListItem/PropertyListItem.types.ts
@@ -17,6 +17,10 @@ export type IOnUpdateNameCallbackArgs = {
 };
 export type IOnUpdateNameCallback = (args: IOnUpdateNameCallbackArgs) => void;
 
+interface IItem {
+    name: string;
+    schema: DTDLSchema;
+}
 export interface IPropertyListItemProps {
     /** the DTDL context of the model or source model (if relationship) */
     parentModelContext: DtdlContext;
@@ -27,17 +31,21 @@ export interface IPropertyListItemProps {
     /** Index of parent in the list. Key used for test automation for the row */
     indexKey: string;
     /** the item itself */
-    item: { name: string; schema: DTDLSchema };
+    item: IItem;
     /** Level in the nesting tree. index of 1 is not nested */
     level?: number;
-    /** disables the input field */
-    disableInput?: boolean;
     /** callback to store an updated version of the schema */
     onCopy: () => void | undefined;
     onUpdateSchema: (schema: DTDLSchema) => void | undefined;
     onReorderItem: (direction: 'Up' | 'Down') => void | undefined;
     onUpdateName: IOnUpdateNameCallback;
     onRemove: () => void | undefined;
+    /** disables the input field */
+    optionDisableInput?: boolean;
+    /** hides the overflow menu */
+    optionHideMenu?: boolean;
+    /** renders a custom icon for the list item instead of based on schema */
+    optionRenderCustomMenuIcon?: (item: IItem) => React.ReactNode;
     /**
      * Call to provide customized styling that will layer on top of the variant rules.
      */

--- a/src/Components/OATPropertyEditor/Internal/PropertyList/PropertyList.tsx
+++ b/src/Components/OATPropertyEditor/Internal/PropertyList/PropertyList.tsx
@@ -355,7 +355,6 @@ const PropertyList: React.FC<IPropertyListProps> = (props) => {
                     selectedItemCopy,
                     property
                 );
-                // TODO: add to Undo stack
                 updateReference(selectedItem);
             }
         };

--- a/src/Models/Constants/Constants.ts
+++ b/src/Models/Constants/Constants.ts
@@ -354,7 +354,7 @@ export const OAT_DISPLAY_NAME_LENGTH_LIMIT = 64;
 export const OAT_NAME_LENGTH_LIMIT = 64;
 export const OAT_ID_LENGTH_LIMIT = 2048;
 /** max limit for the total count of references in the ontology due to perf degredation above this */
-export const OAT_ONTOLOGY_MAX_REFERENCE_LIMIT = 200;
+export const OAT_ONTOLOGY_MAX_REFERENCE_LIMIT = 250;
 
 export const SelectedCameraInteractionKey = 'cb-camera-interaction';
 export const ViewerThemeStorageKey = 'cb-viewer-theme';

--- a/src/Models/Constants/Types.ts
+++ b/src/Models/Constants/Types.ts
@@ -217,7 +217,7 @@ export type OatIconNames =
     | 'DocumentManagement'
     | 'Down'
     | 'GroupList'
-    | 'Permission'
+    | 'Permissions'
     | 'TextField'
     | 'ToggleRight'
     | 'Up'

--- a/src/Models/Constants/Types.ts
+++ b/src/Models/Constants/Types.ts
@@ -217,6 +217,7 @@ export type OatIconNames =
     | 'DocumentManagement'
     | 'Down'
     | 'GroupList'
+    | 'Permission'
     | 'TextField'
     | 'ToggleRight'
     | 'Up'

--- a/src/Resources/Locales/cs.json
+++ b/src/Resources/Locales/cs.json
@@ -1294,6 +1294,9 @@
       "Version3PreviewLabel": {
         "badgeText": "Náhled",
         "badgeCalloutText": "Tento model používá DTDL verze 3. Kliknutím se dozvíte více"
+      },
+      "PropertyList": {
+        "mapKeyName": "Název klíče mapy"
       }
     },
     "PropertyTypes": {
@@ -1461,8 +1464,6 @@
     "linestring": "Řetězec řádků",
     "long": "dlouhý",
     "map": "mapa",
-    "mapKeyName": "Název klíče mapování",
-    "mapValueName": "Název hodnoty mapy",
     "maxMultiplicityLabel": "Maximální násobnost",
     "minMultiplicityLabel": "Minimální násobnost",
     "minMultiplicityMessage": "DTDL V2 podporuje pouze minimální násobnost 0",

--- a/src/Resources/Locales/de.json
+++ b/src/Resources/Locales/de.json
@@ -1294,6 +1294,9 @@
       "Version3PreviewLabel": {
         "badgeText": "Vorschau",
         "badgeCalloutText": "Dieses Modell verwendet DTDL Version 3. Klicken Sie hier, um mehr zu erfahren"
+      },
+      "PropertyList": {
+        "mapKeyName": "Name des Kartenschlüssels"
       }
     },
     "PropertyTypes": {
@@ -1461,8 +1464,6 @@
     "linestring": "Zeilenzeichenfolge",
     "long": "lang",
     "map": "Landkarte",
-    "mapKeyName": "Name des Kartenschlüssels",
-    "mapValueName": "Name des Kartenwerts",
     "maxMultiplicityLabel": "Maximale Vielfalt",
     "minMultiplicityLabel": "Minimale Vielfalt",
     "minMultiplicityMessage": "DTDL V2 unterstützt nur eine minimale Multiplizität von 0",

--- a/src/Resources/Locales/en.json
+++ b/src/Resources/Locales/en.json
@@ -1030,6 +1030,9 @@
             "unsupportedPropertyType": "This property type is not available for the current context version of the associated model"
         },
         "PropertyEditor": {
+            "PropertyList": {
+                "mapKeyName": "Map key name"
+            },
             "Version3PreviewLabel": {
                 "badgeText": "Preview",
                 "badgeCalloutText": "This model uses DTDL version 3. Click to learn more"
@@ -1166,8 +1169,6 @@
         "linestring": "linestring",
         "long": "long",
         "map": "map",
-        "mapKeyName": "Map Key Name",
-        "mapValueName": "Map Value Name",
         "maxMultiplicityLabel": "Maximum multiplicity",
         "minMultiplicityLabel": "Minimum multiplicity",
         "minMultiplicityMessage": "DTDL V2 only supports a minimum multiplicity of 0",

--- a/src/Resources/Locales/es.json
+++ b/src/Resources/Locales/es.json
@@ -1294,6 +1294,9 @@
       "Version3PreviewLabel": {
         "badgeText": "Vista previa",
         "badgeCalloutText": "Este modelo utiliza DTDL versión 3. Haga clic para obtener más información"
+      },
+      "PropertyList": {
+        "mapKeyName": "Nombre de clave de mapa"
       }
     },
     "PropertyTypes": {
@@ -1461,8 +1464,6 @@
     "linestring": "cadena de línea",
     "long": "largo",
     "map": "mapa",
-    "mapKeyName": "Nombre de clave de mapa",
-    "mapValueName": "Nombre del valor del mapa",
     "maxMultiplicityLabel": "Multiplicidad máxima",
     "minMultiplicityLabel": "Multiplicidad mínima",
     "minMultiplicityMessage": "DTDL V2 solo admite una multiplicidad mínima de 0",

--- a/src/Resources/Locales/fr.json
+++ b/src/Resources/Locales/fr.json
@@ -1294,6 +1294,9 @@
       "Version3PreviewLabel": {
         "badgeText": "Aperçu",
         "badgeCalloutText": "Ce modèle utilise DTDL version 3. Cliquez pour en savoir plus"
+      },
+      "PropertyList": {
+        "mapKeyName": "Nom de la clé de mappage"
       }
     },
     "PropertyTypes": {
@@ -1461,8 +1464,6 @@
     "linestring": "chaîne de ligne",
     "long": "long",
     "map": "carte",
-    "mapKeyName": "Nom de la clé de mappage",
-    "mapValueName": "Nom de la valeur de la carte",
     "maxMultiplicityLabel": "Multiplicité maximale",
     "minMultiplicityLabel": "Multiplicité minimale",
     "minMultiplicityMessage": "DTDL V2 ne prend en charge qu’une multiplicité minimale de 0",

--- a/src/Resources/Locales/hu.json
+++ b/src/Resources/Locales/hu.json
@@ -1294,6 +1294,9 @@
       "Version3PreviewLabel": {
         "badgeText": "Előnézet",
         "badgeCalloutText": "Ez a modell a DTDL 3-as verzióját használja. Kattintson ide, ha többet szeretne megtudni"
+      },
+      "PropertyList": {
+        "mapKeyName": "Leképezési kulcs neve"
       }
     },
     "PropertyTypes": {
@@ -1461,8 +1464,6 @@
     "linestring": "vonallánc",
     "long": "hosszú",
     "map": "térkép",
-    "mapKeyName": "Térkép kulcsának neve",
-    "mapValueName": "Térképérték neve",
     "maxMultiplicityLabel": "Maximális sokaság",
     "minMultiplicityLabel": "Minimális szorzás",
     "minMultiplicityMessage": "A DTDL V2 csak a 0 minimális szorzást támogatja",

--- a/src/Resources/Locales/it.json
+++ b/src/Resources/Locales/it.json
@@ -1294,6 +1294,9 @@
       "Version3PreviewLabel": {
         "badgeText": "Anteprima",
         "badgeCalloutText": "Questo modello utilizza DTDL versione 3. Clicca per saperne di più"
+      },
+      "PropertyList": {
+        "mapKeyName": "Nome chiave mappa"
       }
     },
     "PropertyTypes": {
@@ -1461,8 +1464,6 @@
     "linestring": "linestring",
     "long": "lungo",
     "map": "mappa",
-    "mapKeyName": "Nome chiave mappa",
-    "mapValueName": "Nome valore mappa",
     "maxMultiplicityLabel": "Massima molteplicità",
     "minMultiplicityLabel": "Molteplicità minima",
     "minMultiplicityMessage": "DTDL V2 supporta solo una molteplicità minima di 0",

--- a/src/Resources/Locales/ja.json
+++ b/src/Resources/Locales/ja.json
@@ -1294,6 +1294,9 @@
       "Version3PreviewLabel": {
         "badgeText": "プレビュー",
         "badgeCalloutText": "このモデルは DTDL バージョン 3 を使用します。クリックして詳細をご覧ください"
+      },
+      "PropertyList": {
+        "mapKeyName": "マップキー名"
       }
     },
     "PropertyTypes": {
@@ -1461,8 +1464,6 @@
     "linestring": "ラインストリング",
     "long": "長い",
     "map": "地図",
-    "mapKeyName": "マップ キー名",
-    "mapValueName": "マップ値の名前",
     "maxMultiplicityLabel": "最大多重度",
     "minMultiplicityLabel": "最小多重度",
     "minMultiplicityMessage": "DTDL V2 では、最小多重度 0 のみがサポートされます。",

--- a/src/Resources/Locales/ko.json
+++ b/src/Resources/Locales/ko.json
@@ -1294,6 +1294,9 @@
       "Version3PreviewLabel": {
         "badgeText": "미리 보기",
         "badgeCalloutText": "이 모델은 DTDL 버전 3을 사용합니다. 클릭하여 자세히 알아보기"
+      },
+      "PropertyList": {
+        "mapKeyName": "맵 키 이름"
       }
     },
     "PropertyTypes": {
@@ -1461,8 +1464,6 @@
     "linestring": "라인 문자열",
     "long": "오래",
     "map": "지도",
-    "mapKeyName": "맵 키 이름",
-    "mapValueName": "맵 값 이름",
     "maxMultiplicityLabel": "최대 다중성",
     "minMultiplicityLabel": "최소 다중성",
     "minMultiplicityMessage": "DTDL V2는 최소 복합성 0만 지원합니다.",

--- a/src/Resources/Locales/nl.json
+++ b/src/Resources/Locales/nl.json
@@ -1294,6 +1294,9 @@
       "Version3PreviewLabel": {
         "badgeText": "Voorbeeld",
         "badgeCalloutText": "Dit model maakt gebruik van DTDL versie 3. Klik voor meer informatie"
+      },
+      "PropertyList": {
+        "mapKeyName": "Naam van de kaartsleutel"
       }
     },
     "PropertyTypes": {
@@ -1461,8 +1464,6 @@
     "linestring": "lijnenring",
     "long": "lang",
     "map": "kaart",
-    "mapKeyName": "Naam van kaartsleutel",
-    "mapValueName": "Naam van kaartwaarde",
     "maxMultiplicityLabel": "Maximale multipliciteit",
     "minMultiplicityLabel": "Minimale veelheid",
     "minMultiplicityMessage": "DTDL V2 ondersteunt alleen een minimale multipliciteit van 0",

--- a/src/Resources/Locales/pl.json
+++ b/src/Resources/Locales/pl.json
@@ -1294,6 +1294,9 @@
       "Version3PreviewLabel": {
         "badgeText": "Prapremiera",
         "badgeCalloutText": "Ten model korzysta z DTDL w wersji 3. Kliknij, aby dowiedzieć się więcej"
+      },
+      "PropertyList": {
+        "mapKeyName": "Nazwa klucza mapy"
       }
     },
     "PropertyTypes": {
@@ -1461,8 +1464,6 @@
     "linestring": "Ciąg liniowy",
     "long": "długi",
     "map": "mapa",
-    "mapKeyName": "Nazwa klucza mapy",
-    "mapValueName": "Nazwa wartości mapy",
     "maxMultiplicityLabel": "Maksymalna wielokrotność",
     "minMultiplicityLabel": "Minimalna wielokrotność",
     "minMultiplicityMessage": "DTDL V2 obsługuje tylko minimalną wielokrotność 0",

--- a/src/Resources/Locales/pt-pt.json
+++ b/src/Resources/Locales/pt-pt.json
@@ -1294,6 +1294,9 @@
       "Version3PreviewLabel": {
         "badgeText": "Previsualizar",
         "badgeCalloutText": "Este modelo utiliza a versão DTDL 3. Clique para saber mais"
+      },
+      "PropertyList": {
+        "mapKeyName": "Nome da chave do mapa"
       }
     },
     "PropertyTypes": {
@@ -1461,8 +1464,6 @@
     "linestring": "linestring",
     "long": "Longo",
     "map": "mapa",
-    "mapKeyName": "Nome da chave do mapa",
-    "mapValueName": "Nome do valor do mapa",
     "maxMultiplicityLabel": "Multiplicidade máxima",
     "minMultiplicityLabel": "Multiplicidade mínima",
     "minMultiplicityMessage": "DTDL V2 só suporta uma multiplicidade mínima de 0",

--- a/src/Resources/Locales/pt.json
+++ b/src/Resources/Locales/pt.json
@@ -1294,6 +1294,9 @@
       "Version3PreviewLabel": {
         "badgeText": "Visualizar",
         "badgeCalloutText": "Este modelo usa DTDL versão 3. Clique para saber mais"
+      },
+      "PropertyList": {
+        "mapKeyName": "Nome da chave do mapa"
       }
     },
     "PropertyTypes": {
@@ -1461,8 +1464,6 @@
     "linestring": "linestring",
     "long": "Longas",
     "map": "mapa",
-    "mapKeyName": "Nome da chave do mapa",
-    "mapValueName": "Nome do valor do mapa",
     "maxMultiplicityLabel": "Multiplicidade máxima",
     "minMultiplicityLabel": "Multiplicidade mínima",
     "minMultiplicityMessage": "DTDL V2 suporta apenas uma multiplicidade mínima de 0",

--- a/src/Resources/Locales/ru.json
+++ b/src/Resources/Locales/ru.json
@@ -1294,6 +1294,9 @@
       "Version3PreviewLabel": {
         "badgeText": "Предварительный просмотр",
         "badgeCalloutText": "Эта модель использует DTDL версии 3. Нажмите, чтобы узнать больше"
+      },
+      "PropertyList": {
+        "mapKeyName": "Имя ключа карты"
       }
     },
     "PropertyTypes": {
@@ -1461,8 +1464,6 @@
     "linestring": "линейная струна",
     "long": "длинный",
     "map": "карта",
-    "mapKeyName": "Имя ключа карты",
-    "mapValueName": "Имя значения карты",
     "maxMultiplicityLabel": "Максимальная кратность",
     "minMultiplicityLabel": "Минимальная кратность",
     "minMultiplicityMessage": "DTDL V2 поддерживает только минимальную кратность 0",

--- a/src/Resources/Locales/sv.json
+++ b/src/Resources/Locales/sv.json
@@ -1294,6 +1294,9 @@
       "Version3PreviewLabel": {
         "badgeText": "Förhandsvisning",
         "badgeCalloutText": "Den här modellen använder DTDL version 3. Klicka för att läsa mer"
+      },
+      "PropertyList": {
+        "mapKeyName": "Namn på kartnyckel"
       }
     },
     "PropertyTypes": {
@@ -1461,8 +1464,6 @@
     "linestring": "linjesträng",
     "long": "lång",
     "map": "karta",
-    "mapKeyName": "Namn på kartnyckel",
-    "mapValueName": "Namn på kartvärde",
     "maxMultiplicityLabel": "Maximal mångfald",
     "minMultiplicityLabel": "Minsta mångfald",
     "minMultiplicityMessage": "DTDL V2 stöder endast en minsta mångfald på 0",

--- a/src/Resources/Locales/tr.json
+++ b/src/Resources/Locales/tr.json
@@ -1294,6 +1294,9 @@
       "Version3PreviewLabel": {
         "badgeText": "Önizleme",
         "badgeCalloutText": "Bu model DTDL sürüm 3'ü kullanır. Daha fazla bilgi için tıklayın"
+      },
+      "PropertyList": {
+        "mapKeyName": "Eşleme anahtarı adı"
       }
     },
     "PropertyTypes": {
@@ -1461,8 +1464,6 @@
     "linestring": "linestring",
     "long": "uzun",
     "map": "harita",
-    "mapKeyName": "Harita Anahtarı Adı",
-    "mapValueName": "Harita Değeri Adı",
     "maxMultiplicityLabel": "Maksimum çokluk",
     "minMultiplicityLabel": "Minimum çokluk",
     "minMultiplicityMessage": "DTDL V2 yalnızca minimum 0 çokluğunu destekler",

--- a/src/Resources/Locales/zh-Hans.json
+++ b/src/Resources/Locales/zh-Hans.json
@@ -1294,6 +1294,9 @@
       "Version3PreviewLabel": {
         "badgeText": "预览",
         "badgeCalloutText": "此模型使用 DTDL 版本 3。点击了解更多"
+      },
+      "PropertyList": {
+        "mapKeyName": "映射键名称"
       }
     },
     "PropertyTypes": {
@@ -1461,8 +1464,6 @@
     "linestring": "线串",
     "long": "长",
     "map": "地图",
-    "mapKeyName": "映射键名称",
-    "mapValueName": "映射值名称",
     "maxMultiplicityLabel": "最大多重性",
     "minMultiplicityLabel": "最小多重性",
     "minMultiplicityMessage": "DTDL V2 仅支持最小多重性 0",

--- a/tools/templates/component/component.js
+++ b/tools/templates/component/component.js
@@ -8,6 +8,9 @@ module.exports = (componentName) => ({
     import { getStyles } from './${componentName}.styles';
     import { classNamesFunction, styled } from '@fluentui/react';
     import { useExtendedTheme } from '../../Models/Hooks/useExtendedTheme';
+
+    const debugLogging = false;
+    const logDebugConsole = getDebugLogger('${componentName}', debugLogging);
     
     const getClassNames = classNamesFunction<
         I${componentName}StyleProps,
@@ -32,6 +35,8 @@ module.exports = (componentName) => ({
             theme: useExtendedTheme()
         });
     
+        logDebugConsole('debug', 'Render');
+
         return <div className={classNames.root}>Hello ${componentName}!</div>;
     };
     


### PR DESCRIPTION
### Summary of changes 🔍 
Fixing 2 requests from Private Preview to clarify the Maps property experience
1. Give the Map Key field a different icon since it's always a string and to differentiate it from other property items.
2. Remove the overflow menu for the Map Key field since it can't do any of those things.

Also bumping the reference limit up from 200 to 250 as a point of feedback to support some out of the box ontologies.

Before
![image](https://user-images.githubusercontent.com/57726991/222244606-582f51d3-3fb7-45e2-bdf4-23ca80745c12.png)

After
![image](https://user-images.githubusercontent.com/57726991/222244856-28ed93ff-42ac-41fc-bb36-0e37c6b5c17d.png)

### Testing 🧪
Check out this story to see the new experience `components-oat-oatpropertyeditor-propertylist--complex-model`
