### PR TITLE
OAT telemetry instrumentation

### DIFF
--- a/src/Components/OATGraphViewer/OATGraphViewer.tsx
+++ b/src/Components/OATGraphViewer/OATGraphViewer.tsx
@@ -95,6 +95,13 @@ import {
     isDTDLComponentReference,
     isDTDLRelationshipReference
 } from '../../Models/Services/DtdlUtils';
+import useTelemetry from '../../Models/Hooks/useTelemetry';
+import {
+    AppRegion,
+    ComponentName,
+    TelemetryEvents
+} from '../../Models/Constants/OatTelemetryConstants';
+import { TelemetryTrigger } from '../../Models/Constants/TelemetryConstants';
 
 const debugLogging = false;
 const logDebugConsole = getDebugLogger('OATGraphViewer', debugLogging);
@@ -121,6 +128,7 @@ const OATGraphViewerContent: React.FC<IOATGraphViewerProps> = (props) => {
     // hooks
     const { t } = useTranslation();
     const theme = useExtendedTheme();
+    const { sendEventTelemetry } = useTelemetry();
 
     // contexts
     const { execute } = useContext(CommandHistoryContext);
@@ -538,7 +546,14 @@ const OATGraphViewerContent: React.FC<IOATGraphViewerProps> = (props) => {
     /** Forces the auto layout of the current elements on the graph */
     const forceGraphLayout = useCallback(() => {
         applyLayoutToElements(elements);
-    }, [applyLayoutToElements, elements]);
+        // Log auto layout telemetry
+        sendEventTelemetry({
+            name: TelemetryEvents.autoLayout,
+            triggerType: TelemetryTrigger.UserAction,
+            appRegion: AppRegion.OAT,
+            componentName: ComponentName.OAT
+        });
+    }, [applyLayoutToElements, elements, sendEventTelemetry]);
 
     const clearSelectedModel = () => {
         logDebugConsole('info', 'Clearing selected model');

--- a/src/Components/OATHeader/OATHeader.tsx
+++ b/src/Components/OATHeader/OATHeader.tsx
@@ -72,10 +72,11 @@ export const EXPORT_LOC_KEYS: IExportLocalizationKeys = {
     ExceptionMessage: 'OAT.Common.unhandledExceptionMessage'
 };
 
+const TELEMETRY_COMPONENT_NAME = ComponentName.OAT;
+const TELEMETRY_APP_REGION = AppRegion.OAT;
+
 const OATHeader: React.FC<IOATHeaderProps> = (props) => {
     const { styles } = props;
-    const componentName = ComponentName.OAT;
-    const appRegion = AppRegion.OAT;
 
     // hooks
     const { t } = useTranslation();
@@ -133,11 +134,15 @@ const OATHeader: React.FC<IOATHeaderProps> = (props) => {
                 ];
                 // Log limit exceeded
                 sendEventTelemetry({
-                    name: TelemetryEvents.importFailLimit,
+                    name: TelemetryEvents.import,
                     triggerType: TelemetryTrigger.UserAction,
-                    appRegion: appRegion,
-                    componentName: componentName,
-                    customProperties: getOatMetricsForModels(result.data)
+                    appRegion: TELEMETRY_APP_REGION,
+                    componentName: TELEMETRY_COMPONENT_NAME,
+                    customProperties: {
+                        success: false,
+                        reason: 'Limit exceeded',
+                        ...getOatMetricsForModels(result.data)
+                    }
                 });
             }
             if (result.status === 'Success') {
@@ -154,11 +159,14 @@ const OATHeader: React.FC<IOATHeaderProps> = (props) => {
                 });
                 // Log success
                 sendEventTelemetry({
-                    name: TelemetryEvents.importSuccess,
+                    name: TelemetryEvents.import,
                     triggerType: TelemetryTrigger.UserAction,
-                    appRegion: appRegion,
-                    componentName: componentName,
-                    customProperties: getOatMetricsForModels(result.data)
+                    appRegion: TELEMETRY_APP_REGION,
+                    componentName: TELEMETRY_COMPONENT_NAME,
+                    customProperties: {
+                        success: true,
+                        ...getOatMetricsForModels(result.data)
+                    }
                 });
             } else if (result.status === 'Failed') {
                 // show error
@@ -184,13 +192,13 @@ const OATHeader: React.FC<IOATHeaderProps> = (props) => {
                 });
                 // Log import error
                 sendEventTelemetry({
-                    name: TelemetryEvents.importFailException,
+                    name: TelemetryEvents.import,
                     triggerType: TelemetryTrigger.UserAction,
-                    appRegion: appRegion,
-                    componentName: componentName,
+                    appRegion: TELEMETRY_APP_REGION,
+                    componentName: TELEMETRY_COMPONENT_NAME,
                     customProperties: {
-                        errorTitle: error.title,
-                        errorMessage: error.message
+                        success: false,
+                        reason: 'Unhandled exception'
                     }
                 });
             }
@@ -200,8 +208,6 @@ const OATHeader: React.FC<IOATHeaderProps> = (props) => {
             logDebugConsole('debug', '[IMPORT] [END] Files upload.', result);
         },
         [
-            appRegion,
-            componentName,
             oatPageDispatch,
             oatPageState.currentOntologyModels,
             sendEventTelemetry,
@@ -239,13 +245,16 @@ const OATHeader: React.FC<IOATHeaderProps> = (props) => {
                 downloadFile(content, fileName);
                 // Log success
                 sendEventTelemetry({
-                    name: TelemetryEvents.exportSuccess,
+                    name: TelemetryEvents.export,
                     triggerType: TelemetryTrigger.UserAction,
-                    appRegion: appRegion,
-                    componentName: componentName,
-                    customProperties: getOatMetricsForModels(
-                        oatPageState.currentOntologyModels
-                    )
+                    appRegion: TELEMETRY_APP_REGION,
+                    componentName: TELEMETRY_COMPONENT_NAME,
+                    customProperties: {
+                        success: true,
+                        ...getOatMetricsForModels(
+                            oatPageState.currentOntologyModels
+                        )
+                    }
                 });
             });
         } else {
@@ -264,15 +273,15 @@ const OATHeader: React.FC<IOATHeaderProps> = (props) => {
                     message: error.message
                 }
             });
