### PR TITLE
[Data History Explorer]: Remove feature flags

### DIFF
--- a/src/Adapters/ADTAdapter.ts
+++ b/src/Adapters/ADTAdapter.ts
@@ -802,7 +802,7 @@ export default class ADTAdapter implements IADTAdapter {
                 return axios({
                     method: 'get',
                     url: this.generateUrl(
-                        `${this.adtProxyServerPath}/models/${encodeURIComponent(
+                        `/models/${encodeURIComponent(
                             targetModelId
                         )}?includeModelDefinition=True`
                     ),

--- a/src/Components/PropertyInspector/PropertyTree/PropertyTree.tsx
+++ b/src/Components/PropertyInspector/PropertyTree/PropertyTree.tsx
@@ -2,7 +2,6 @@ import React, { createContext } from 'react';
 import { TreeProps, PropertyTreeProps } from './PropertyTree.types';
 import './PropertyTree.scss';
 import TreeNode from './TreeComponents/TreeNode';
-import { LOCAL_STORAGE_KEYS } from '../../../Models/Constants/Constants';
 import DataHistoryExplorerModalControl from '../../DataHistoryExplorerModal/DataHistoryExplorerModalControl/DataHistoryExplorerModalControl';
 
 export const PropertyTreeContext = createContext<

--- a/src/Components/PropertyInspector/PropertyTree/PropertyTree.tsx
+++ b/src/Components/PropertyInspector/PropertyTree/PropertyTree.tsx
@@ -9,11 +9,6 @@ export const PropertyTreeContext = createContext<
     Omit<PropertyTreeProps, 'data'>
 >(null);
 
-const isDataHistoryFeatureEnabled =
-    localStorage.getItem(
-        LOCAL_STORAGE_KEYS.FeatureFlags.DataHistoryExplorer.showExplorer
-    ) === 'true';
-
 const PropertyTree: React.FC<PropertyTreeProps> = ({
     data,
     isTreeEdited,
@@ -44,7 +39,7 @@ const PropertyTree: React.FC<PropertyTreeProps> = ({
             }}
         >
             <div className="cb-property-tree-container">
-                {isDataHistoryFeatureEnabled && !!dataHistoryControlProps && (
+                {!!dataHistoryControlProps && (
                     <DataHistoryExplorerModalControl
                         styles={{
                             root: { position: 'absolute', right: 0, top: -4 } // will keep the styling here hardcoded until we refactor the styling change for this component

--- a/src/Models/Constants/Constants.ts
+++ b/src/Models/Constants/Constants.ts
@@ -90,9 +90,6 @@ export const LOCAL_STORAGE_KEYS = {
         Telemetry: {
             debugLogging: 'cardboard.debug.telemetryLogging' // enables debug logging for all emitted telemetry events
         },
-        DataHistoryExplorer: {
-            showExplorer: 'cardboard.feature.dataHistoryExplorer' // enables data history explorer feature if supported
-        },
         Proxy: {
             forceCORS: 'cardboard.feature.forceCORS' // force CORS to run instead of proxy
         },


### PR DESCRIPTION
### Summary of changes 🔍 
- Removed local storage feature flag wall
- Fixed one bug about duplicate proxy url to get extended models
![image](https://user-images.githubusercontent.com/45217314/222517379-623d1c5b-5759-4320-8e92-c4e648532346.png)



### Testing 🧪
 - After removing the feature flag from your local storage (`cardboard.feature.dataHistoryExplorer`), you can check it in Property Inspector in ADT3DScenePage stories (View mode) and see that the feature is still there.

### Checklist ✔️
- [ ] Linked associated issue (if present)
- [x] Added relevant labels
- [x] Requested developer reviews
- [ ] Request UI review from design / PM
- [x] Verify all code checks are passing