### PR TITLE
Data pusher fix duplication in URL

### DIFF
--- a/src/Adapters/ADTAdapter.ts
+++ b/src/Adapters/ADTAdapter.ts
@@ -128,11 +128,7 @@ export default class ADTAdapter implements IADTAdapter {
             (useAdtProxy || !validateExplorerOrigin(window.origin)) &&
             !forceCORS;
         this.authService.login();
-        this.axiosInstance = axios.create({
-            baseURL: this.useAdtProxy
-                ? this.adtProxyServerPath
-                : this.adtHostUrl
-        });
+        this.axiosInstance = axios.create();
         axiosRetry(this.axiosInstance, {
             retries: 3,
             retryCondition: (axiosError: AxiosError) => {


### PR DESCRIPTION
### Summary of changes 🔍 
Fixes duplication created by setting a baseURL in the axios instance used for data pusher requests. URL is now managed by `generateURL` function exclusively.

`this.axiosInstance` can only be found in the following methods of ADT Adapter:
- createModels (only found in `GenerateADTAssets.tsx` a data pusher component)
- createTwins (only found in `GenerateADTAssets.tsx` a data pusher component) 
- createRelationships (only found in `GenerateADTAssets.tsx` a data pusher component)

### Testing 🧪
Try out data pusher stories locally with both CORS on and off.

### Checklist ✔️
- [ ] Linked associated issue (if present)
- [ ] Added relevant labels
- [ ] Requested developer reviews
- [ ] Request UI review from design / PM
- [ ] Verify all code checks are passing