-            // Log success
+            // Log error
             sendEventTelemetry({
-                name: TelemetryEvents.exportFail,
+                name: TelemetryEvents.export,
                 triggerType: TelemetryTrigger.UserAction,
-                appRegion: appRegion,
-                componentName: componentName,
+                appRegion: TELEMETRY_APP_REGION,
+                componentName: TELEMETRY_COMPONENT_NAME,
                 customProperties: {
-                    errorTitle: error.title,
-                    errorMessage: error.message,
+                    success: false,
+                    reason: 'Unhandled exception',
                     ...getOatMetricsForModels(
                         oatPageState.currentOntologyModels
                     )
@@ -284,8 +293,6 @@ const OATHeader: React.FC<IOATHeaderProps> = (props) => {
         oatPageState.currentOntologyProjectName,
         t,
         sendEventTelemetry,
-        appRegion,
-        componentName,
         oatPageDispatch
     ]);
 

--- a/src/Components/OATHeader/OATHeader.tsx
+++ b/src/Components/OATHeader/OATHeader.tsx
@@ -38,6 +38,14 @@ import {
 } from '../../Models/Services/OatPublicUtils';
 import { getTotalReferenceCount } from '../../Models/Context/OatPageContext/OatPageContextUtils';
 import { OAT_ONTOLOGY_MAX_REFERENCE_LIMIT } from '../../Models/Constants/Constants';
+import useTelemetry from '../../Models/Hooks/useTelemetry';
+import {
+    AppRegion,
+    ComponentName,
+    TelemetryEvents
+} from '../../Models/Constants/OatTelemetryConstants';
+import { TelemetryTrigger } from '../../Models/Constants/TelemetryConstants';
+import { getOatMetricsForModels } from '../../Models/Services/OatTelemetryUtils';
 
 const debugLogging = false;
 const logDebugConsole = getDebugLogger('OATHeader', debugLogging);
@@ -66,11 +74,14 @@ export const EXPORT_LOC_KEYS: IExportLocalizationKeys = {
 
 const OATHeader: React.FC<IOATHeaderProps> = (props) => {
     const { styles } = props;
+    const componentName = ComponentName.OAT;
+    const appRegion = AppRegion.OAT;
 
     // hooks
     const { t } = useTranslation();
     const commandContex = useContext(CommandHistoryContext);
     const { undo, redo, canUndo, canRedo } = commandContex;
+    const { sendEventTelemetry } = useTelemetry();
 
     // contexts
     const { oatPageDispatch, oatPageState } = useOatPageContext();
@@ -111,15 +122,23 @@ const OATHeader: React.FC<IOATHeaderProps> = (props) => {
                 getTotalReferenceCount(result.data) >=
                 OAT_ONTOLOGY_MAX_REFERENCE_LIMIT
             ) {
-                (result.status = 'Failed'),
-                    (result.errors = [
-                        {
-                            title: t('OAT.ImportLimits.title'),
-                            message: t('OAT.ImportLimits.message', {
-                                count: OAT_ONTOLOGY_MAX_REFERENCE_LIMIT
-                            })
-                        }
-                    ]);
+                result.status = 'Failed';
+                result.errors = [
+                    {
+                        title: t('OAT.ImportLimits.title'),
+                        message: t('OAT.ImportLimits.message', {
+                            count: OAT_ONTOLOGY_MAX_REFERENCE_LIMIT
+                        })
+                    }
+                ];
+                // Log limit exceeded
+                sendEventTelemetry({
+                    name: TelemetryEvents.importFailLimit,
+                    triggerType: TelemetryTrigger.UserAction,
+                    appRegion: appRegion,
+                    componentName: componentName,
+                    customProperties: getOatMetricsForModels(result.data)
+                });
             }
             if (result.status === 'Success') {
                 oatPageDispatch({
@@ -132,6 +151,14 @@ const OATHeader: React.FC<IOATHeaderProps> = (props) => {
                 oatPageDispatch({
                     type: OatPageContextActionType.IMPORT_MODELS,
                     payload: { models: result.data }
+                });
+                // Log success
+                sendEventTelemetry({
+                    name: TelemetryEvents.importSuccess,
+                    triggerType: TelemetryTrigger.UserAction,
+                    appRegion: appRegion,
+                    componentName: componentName,
+                    customProperties: getOatMetricsForModels(result.data)
                 });
             } else if (result.status === 'Failed') {
                 // show error
@@ -155,13 +182,31 @@ const OATHeader: React.FC<IOATHeaderProps> = (props) => {
                         state: 'closed'
                     }
                 });
+                // Log import error
+                sendEventTelemetry({
+                    name: TelemetryEvents.importFailException,
+                    triggerType: TelemetryTrigger.UserAction,
+                    appRegion: appRegion,
+                    componentName: componentName,
+                    customProperties: {
+                        errorTitle: error.title,
+                        errorMessage: error.message
+                    }
+                });
             }
             // Reset value of input element so that it can be reused with the same file
             uploadFolderInputRef.current.value = null;
             uploadFileInputRef.current.value = null;
             logDebugConsole('debug', '[IMPORT] [END] Files upload.', result);
         },
-        [oatPageDispatch, oatPageState.currentOntologyModels, t]
+        [
+            appRegion,
+            componentName,
+            oatPageDispatch,
+            oatPageState.currentOntologyModels,
+            sendEventTelemetry,
+            t
+        ]
     );
 
     const onExportClick = useCallback(() => {
@@ -192,6 +237,16 @@ const OATHeader: React.FC<IOATHeaderProps> = (props) => {
                     fileName = `${oatPageState.currentOntologyProjectName}-models.zip`;
                 }
                 downloadFile(content, fileName);
+                // Log success
+                sendEventTelemetry({
+                    name: TelemetryEvents.exportSuccess,
+                    triggerType: TelemetryTrigger.UserAction,
+                    appRegion: appRegion,
+                    componentName: componentName,
+                    customProperties: getOatMetricsForModels(
+                        oatPageState.currentOntologyModels
+                    )
+                });
             });
         } else {
             // show error
@@ -209,11 +264,28 @@ const OATHeader: React.FC<IOATHeaderProps> = (props) => {
                     message: error.message
                 }
             });
+            // Log success
+            sendEventTelemetry({
+                name: TelemetryEvents.exportFail,
+                triggerType: TelemetryTrigger.UserAction,
+                appRegion: appRegion,
+                componentName: componentName,
+                customProperties: {
+                    errorTitle: error.title,
+                    errorMessage: error.message,
+                    ...getOatMetricsForModels(
+                        oatPageState.currentOntologyModels
+                    )
+                }
+            });
         }
     }, [
         oatPageState.currentOntologyModels,
         oatPageState.currentOntologyProjectName,
         t,
+        sendEventTelemetry,
+        appRegion,
+        componentName,
         oatPageDispatch
     ]);
 

