### PR TITLE
Fix typo in twin update call

### DIFF
--- a/src/Adapters/ADTAdapter.ts
+++ b/src/Adapters/ADTAdapter.ts
@@ -426,7 +426,7 @@ export default class ADTAdapter implements IADTAdapter {
                     const id = event.dtId;
                     const config: AxiosRequestConfig = {
                         method: 'patch',
-                        url: this.generateUrl(`/digitaltiwns/${id}`),
+                        url: this.generateUrl(`/digitaltwins/${id}`),
                         data: event.patchJSON,
                         headers: this.generateHeaders({
                             'Content-Type': 'application/json',


### PR DESCRIPTION
### Summary of changes 🔍 
Fix a typo in the url of twin update call.

### Testing 🧪
N/A

### Checklist ✔️
- [ ] Linked associated issue (if present)
- [ ] Added relevant labels
- [ ] Requested developer reviews
- [ ] Request UI review from design / PM
- [ ] Verify all code checks are passing