--- a/src/Components/OATModelList/OATModelList.tsx
+++ b/src/Components/OATModelList/OATModelList.tsx
@@ -1,4 +1,10 @@
-import React, { useEffect, useState, useContext, useRef } from 'react';
+import React, {
+    useEffect,
+    useState,
+    useContext,
+    useRef,
+    useCallback
+} from 'react';
 import {
     classNamesFunction,
     IButtonProps,
@@ -31,6 +37,13 @@ import { useExtendedTheme } from '../../Models/Hooks/useExtendedTheme';
 import { TFunction } from 'i18next';
 import { parseModelId } from '../../Models/Services/OatUtils';
 import IllustrationMessage from '../IllustrationMessage/IllustrationMessage';
+import useTelemetry from '../../Models/Hooks/useTelemetry';
+import { TelemetryTrigger } from '../../Models/Constants/TelemetryConstants';
+import {
+    AppRegion,
+    ComponentName,
+    TelemetryEvents
+} from '../../Models/Constants/OatTelemetryConstants';
 
 const debugLogging = false;
 const logDebugConsole = getDebugLogger('OatModelList', debugLogging);
@@ -47,6 +60,7 @@ const OATModelList: React.FC<IOATModelListProps> = (props) => {
 
     // hooks
     const { t } = useTranslation();
+    const { sendEventTelemetry } = useTelemetry();
 
     // contexts
     const { execute } = useContext(CommandHistoryContext);
@@ -70,6 +84,16 @@ const OATModelList: React.FC<IOATModelListProps> = (props) => {
             classNames
         )
     );
+
+    // callbacks
+    const sendSearchTelemetry = useCallback(() => {
+        sendEventTelemetry({
+            name: TelemetryEvents.modelSearch,
+            triggerType: TelemetryTrigger.UserAction,
+            appRegion: AppRegion.OAT,
+            componentName: ComponentName.OAT
+        });
+    }, [sendEventTelemetry]);
 
     // update the list items anytime a new model is added to the context
     useEffect(() => {
@@ -169,7 +193,10 @@ const OATModelList: React.FC<IOATModelListProps> = (props) => {
             ) : (
                 <SearchBox
                     placeholder={t('OAT.ModelList.searchModels')}
-                    onChange={(_, value) => setFilter(value)}
+                    onChange={(_, value) => {
+                        setFilter(value);
+                        sendSearchTelemetry();
+                    }}
                     styles={classNames.subComponentStyles.searchbox}
                     data-testid={'models-list-search-box'}
                 />

--- a/src/Components/OATModelList/OATModelList.tsx
+++ b/src/Components/OATModelList/OATModelList.tsx
@@ -88,7 +88,7 @@ const OATModelList: React.FC<IOATModelListProps> = (props) => {
     // callbacks
     const sendSearchTelemetry = useCallback(() => {
         sendEventTelemetry({
-            name: TelemetryEvents.modelSearch,
+            name: TelemetryEvents.modelListSearch,
             triggerType: TelemetryTrigger.UserAction,
             appRegion: AppRegion.OAT,
             componentName: ComponentName.OAT
@@ -195,7 +195,11 @@ const OATModelList: React.FC<IOATModelListProps> = (props) => {
                     placeholder={t('OAT.ModelList.searchModels')}
                     onChange={(_, value) => {
                         setFilter(value);
-                        sendSearchTelemetry();
+                    }}
+                    onBlur={() => {
+                        if (filter && filter.length) {
+                            sendSearchTelemetry();
+                        }
                     }}
                     styles={classNames.subComponentStyles.searchbox}
                     data-testid={'models-list-search-box'}

--- a/src/Components/OATPropertyEditor/Internal/EditorJsonTab/Internal/JSONEditor/JSONEditor.tsx
+++ b/src/Components/OATPropertyEditor/Internal/EditorJsonTab/Internal/JSONEditor/JSONEditor.tsx
@@ -32,6 +32,13 @@ import { DtdlInterface } from '../../../../../../Models/Constants';
 import { getDebugLogger } from '../../../../../../Models/Services/Utils';
 import Editor from '@monaco-editor/react';
 import { validateItemChangeBeforeSaving } from '../../../../../../Models/Services/DtdlUtils';
+import useTelemetry from '../../../../../../Models/Hooks/useTelemetry';
+import {
+    AppRegion,
+    ComponentName,
+    TelemetryEvents
+} from '../../../../../../Models/Constants/OatTelemetryConstants';
+import { TelemetryTrigger } from '../../../../../../Models/Constants/TelemetryConstants';
 
 const debugLogging = false;
 export const logDebugConsole = getDebugLogger('JSONEditor', debugLogging);
@@ -70,6 +77,7 @@ const JSONEditor: React.FC<IJSONEditorProps> = (props) => {
 
     // hooks
     const { t } = useTranslation();
+    const { sendEventTelemetry } = useTelemetry();
 
     // data
     const selectedItem = useMemo(() => {
@@ -110,7 +118,13 @@ const JSONEditor: React.FC<IJSONEditorProps> = (props) => {
             type: OatPageContextActionType.SET_OAT_MODIFIED,
             payload: { isModified: false }
         });
-    }, [selectedItem, oatPageDispatch]);
+        sendEventTelemetry({
+            name: TelemetryEvents.dtdlJsonCancelled,
+            triggerType: TelemetryTrigger.UserAction,
+            appRegion: AppRegion.OAT,
+            componentName: ComponentName.OAT
+        });
+    }, [selectedItem, oatPageDispatch, sendEventTelemetry]);
 
     const onSaveClick = useCallback(async () => {
         logDebugConsole('debug', '[SAVE] Start {content}', content);
@@ -124,12 +138,24 @@ const JSONEditor: React.FC<IJSONEditorProps> = (props) => {
                     type: OatPageContextActionType.SET_OAT_MODIFIED,
                     payload: { isModified: false }
                 });
+                sendEventTelemetry({
+                    name: TelemetryEvents.dtdlJsonSuccess,
+                    triggerType: TelemetryTrigger.UserAction,
+                    appRegion: AppRegion.OAT,
+                    componentName: ComponentName.OAT
+                });
             };
 
             const undoSave = () => {
                 oatPageDispatch({
                     type: OatPageContextActionType.SET_CURRENT_MODELS,
                     payload: { models: oatPageState.currentOntologyModels }
+                });
+                sendEventTelemetry({
+                    name: TelemetryEvents.dtdlJsonUndo,
+                    triggerType: TelemetryTrigger.UserAction,
+                    appRegion: AppRegion.OAT,
+                    componentName: ComponentName.OAT
                 });
             };
 
@@ -170,7 +196,8 @@ const JSONEditor: React.FC<IJSONEditorProps> = (props) => {
         oatPageDispatch,
         oatPageState.currentOntologyModels,
         oatPageState.selection.modelId,
-        selectedItem
+        selectedItem,
+        sendEventTelemetry
     ]);
 
     // side effects

--- a/src/Components/OATPropertyEditor/Internal/EditorJsonTab/Internal/JSONEditor/JSONEditor.tsx
+++ b/src/Components/OATPropertyEditor/Internal/EditorJsonTab/Internal/JSONEditor/JSONEditor.tsx
@@ -151,12 +151,6 @@ const JSONEditor: React.FC<IJSONEditorProps> = (props) => {
                     type: OatPageContextActionType.SET_CURRENT_MODELS,
                     payload: { models: oatPageState.currentOntologyModels }
                 });
-                sendEventTelemetry({
-                    name: TelemetryEvents.dtdlJsonUndo,
-                    triggerType: TelemetryTrigger.UserAction,
-                    appRegion: AppRegion.OAT,
-                    componentName: ComponentName.OAT
-                });
             };
 
             execute(save, undoSave);

--- a/src/Components/OATPropertyEditor/Internal/EditorPropertiesTab/EditorPropertiesTab.tsx
+++ b/src/Components/OATPropertyEditor/Internal/EditorPropertiesTab/EditorPropertiesTab.tsx
@@ -27,6 +27,13 @@ import { OatPageContextActionType } from '../../../../Models/Context/OatPageCont
 import { getDebugLogger, deepCopy } from '../../../../Models/Services/Utils';
 import { useCommandHistoryContext } from '../../../../Pages/OATEditorPage/Internal/Context/CommandHistoryContext';
 import { getPropertyInspectorStyles } from '../../OATPropertyEditor.styles';
+import useTelemetry from '../../../../Models/Hooks/useTelemetry';
+import { TelemetryTrigger } from '../../../../Models/Constants/TelemetryConstants';
+import {
+    AppRegion,
+    ComponentName,
+    TelemetryEvents
+} from '../../../../Models/Constants/OatTelemetryConstants';
 
 const debugLogging = false;
 const logDebugConsole = getDebugLogger('EditorPropertiesTab', debugLogging);
@@ -47,6 +54,7 @@ const EditorPropertiesTab: React.FC<IEditorPropertiesTabProps> = (props) => {
 
     // hooks
     const { t } = useTranslation();
+    const { sendEventTelemetry } = useTelemetry();
 
     // data
     const propertiesKeyName = getModelPropertyCollectionName(
@@ -115,6 +123,16 @@ const EditorPropertiesTab: React.FC<IEditorPropertiesTabProps> = (props) => {
                             model: selectedItemCopy
                         }
                     });
+                    // Add type telemetry
+                    sendEventTelemetry({
+                        name: TelemetryEvents.propertyModelAddSuccess,
+                        triggerType: TelemetryTrigger.UserAction,
+                        appRegion: AppRegion.OAT,
+                        componentName: ComponentName.OAT,
+                        customProperties: {
+                            type: data.schema
+                        }
+                    });
                 };
 
                 const undoUpdate = () => {
@@ -125,6 +143,16 @@ const EditorPropertiesTab: React.FC<IEditorPropertiesTabProps> = (props) => {
                             positions:
                                 oatPageState.currentOntologyModelPositions,
                             selection: oatPageState.selection
+                        }
+                    });
+                    // Add type telemetry undo
+                    sendEventTelemetry({
+                        name: TelemetryEvents.propertyModelAddUndo,
+                        triggerType: TelemetryTrigger.UserAction,
+                        appRegion: AppRegion.OAT,
+                        componentName: ComponentName.OAT,
+                        customProperties: {
+                            type: data.schema
                         }
                     });
                 };
@@ -139,6 +167,16 @@ const EditorPropertiesTab: React.FC<IEditorPropertiesTabProps> = (props) => {
                             reference: selectedItemCopy
                         }
                     });
+                    // Add type reference telemetry
+                    sendEventTelemetry({
+                        name: TelemetryEvents.propertyReferenceAddSuccess,
+                        triggerType: TelemetryTrigger.UserAction,
+                        appRegion: AppRegion.OAT,
+                        componentName: ComponentName.OAT,
+                        customProperties: {
+                            type: data.schema
+                        }
+                    });
                 };
 
                 const undoUpdate = () => {
@@ -149,6 +187,16 @@ const EditorPropertiesTab: React.FC<IEditorPropertiesTabProps> = (props) => {
                             positions:
                                 oatPageState.currentOntologyModelPositions,
                             selection: oatPageState.selection
+                        }
+                    });
+                    // Add type reference telemetry undo
+                    sendEventTelemetry({
+                        name: TelemetryEvents.propertyReferenceAddUndo,
+                        triggerType: TelemetryTrigger.UserAction,
+                        appRegion: AppRegion.OAT,
+                        componentName: ComponentName.OAT,
+                        customProperties: {
+                            type: data.schema
                         }
                     });
                 };
@@ -164,7 +212,8 @@ const EditorPropertiesTab: React.FC<IEditorPropertiesTabProps> = (props) => {
             oatPageState.selection,
             parentModelId,
             propertiesKeyName,
-            selectedItem
+            selectedItem,
+            sendEventTelemetry
         ]
     );
 

--- a/src/Components/OATPropertyEditor/Internal/EditorPropertiesTab/EditorPropertiesTab.tsx
+++ b/src/Components/OATPropertyEditor/Internal/EditorPropertiesTab/EditorPropertiesTab.tsx
@@ -125,7 +125,7 @@ const EditorPropertiesTab: React.FC<IEditorPropertiesTabProps> = (props) => {
                     });
                     // Add type telemetry
                     sendEventTelemetry({
-                        name: TelemetryEvents.propertyModelAddSuccess,
+                        name: TelemetryEvents.propertyAddToModel,
                         triggerType: TelemetryTrigger.UserAction,
                         appRegion: AppRegion.OAT,
                         componentName: ComponentName.OAT,
@@ -143,16 +143,6 @@ const EditorPropertiesTab: React.FC<IEditorPropertiesTabProps> = (props) => {
                             positions:
                                 oatPageState.currentOntologyModelPositions,
                             selection: oatPageState.selection
-                        }
-                    });
-                    // Add type telemetry undo
-                    sendEventTelemetry({
-                        name: TelemetryEvents.propertyModelAddUndo,
-                        triggerType: TelemetryTrigger.UserAction,
-                        appRegion: AppRegion.OAT,
-                        componentName: ComponentName.OAT,
-                        customProperties: {
-                            type: data.schema
                         }
                     });
                 };
@@ -169,7 +159,7 @@ const EditorPropertiesTab: React.FC<IEditorPropertiesTabProps> = (props) => {
                     });
                     // Add type reference telemetry
                     sendEventTelemetry({
-                        name: TelemetryEvents.propertyReferenceAddSuccess,
+                        name: TelemetryEvents.propertyAddToReference,
                         triggerType: TelemetryTrigger.UserAction,
                         appRegion: AppRegion.OAT,
                         componentName: ComponentName.OAT,
@@ -187,16 +177,6 @@ const EditorPropertiesTab: React.FC<IEditorPropertiesTabProps> = (props) => {
                             positions:
                                 oatPageState.currentOntologyModelPositions,
                             selection: oatPageState.selection
-                        }
-                    });
-                    // Add type reference telemetry undo
-                    sendEventTelemetry({
-                        name: TelemetryEvents.propertyReferenceAddUndo,
-                        triggerType: TelemetryTrigger.UserAction,
-                        appRegion: AppRegion.OAT,
-                        componentName: ComponentName.OAT,
-                        customProperties: {
-                            type: data.schema
                         }
                     });
                 };

--- a/src/Components/OATPropertyEditor/Internal/FormRootModelDetails/Internal/FormRootModelDetailsContent/PropertyDetailsEditorModalContent.tsx
+++ b/src/Components/OATPropertyEditor/Internal/FormRootModelDetails/Internal/FormRootModelDetailsContent/PropertyDetailsEditorModalContent.tsx
@@ -167,7 +167,7 @@ const PropertyDetailsEditorModalContent: React.FC<IModalFormRootModelContentProp
             })
         );
         sendEventTelemetry({
-            name: TelemetryEvents.upgradeVersion,
+            name: TelemetryEvents.upgradeModelVersion,
             triggerType: TelemetryTrigger.UserAction,
             appRegion: AppRegion.OAT,
             componentName: ComponentName.OAT

--- a/src/Components/OATPropertyEditor/Internal/FormRootModelDetails/Internal/FormRootModelDetailsContent/PropertyDetailsEditorModalContent.tsx
+++ b/src/Components/OATPropertyEditor/Internal/FormRootModelDetails/Internal/FormRootModelDetailsContent/PropertyDetailsEditorModalContent.tsx
@@ -56,6 +56,13 @@ import {
 } from '../../../../../../Models/Services/Utils';
 import Version3UpgradeButton from '../../../Version3UpgradeButton/Version3UpgradeButton';
 import { DTDL_CONTEXT_VERSION_3 } from '../../../../../../Models/Classes/DTDL';
+import useTelemetry from '../../../../../../Models/Hooks/useTelemetry';
+import { TelemetryTrigger } from '../../../../../../Models/Constants/TelemetryConstants';
+import {
+    AppRegion,
+    ComponentName,
+    TelemetryEvents
+} from '../../../../../../Models/Constants/OatTelemetryConstants';
 
 const SINGLE_LANGUAGE_KEY = 'singleLanguage';
 const MULTI_LANGUAGE_KEY = 'multiLanguage';
@@ -82,6 +89,7 @@ const PropertyDetailsEditorModalContent: React.FC<IModalFormRootModelContentProp
 
     // hooks
     const { t } = useTranslation();
+    const { sendEventTelemetry } = useTelemetry();
 
     // contexts
     const { oatPageState } = useOatPageContext();
@@ -158,7 +166,13 @@ const PropertyDetailsEditorModalContent: React.FC<IModalFormRootModelContentProp
                 );
             })
         );
-    }, [onUpdateItem]);
+        sendEventTelemetry({
+            name: TelemetryEvents.upgradeVersion,
+            triggerType: TelemetryTrigger.UserAction,
+            appRegion: AppRegion.OAT,
+            componentName: ComponentName.OAT
+        });
+    }, [onUpdateItem, sendEventTelemetry]);
 
     // data
     const displayNameMultiLangOptions: IChoiceGroupOption[] = [

--- a/src/Components/OATPropertyEditor/Internal/PropertiesModelSummary.tsx
+++ b/src/Components/OATPropertyEditor/Internal/PropertiesModelSummary.tsx
@@ -249,7 +249,7 @@ export const PropertiesModelSummary: React.FC<IPropertiesModelSummaryProps> = (
                 setModelPath(value.trim());
                 // Log event for path
                 sendEventTelemetry({
-                    name: TelemetryEvents.modalChangePath,
+                    name: TelemetryEvents.modelChangePath,
                     triggerType: TelemetryTrigger.UserAction,
                     appRegion: AppRegion.OAT,
                     componentName: ComponentName.OAT

--- a/src/Components/OATPropertyEditor/Internal/PropertiesModelSummary.tsx
+++ b/src/Components/OATPropertyEditor/Internal/PropertiesModelSummary.tsx
@@ -44,6 +44,13 @@ import { getTargetFromSelection } from '../Utils';
 import ModelPropertyHeader from './ModelPropertyHeader/ModelPropertyHeader';
 import PropertyDetailsEditorModal from './FormRootModelDetails/PropertyDetailsEditorModal';
 import { DtdlInterface, DtdlInterfaceContent } from '../../../Models/Constants';
+import useTelemetry from '../../../Models/Hooks/useTelemetry';
+import { TelemetryTrigger } from '../../../Models/Constants/TelemetryConstants';
+import {
+    AppRegion,
+    ComponentName,
+    TelemetryEvents
+} from '../../../Models/Constants/OatTelemetryConstants';
 
 const debugLogging = false;
 const logDebugConsole = getDebugLogger('PropertiesModelSummary', debugLogging);
@@ -62,6 +69,7 @@ export const PropertiesModelSummary: React.FC<IPropertiesModelSummaryProps> = (
 
     // hooks
     const { t } = useTranslation();
+    const { sendEventTelemetry } = useTelemetry();
 
     // contexts
     const { execute } = useContext(CommandHistoryContext);
@@ -235,11 +243,21 @@ export const PropertiesModelSummary: React.FC<IPropertiesModelSummaryProps> = (
             setModelUniqueName(value.trim());
         }
     }, []);
-    const onChangePath = useCallback((_ev, value: string) => {
-        if (isValidDtmiPath(value.trim(), false)) {
-            setModelPath(value.trim());
-        }
-    }, []);
+    const onChangePath = useCallback(
+        (_ev, value: string) => {
+            if (isValidDtmiPath(value.trim(), false)) {
+                setModelPath(value.trim());
+                // Log event for path
+                sendEventTelemetry({
+                    name: TelemetryEvents.modalChangePath,
+                    triggerType: TelemetryTrigger.UserAction,
+                    appRegion: AppRegion.OAT,
+                    componentName: ComponentName.OAT
+                });
+            }
+        },
+        [sendEventTelemetry]
+    );
     const onChangeVersion = useCallback(
         (_ev, value: string) => {
             if (

--- a/src/Components/OATPropertyEditor/Internal/PropertiesModelSummary.tsx
+++ b/src/Components/OATPropertyEditor/Internal/PropertiesModelSummary.tsx
@@ -238,11 +238,21 @@ export const PropertiesModelSummary: React.FC<IPropertiesModelSummaryProps> = (
             oatPageState.selection
         ]
     );
-    const onChangeUniqueName = useCallback((_ev, value: string) => {
-        if (isValidModelName(value.trim(), false)) {
-            setModelUniqueName(value.trim());
-        }
-    }, []);
+    const onChangeUniqueName = useCallback(
+        (_ev, value: string) => {
+            if (isValidModelName(value.trim(), false)) {
+                setModelUniqueName(value.trim());
+                // Log event for name change
+                sendEventTelemetry({
+                    name: TelemetryEvents.modelChangeName,
+                    triggerType: TelemetryTrigger.UserAction,
+                    appRegion: AppRegion.OAT,
+                    componentName: ComponentName.OAT
+                });
+            }
+        },
+        [sendEventTelemetry]
+    );
     const onChangePath = useCallback(
         (_ev, value: string) => {
             if (isValidDtmiPath(value.trim(), false)) {
@@ -268,9 +278,16 @@ export const PropertiesModelSummary: React.FC<IPropertiesModelSummaryProps> = (
                 )
             ) {
                 setModelVersion(value.trim());
+                // Log event for name change
+                sendEventTelemetry({
+                    name: TelemetryEvents.modelChangeVersion,
+                    triggerType: TelemetryTrigger.UserAction,
+                    appRegion: AppRegion.OAT,
+                    componentName: ComponentName.OAT
+                });
             }
         },
-        [modelContext]
+        [modelContext, sendEventTelemetry]
     );
     const onChangeRelationshipName = useCallback(
         (_ev, value: string) => {

--- a/src/Models/Constants/OatTelemetryConstants.ts
+++ b/src/Models/Constants/OatTelemetryConstants.ts
@@ -1,0 +1,98 @@
+import { OatPageContextActionType } from '../Context/OatPageContext/OatPageContext.types';
+
+/** Common metrics interface */
+export interface OatGlobalMetrics extends OatMetrics {
+    projectCount: number;
+}
+
+export interface OatMetrics {
+    modelCount: number;
+    v2ModelCount: number;
+    v3ModelCount: number;
+    relationshipCount: number;
+    inheritanceCount: number;
+    componentCount: number;
+    propertyCount: number;
+}
+
+/** Highest level sections of the app */
+export enum AppRegion {
+    OAT = 'OAT'
+}
+
+/**
+ * The high level component emitting the event
+ * Keep it at the general level, no need to get overly specific.
+ * Ex: OAT
+ */
+export enum ComponentName {
+    OAT = 'OAT'
+}
+
+const BASE_PATH = 'OAT';
+
+export const TelemetryEvents = {
+    // Initialize
+    init: `${BASE_PATH}.Initialize`,
+    // Import
+    importFailLimit: `${BASE_PATH}.Import.Failure.LimitExceeded`,
+    importFailException: `${BASE_PATH}.Import.Failure.UnhandledException`,
+    importSuccess: `${BASE_PATH}.Import.Success`,
+    // Export
+    exportFail: `${BASE_PATH}.Export.Success`,
+    exportSuccess: `${BASE_PATH}.Export.Failure`,
+    // Command history
+    redo: `${BASE_PATH}.Redo.Clicked`,
+    undo: `${BASE_PATH}.Undo.Clicked`,
+    // Upgrade version
+    upgradeVersion: `${BASE_PATH}.ModelVersion.Upgrade`,
+    // Modal path change
+    modalChangePath: `${BASE_PATH}.ModalPath.Update`,
+    // Dtdl JSON edit
+    dtdlJsonSuccess: `${BASE_PATH}.DtdlUpdate.Success`,
+    dtdlJsonCancelled: `${BASE_PATH}.DtdlUpdate.Cancelled`,
+    dtdlJsonUndo: `${BASE_PATH}.DtdlUpdate.Undo`,
+    // Search
+    modelSearch: `${BASE_PATH}.ModelSearch`,
+    // Auto layout
+    autoLayout: `${BASE_PATH}.AutoLayout.Clicked`,
+    // Property addition
+    propertyModelAddSuccess: `${BASE_PATH}.ModelProperty.Add`,
+    propertyModelAddUndo: `${BASE_PATH}.ModelProperty.Undo`,
+    propertyReferenceAddSuccess: `${BASE_PATH}.ReferenceProperty.Add`,
+    propertyReferenceAddUndo: `${BASE_PATH}.ReferenceProperty.Undo`
+};
+
+export const OatIncludedEvents = [
+    OatPageContextActionType.CREATE_PROJECT,
+    OatPageContextActionType.EDIT_PROJECT,
+    OatPageContextActionType.DUPLICATE_PROJECT,
+    OatPageContextActionType.SWITCH_CURRENT_PROJECT,
+    OatPageContextActionType.DELETE_MODEL,
+    OatPageContextActionType.DELETE_REFERENCE,
+    OatPageContextActionType.SET_CURRENT_NAMESPACE,
+    OatPageContextActionType.SET_CURRENT_PROJECT_NAME,
+    OatPageContextActionType.UPDATE_MODEL_ID,
+    OatPageContextActionType.ADD_NEW_MODEL,
+    OatPageContextActionType.ADD_NEW_RELATIONSHIP,
+    OatPageContextActionType.ADD_NEW_MODEL_WITH_RELATIONSHIP,
+    OatPageContextActionType.SET_SELECTED_PROPERTY_EDITOR_TAB,
+    OatPageContextActionType.SET_OAT_SELECTED_MODEL
+];
+
+export const ActionToEventMapping = {
+    CREATE_PROJECT: `${BASE_PATH}.CreateProject`,
+    EDIT_PROJECT: `${BASE_PATH}.EditProject`,
+    DUPLICATE_PROJECT: `${BASE_PATH}.DuplicateProject`,
+    SWITCH_CURRENT_PROJECT: `${BASE_PATH}.SwitchProject`,
+    DELETE_MODEL: `${BASE_PATH}.DeleteModel`,
+    DELETE_REFERENCE: `${BASE_PATH}.DeleteReference`,
+    SET_CURRENT_NAMESPACE: `${BASE_PATH}.SetCurrentNamespace`,
+    SET_CURRENT_PROJECT_NAME: `${BASE_PATH}.SetCurrentProjectName`,
+    UPDATE_MODEL_ID: `${BASE_PATH}.UpdateModelId`,
+    ADD_NEW_MODEL: `${BASE_PATH}.AddNewModel`,
+    ADD_NEW_RELATIONSHIP: `${BASE_PATH}.AddNewRelationship`,
+    ADD_NEW_MODEL_WITH_RELATIONSHIP: `${BASE_PATH}.AddNewModelWithRelationShip`,
+    SET_SELECTED_PROPERTY_EDITOR_TAB: `${BASE_PATH}.SetSelectedPropertyEditorTab`,
+    SET_OAT_SELECTED_MODEL: `${BASE_PATH}.SetOatSelectedModel`
+};

--- a/src/Models/Constants/OatTelemetryConstants.ts
+++ b/src/Models/Constants/OatTelemetryConstants.ts
@@ -1,18 +1,17 @@
 import { OatPageContextActionType } from '../Context/OatPageContext/OatPageContext.types';
 
 /** Common metrics interface */
-export interface OatGlobalMetrics extends OatMetrics {
+export interface OatOnMountMetrics extends OatImportExportMetrics {
     projectCount: number;
 }
 
-export interface OatMetrics {
+export interface OatImportExportMetrics {
     modelCount: number;
     v2ModelCount: number;
     v3ModelCount: number;
     relationshipCount: number;
     inheritanceCount: number;
     componentCount: number;
-    propertyCount: number;
 }
 
 /** Highest level sections of the app */
@@ -35,32 +34,26 @@ export const TelemetryEvents = {
     // Initialize
     init: `${BASE_PATH}.Initialize`,
     // Import
-    importFailLimit: `${BASE_PATH}.Import.Failure.LimitExceeded`,
-    importFailException: `${BASE_PATH}.Import.Failure.UnhandledException`,
-    importSuccess: `${BASE_PATH}.Import.Success`,
+    import: `${BASE_PATH}.Import`,
     // Export
-    exportFail: `${BASE_PATH}.Export.Success`,
-    exportSuccess: `${BASE_PATH}.Export.Failure`,
+    export: `${BASE_PATH}.Export`,
     // Command history
     redo: `${BASE_PATH}.Redo.Clicked`,
     undo: `${BASE_PATH}.Undo.Clicked`,
     // Upgrade version
-    upgradeVersion: `${BASE_PATH}.ModelVersion.Upgrade`,
+    upgradeModelVersion: `${BASE_PATH}.ModelVersion.Upgrade`,
     // Modal path change
-    modalChangePath: `${BASE_PATH}.ModalPath.Update`,
+    modelChangePath: `${BASE_PATH}.ModelPath.Update`,
     // Dtdl JSON edit
     dtdlJsonSuccess: `${BASE_PATH}.DtdlUpdate.Success`,
     dtdlJsonCancelled: `${BASE_PATH}.DtdlUpdate.Cancelled`,
-    dtdlJsonUndo: `${BASE_PATH}.DtdlUpdate.Undo`,
     // Search
-    modelSearch: `${BASE_PATH}.ModelSearch`,
+    modelListSearch: `${BASE_PATH}.ModelListSearch`,
     // Auto layout
     autoLayout: `${BASE_PATH}.AutoLayout.Clicked`,
     // Property addition
-    propertyModelAddSuccess: `${BASE_PATH}.ModelProperty.Add`,
-    propertyModelAddUndo: `${BASE_PATH}.ModelProperty.Undo`,
-    propertyReferenceAddSuccess: `${BASE_PATH}.ReferenceProperty.Add`,
-    propertyReferenceAddUndo: `${BASE_PATH}.ReferenceProperty.Undo`
+    propertyAddToModel: `${BASE_PATH}.ModelProperty.Add`,
+    propertyAddToReference: `${BASE_PATH}.ReferenceProperty.Add`
 };
 
 export const OatIncludedEvents = [
@@ -81,18 +74,18 @@ export const OatIncludedEvents = [
 ];
 
 export const ActionToEventMapping = {
-    CREATE_PROJECT: `${BASE_PATH}.CreateProject`,
-    EDIT_PROJECT: `${BASE_PATH}.EditProject`,
-    DUPLICATE_PROJECT: `${BASE_PATH}.DuplicateProject`,
-    SWITCH_CURRENT_PROJECT: `${BASE_PATH}.SwitchProject`,
-    DELETE_MODEL: `${BASE_PATH}.DeleteModel`,
-    DELETE_REFERENCE: `${BASE_PATH}.DeleteReference`,
-    SET_CURRENT_NAMESPACE: `${BASE_PATH}.SetCurrentNamespace`,
-    SET_CURRENT_PROJECT_NAME: `${BASE_PATH}.SetCurrentProjectName`,
-    UPDATE_MODEL_ID: `${BASE_PATH}.UpdateModelId`,
-    ADD_NEW_MODEL: `${BASE_PATH}.AddNewModel`,
-    ADD_NEW_RELATIONSHIP: `${BASE_PATH}.AddNewRelationship`,
-    ADD_NEW_MODEL_WITH_RELATIONSHIP: `${BASE_PATH}.AddNewModelWithRelationShip`,
-    SET_SELECTED_PROPERTY_EDITOR_TAB: `${BASE_PATH}.SetSelectedPropertyEditorTab`,
-    SET_OAT_SELECTED_MODEL: `${BASE_PATH}.SetOatSelectedModel`
+    [OatPageContextActionType.CREATE_PROJECT]: `${BASE_PATH}.CreateProject`,
+    [OatPageContextActionType.EDIT_PROJECT]: `${BASE_PATH}.EditProject`,
+    [OatPageContextActionType.DUPLICATE_PROJECT]: `${BASE_PATH}.DuplicateProject`,
+    [OatPageContextActionType.SWITCH_CURRENT_PROJECT]: `${BASE_PATH}.SwitchProject`,
+    [OatPageContextActionType.DELETE_MODEL]: `${BASE_PATH}.DeleteModel`,
+    [OatPageContextActionType.DELETE_REFERENCE]: `${BASE_PATH}.DeleteReference`,
+    [OatPageContextActionType.SET_CURRENT_NAMESPACE]: `${BASE_PATH}.SetCurrentNamespace`,
+    [OatPageContextActionType.SET_CURRENT_PROJECT_NAME]: `${BASE_PATH}.SetCurrentProjectName`,
+    [OatPageContextActionType.UPDATE_MODEL_ID]: `${BASE_PATH}.UpdateModelId`,
+    [OatPageContextActionType.ADD_NEW_MODEL]: `${BASE_PATH}.AddNewModel`,
+    [OatPageContextActionType.ADD_NEW_RELATIONSHIP]: `${BASE_PATH}.AddNewRelationship`,
+    [OatPageContextActionType.ADD_NEW_MODEL_WITH_RELATIONSHIP]: `${BASE_PATH}.AddNewModelWithRelationShip`,
+    [OatPageContextActionType.SET_SELECTED_PROPERTY_EDITOR_TAB]: `${BASE_PATH}.SetSelectedPropertyEditorTab`,
+    [OatPageContextActionType.SET_OAT_SELECTED_MODEL]: `${BASE_PATH}.SetOatSelectedModel`
 };

--- a/src/Models/Constants/OatTelemetryConstants.ts
+++ b/src/Models/Constants/OatTelemetryConstants.ts
@@ -42,8 +42,10 @@ export const TelemetryEvents = {
     undo: `${BASE_PATH}.Undo.Clicked`,
     // Upgrade version
     upgradeModelVersion: `${BASE_PATH}.ModelVersion.Upgrade`,
-    // Modal path change
+    // Model field changes
     modelChangePath: `${BASE_PATH}.ModelPath.Update`,
+    modelChangeName: `${BASE_PATH}.ModelName.Update`,
+    modelChangeVersion: `${BASE_PATH}.ModelVersion.Update`,
     // Dtdl JSON edit
     dtdlJsonSuccess: `${BASE_PATH}.DtdlUpdate.Success`,
     dtdlJsonCancelled: `${BASE_PATH}.DtdlUpdate.Cancelled`,

--- a/src/Models/Context/OatPageContext/OatPageContextUtils.ts
+++ b/src/Models/Context/OatPageContext/OatPageContextUtils.ts
@@ -45,6 +45,7 @@ import {
 import { isOatContextStorageEnabled, logDebugConsole } from './OatPageContext';
 import { IOatPageContextState } from './OatPageContext.types';
 import {
+    getDtdlVersionFromContext,
     hasType,
     isDTDLComponentReference,
     isDTDLProperty,
@@ -399,6 +400,78 @@ export const getTotalReferenceCount = (models: DtdlInterface[]): number => {
         referenceList.push(...localRefs);
     });
     return referenceList.length;
+};
+
+/** gets number of inheritances in the ontology. Done for telemetry */
+export const getTotalInheritanceCount = (models: DtdlInterface[]): number => {
+    let inheritanceCount = 0;
+    models.forEach((m) => {
+        if (!m.extends) {
+            return;
+        } else if (typeof m.extends == 'object') {
+            inheritanceCount = inheritanceCount + m.extends.length;
+        } else {
+            inheritanceCount = inheritanceCount + 1;
+        }
+    });
+    return inheritanceCount;
+};
+
+/** get property count */
+export const getTotalPropertyCount = (models: DtdlInterface[]): number => {
+    const countProperties = (contents: DtdlInterfaceContent[]): number => {
+        let count = 0;
+        contents.forEach((c) => {
+            if (isDTDLProperty(c)) count = count + 1;
+        });
+        return count;
+    };
+
+    let propertyCount = 0;
+    models.forEach((m) => {
+        if (!m.contents) {
+            return;
+        } else {
+            propertyCount = propertyCount + countProperties(m.contents);
+        }
+    });
+    return propertyCount;
+};
+
+/** get component count */
+export const getTotalComponentCount = (models: DtdlInterface[]): number => {
+    const countComponents = (contents: DtdlInterfaceContent[]): number => {
+        let count = 0;
+        contents.forEach((c) => {
+            if (isDTDLComponentReference(c)) count = count + 1;
+        });
+        return count;
+    };
+
+    let componentCount = 0;
+    models.forEach((m) => {
+        if (!m.contents) {
+            return;
+        } else {
+            componentCount = componentCount + countComponents(m.contents);
+        }
+    });
+    return componentCount;
+};
+
+/** get model version count */
+export const getModelVersionCount = (
+    models: DtdlInterface[]
+): [number, number] => {
+    let v2ModelCount = 0;
+    let v3ModelCount = 0;
+    models.forEach((m) => {
+        const version = getDtdlVersionFromContext(m['@context']);
+        version === '2'
+            ? (v2ModelCount = v2ModelCount + 1)
+            : (v3ModelCount = v3ModelCount + 1);
+    });
+    return [v2ModelCount, v3ModelCount];
 };
 
 //#region Creating new relationship

--- a/src/Models/Context/OatPageContext/OatPageContextUtils.ts
+++ b/src/Models/Context/OatPageContext/OatPageContextUtils.ts
@@ -421,16 +421,16 @@ export const getModelMetricsForTelemetry = (
     let v3ModelCount = 0;
 
     models.forEach((m) => {
-        // Calculate relationships
-        const relationships =
-            m.contents.filter((x) => isDTDLRelationshipReference(x)) ?? [];
-        relationshipCount += relationships.length;
+        // Calculate relationships & components
+        m.contents.forEach((content) => {
+            if (isDTDLRelationshipReference(content)) {
+                relationshipCount += 1;
+            } else if (isDTDLComponentReference(content)) {
+                componentCount += 1;
+            }
+        });
         // Calculate inheritance
         inheritanceCount += ensureIsArray(m.extends).length;
-        // Calculate components
-        const components =
-            m.contents.filter((x) => isDTDLComponentReference(x)) ?? [];
-        componentCount += components.length;
         // Calculate model versions
         modelHasVersion3Context(m) ? (v3ModelCount += 1) : (v2ModelCount += 1);
     });

--- a/src/Models/Services/OatTelemetryUtils.ts
+++ b/src/Models/Services/OatTelemetryUtils.ts
@@ -1,0 +1,78 @@
+import { IOATFile } from '../../Pages/OATEditorPage/Internal/Classes/OatTypes';
+import { DtdlInterface } from '../Constants';
+import {
+    ActionToEventMapping,
+    OatGlobalMetrics,
+    OatMetrics
+} from '../Constants/OatTelemetryConstants';
+import { OatPageContextActionType } from '../Context/OatPageContext/OatPageContext.types';
+import {
+    getModelVersionCount,
+    getTotalComponentCount,
+    getTotalInheritanceCount,
+    getTotalPropertyCount,
+    getTotalReferenceCount
+} from '../Context/OatPageContext/OatPageContextUtils';
+
+export const getNameFromAction = (action: OatPageContextActionType) => {
+    return ActionToEventMapping[action];
+};
+
+export const getOatMetricsForModels = (models: DtdlInterface[]): OatMetrics => {
+    const [v2ModelCount, v3ModelCount] = getModelVersionCount(models);
+    return {
+        modelCount: models.length,
+        relationshipCount: getTotalReferenceCount(models),
+        inheritanceCount: getTotalInheritanceCount(models),
+        componentCount: getTotalComponentCount(models),
+        propertyCount: getTotalPropertyCount(models),
+        v2ModelCount: v2ModelCount,
+        v3ModelCount: v3ModelCount
+    };
+};
+
+export const getOatMetrics = (files: IOATFile[]): OatGlobalMetrics => {
+    if (!files.length) {
+        return {
+            modelCount: 0,
+            relationshipCount: 0,
+            projectCount: 0,
+            inheritanceCount: 0,
+            componentCount: 0,
+            propertyCount: 0,
+            v2ModelCount: 0,
+            v3ModelCount: 0
+        };
+    }
+
+    let modelCount = 0;
+    let relationshipCount = 0;
+    let inheritanceCount = 0;
+    let componentCount = 0;
+    let propertyCount = 0;
+    let v2ModelCount = 0;
+    let v3ModelCount = 0;
+    files.forEach((f) => {
+        if (f.data && f.data.models) {
+            const metrics = getOatMetricsForModels(f.data.models);
+            modelCount = modelCount + metrics.modelCount;
+            relationshipCount = relationshipCount + metrics.relationshipCount;
+            inheritanceCount = inheritanceCount + metrics.inheritanceCount;
+            componentCount = componentCount + metrics.componentCount;
+            propertyCount = propertyCount + metrics.propertyCount;
+            v2ModelCount = v2ModelCount + metrics.v2ModelCount;
+            v3ModelCount = v3ModelCount + metrics.v3ModelCount;
+        }
+    });
+
+    return {
+        modelCount: modelCount,
+        relationshipCount: relationshipCount,
+        projectCount: files.length,
+        inheritanceCount: inheritanceCount,
+        componentCount: componentCount,
+        propertyCount: propertyCount,
+        v2ModelCount: v2ModelCount,
+        v3ModelCount: v3ModelCount
+    };
+};

--- a/src/Models/Services/OatTelemetryUtils.ts
+++ b/src/Models/Services/OatTelemetryUtils.ts
@@ -2,36 +2,31 @@ import { IOATFile } from '../../Pages/OATEditorPage/Internal/Classes/OatTypes';
 import { DtdlInterface } from '../Constants';
 import {
     ActionToEventMapping,
-    OatGlobalMetrics,
-    OatMetrics
+    OatOnMountMetrics,
+    OatImportExportMetrics
 } from '../Constants/OatTelemetryConstants';
 import { OatPageContextActionType } from '../Context/OatPageContext/OatPageContext.types';
-import {
-    getModelVersionCount,
-    getTotalComponentCount,
-    getTotalInheritanceCount,
-    getTotalPropertyCount,
-    getTotalReferenceCount
-} from '../Context/OatPageContext/OatPageContextUtils';
+import { getModelMetricsForTelemetry } from '../Context/OatPageContext/OatPageContextUtils';
 
 export const getNameFromAction = (action: OatPageContextActionType) => {
     return ActionToEventMapping[action];
 };
 
-export const getOatMetricsForModels = (models: DtdlInterface[]): OatMetrics => {
-    const [v2ModelCount, v3ModelCount] = getModelVersionCount(models);
+export const getOatMetricsForModels = (
+    models: DtdlInterface[]
+): OatImportExportMetrics => {
+    const oatMetrics = getModelMetricsForTelemetry(models);
     return {
         modelCount: models.length,
-        relationshipCount: getTotalReferenceCount(models),
-        inheritanceCount: getTotalInheritanceCount(models),
-        componentCount: getTotalComponentCount(models),
-        propertyCount: getTotalPropertyCount(models),
-        v2ModelCount: v2ModelCount,
-        v3ModelCount: v3ModelCount
+        relationshipCount: oatMetrics.relationshipCount,
+        inheritanceCount: oatMetrics.inheritanceCount,
+        componentCount: oatMetrics.componentCount,
+        v2ModelCount: oatMetrics.v2ModelCount,
+        v3ModelCount: oatMetrics.v3ModelCount
     };
 };
 
-export const getOatMetrics = (files: IOATFile[]): OatGlobalMetrics => {
+export const getOatGlobalMetrics = (files: IOATFile[]): OatOnMountMetrics => {
     if (!files.length) {
         return {
             modelCount: 0,
@@ -39,7 +34,6 @@ export const getOatMetrics = (files: IOATFile[]): OatGlobalMetrics => {
             projectCount: 0,
             inheritanceCount: 0,
             componentCount: 0,
-            propertyCount: 0,
             v2ModelCount: 0,
             v3ModelCount: 0
         };
@@ -49,7 +43,6 @@ export const getOatMetrics = (files: IOATFile[]): OatGlobalMetrics => {
     let relationshipCount = 0;
     let inheritanceCount = 0;
     let componentCount = 0;
-    let propertyCount = 0;
     let v2ModelCount = 0;
     let v3ModelCount = 0;
     files.forEach((f) => {
@@ -59,7 +52,6 @@ export const getOatMetrics = (files: IOATFile[]): OatGlobalMetrics => {
             relationshipCount = relationshipCount + metrics.relationshipCount;
             inheritanceCount = inheritanceCount + metrics.inheritanceCount;
             componentCount = componentCount + metrics.componentCount;
-            propertyCount = propertyCount + metrics.propertyCount;
             v2ModelCount = v2ModelCount + metrics.v2ModelCount;
             v3ModelCount = v3ModelCount + metrics.v3ModelCount;
         }
@@ -71,7 +63,6 @@ export const getOatMetrics = (files: IOATFile[]): OatGlobalMetrics => {
         projectCount: files.length,
         inheritanceCount: inheritanceCount,
         componentCount: componentCount,
-        propertyCount: propertyCount,
         v2ModelCount: v2ModelCount,
         v3ModelCount: v3ModelCount
     };

--- a/src/Models/Services/TelemetryService/TelemetryService.types.ts
+++ b/src/Models/Services/TelemetryService/TelemetryService.types.ts
@@ -3,6 +3,10 @@ import {
     ComponentName,
     TelemetryTrigger
 } from '../../Constants/TelemetryConstants';
+import {
+    AppRegion as OatAppRegion,
+    ComponentName as OatComponentName
+} from '../../Constants/OatTelemetryConstants';
 
 /** Loosely based on the Application insights telemetry data model
  * https://docs.microsoft.com/en-us/azure/azure-monitor/app/data-model
@@ -68,18 +72,18 @@ interface IEventTelemetryParamsBase extends IBaseTelemetryParams {
 }
 type IEventTelemetryForComponentAction = IEventTelemetryParamsBase & {
     triggerType: TelemetryTrigger.UserAction;
-    componentName: ComponentName;
-    appRegion: AppRegion;
+    componentName: ComponentName | OatComponentName;
+    appRegion: AppRegion | OatAppRegion;
 };
 type IEventTelemetryForComponentView = IEventTelemetryParamsBase & {
     triggerType: TelemetryTrigger.UserView;
-    componentName: ComponentName;
-    appRegion: AppRegion;
+    componentName: ComponentName | OatComponentName;
+    appRegion: AppRegion | OatAppRegion;
 };
 type IEventTelemetryForService = IEventTelemetryParamsBase & {
     triggerType: TelemetryTrigger.SystemAction;
-    componentName?: ComponentName;
-    appRegion?: AppRegion;
+    componentName?: ComponentName | OatComponentName;
+    appRegion?: AppRegion | OatAppRegion;
 };
 
 export interface IMetricTelemetryParams extends IBaseTelemetryParams {

--- a/src/Pages/OATEditorPage/Internal/Classes/OatTypes.ts
+++ b/src/Pages/OATEditorPage/Internal/Classes/OatTypes.ts
@@ -1,5 +1,3 @@
-import { FitViewFunc, Node, XYPosition } from 'react-flow-renderer';
-
 import { IOatProjectData } from './ProjectData';
 
 export interface IOATFile {
@@ -19,10 +17,14 @@ interface ViewportHelperFunctionOptions {
  * NOTE: there are more actions than this, this is just what we were using.
  */
 export interface IReactFlowInstance {
-    getNodes: () => Node[];
     zoomOut: (options?: ViewportHelperFunctionOptions) => void;
     zoomTo: (options?: ViewportHelperFunctionOptions) => void;
     zoomIn: (options?: ViewportHelperFunctionOptions) => void;
-    fitView: FitViewFunc;
+    fitView: () => void; // does take args, so check the docs if you need them
     project: (position: XYPosition) => XYPosition;
+}
+
+interface XYPosition {
+    x: number;
+    y: number;
 }

--- a/src/Pages/OATEditorPage/Internal/Hooks/useCommandHistory.tsx
+++ b/src/Pages/OATEditorPage/Internal/Hooks/useCommandHistory.tsx
@@ -1,4 +1,12 @@
 import { useState, useMemo } from 'react';
+import {
+    AppRegion,
+    ComponentName,
+    TelemetryEvents
+} from '../../../../Models/Constants/OatTelemetryConstants';
+import { TelemetryTrigger } from '../../../../Models/Constants/TelemetryConstants';
+import { TelemetryService } from '../../../../Models/Services';
+import { TelemetryEvent } from '../../../../Models/Services/TelemetryService/Telemetry';
 import { getDebugLogger } from '../../../../Models/Services/Utils';
 
 interface ICommandRecord {
@@ -50,6 +58,15 @@ export const useCommandHistory = (
         if (canRedo) {
             history[index].doFn();
             setIndex((previousIndex) => previousIndex + 1);
+            // Log event
+            TelemetryService.sendEvent(
+                new TelemetryEvent({
+                    name: TelemetryEvents.redo,
+                    appRegion: AppRegion.OAT,
+                    triggerType: TelemetryTrigger.UserAction,
+                    componentName: ComponentName.OAT
+                })
+            );
         }
     };
 
@@ -61,6 +78,15 @@ export const useCommandHistory = (
         if (canUndo) {
             history[index - 1].undoFn();
             setIndex((previousIndex) => previousIndex - 1);
+            // Log event
+            TelemetryService.sendEvent(
+                new TelemetryEvent({
+                    name: TelemetryEvents.undo,
+                    appRegion: AppRegion.OAT,
+                    triggerType: TelemetryTrigger.UserAction,
+                    componentName: ComponentName.OAT
+                })
+            );
         }
     };
 

--- a/src/Pages/OATEditorPage/OATEditorPage.tsx
+++ b/src/Pages/OATEditorPage/OATEditorPage.tsx
@@ -24,7 +24,7 @@ import {
     TelemetryEvents
 } from '../../Models/Constants/OatTelemetryConstants';
 import { TelemetryTrigger } from '../../Models/Constants/TelemetryConstants';
-import { getOatMetrics } from '../../Models/Services/OatTelemetryUtils';
+import { getOatGlobalMetrics } from '../../Models/Services/OatTelemetryUtils';
 
 const OATEditorPageContent: React.FC<IOATEditorPageProps> = (props) => {
     const { locale, localeStrings, selectedThemeName } = props;
@@ -42,7 +42,9 @@ const OATEditorPageContent: React.FC<IOATEditorPageProps> = (props) => {
                 triggerType: TelemetryTrigger.SystemAction,
                 appRegion: AppRegion.OAT,
                 componentName: ComponentName.OAT,
-                customProperties: getOatMetrics(oatPageState.ontologyFiles)
+                customProperties: getOatGlobalMetrics(
+                    oatPageState.ontologyFiles
+                )
             });
             isMounted.current = true;
         }

--- a/src/Pages/OATEditorPage/OATEditorPage.tsx
+++ b/src/Pages/OATEditorPage/OATEditorPage.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 
 import OATHeader from '../../Components/OATHeader/OATHeader';
@@ -17,14 +17,36 @@ import BaseComponent from '../../Components/BaseComponent/BaseComponent';
 import { getTargetFromSelection } from '../../Components/OATPropertyEditor/Utils';
 import { isDTDLReference } from '../../Models/Services/DtdlUtils';
 import OATImportProgressDialog from '../../Components/OATImportProgressDialog/OATImportProgressDialog';
+import useTelemetry from '../../Models/Hooks/useTelemetry';
+import {
+    AppRegion,
+    ComponentName,
+    TelemetryEvents
+} from '../../Models/Constants/OatTelemetryConstants';
+import { TelemetryTrigger } from '../../Models/Constants/TelemetryConstants';
+import { getOatMetrics } from '../../Models/Services/OatTelemetryUtils';
 
 const OATEditorPageContent: React.FC<IOATEditorPageProps> = (props) => {
     const { locale, localeStrings, selectedThemeName } = props;
-
-    // hooks
+    const isMounted = useRef(false);
 
     // contexts
     const { oatPageState } = useOatPageContext();
+
+    // hooks
+    const { sendEventTelemetry } = useTelemetry();
+    useEffect(() => {
+        if (!isMounted) {
+            sendEventTelemetry({
+                name: TelemetryEvents.init,
+                triggerType: TelemetryTrigger.SystemAction,
+                appRegion: AppRegion.OAT,
+                componentName: ComponentName.OAT,
+                customProperties: getOatMetrics(oatPageState.ontologyFiles)
+            });
+            isMounted.current = true;
+        }
+    }, [oatPageState.ontologyFiles, sendEventTelemetry]);
 
     // data
     const selectedItem = useMemo(() => {


### PR DESCRIPTION
### Summary of changes 🔍 
Adding Telemetry to OAT actions. Added telemetry to be able to respond all these questions:
High level usage 
Daily active users
How many times does each user import and export in a day?
How many models, relationships, inheritances and components are in each import / export?
How many ontologies does each user have?
How many models are in each ontology?
How many models are v2 vs v3?
How many relationships, inheritances and components are in each ontology?

Feature usage
How often is DTDL manually edited and saved? 
How often is the path of a modal changed and saved? 
How often is the version of a model changed and saved? 
How often is a user searching for a model in the left panel? 
How often do users use the "auto layout" button? 
How often are properties added to a model and saved? 
	Which property types are added?
How often do imports fail? Is it due to reference limitation or syntax? 
	If limitation: how many models, relationships, inheritances and components does it have?

And also some reducer actions tied to telemetry for extra insight into usage.


### Testing 🧪
N/A

### Checklist ✔️
- [ ] Linked associated issue (if present)
- [ ] Added relevant labels
- [ ] Requested developer reviews
- [ ] Request UI review from design / PM
- [ ] Verify all code checks are passing