### PR TITLE
WizardShell, navigation and skeleton components

### DIFF
--- a/src/Apps/Legion/Components/StepperWizard/Internal/Step.tsx
+++ b/src/Apps/Legion/Components/StepperWizard/Internal/Step.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { FontIcon } from '@fluentui/react';
+import { IStepProps } from './Step.types';
+
+export const Step: React.FC<IStepProps> = ({
+    type,
+    label,
+    onClick,
+    isSelected,
+    isFinished,
+    isNavigationDisabled,
+    includeIcons,
+    isAllCompletedSuccessfully,
+    hasWarning
+}) => {
+    return (
+        <div
+            className={`cb-stepper-wizard-step ${
+                isSelected ? 'cb-step-is-selected' : ''
+            } ${
+                isNavigationDisabled ? 'cb-step-is-disabled' : ''
+            } cb-stepper-${type}`}
+            tabIndex={0}
+            onClick={onClick}
+            role="button"
+        >
+            <div
+                className={`cb-stepper-wizard-step-circle ${
+                    isSelected ? 'cb-step-is-selected' : ''
+                } ${isFinished ? 'cb-step-is-finished' : ''} ${
+                    isAllCompletedSuccessfully ? 'cb-green-line' : ''
+                }`}
+            >
+                {includeIcons && (
+                    <>
+                        {isFinished && (
+                            <FontIcon
+                                iconName={'CheckMark'}
+                                className={'cb-stepper-wizard-step-circle-icon'}
+                            />
+                        )}
+                        {hasWarning && (
+                            <FontIcon
+                                iconName={'Warning'}
+                                className={'cb-stepper-wizard-step-circle-icon'}
+                            />
+                        )}
+                    </>
+                )}
+            </div>
+            <span className={'cb-stepper-wizard-step-label'}>{label}</span>
+        </div>
+    );
+};

--- a/src/Apps/Legion/Components/StepperWizard/Internal/Step.types.ts
+++ b/src/Apps/Legion/Components/StepperWizard/Internal/Step.types.ts
@@ -1,0 +1,30 @@
+import { StepperWizardType } from '../StepperWizard.types';
+import { IExtendedTheme } from '../../../../../Theming/Theme.types';
+import { IStyle } from '@fluentui/react';
+
+export interface IStepProps {
+    type: StepperWizardType;
+    label: string;
+    onClick?: (event?: React.MouseEvent<HTMLDivElement>) => void | undefined;
+    isSelected: boolean;
+    isFinished: boolean;
+    isNavigationDisabled: boolean;
+    includeIcons: boolean;
+    isAllCompletedSuccessfully: boolean;
+    hasWarning: boolean;
+}
+
+export interface StepStyleProps {
+    theme: IExtendedTheme;
+}
+export interface StepStyles {
+    root: IStyle;
+
+    /**
+     * SubComponent styles.
+     */
+    subComponentStyles?: StepSubComponentStyles;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface StepSubComponentStyles {}

--- a/src/Apps/Legion/Components/StepperWizard/Internal/StepSeparator.tsx
+++ b/src/Apps/Legion/Components/StepperWizard/Internal/StepSeparator.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { IStepSeparatorProps } from './StepSeparator.types';
+
+export const StepSeparator: React.FC<IStepSeparatorProps> = ({
+    orientation,
+    isFinished,
+    isAllCompletedSuccessfully
+}) => {
+    return (
+        <div
+            className={`cb-stepper-wizard-stepper-separator cb-stepper-${orientation}`}
+        >
+            <div
+                className={`cb-stepper-wizard-stepper-separator-line ${
+                    isFinished ? 'cb-step-is-finished' : ''
+                } ${
+                    isAllCompletedSuccessfully ? 'cb-green-line' : ''
+                } cb-stepper-${orientation}`}
+            ></div>
+        </div>
+    );
+};

--- a/src/Apps/Legion/Components/StepperWizard/Internal/StepSeparator.types.ts
+++ b/src/Apps/Legion/Components/StepperWizard/Internal/StepSeparator.types.ts
@@ -1,0 +1,24 @@
+import { IStyle } from '@fluentui/react';
+import { IExtendedTheme } from '../../../../../Theming/Theme.types';
+import { StepperWizardType } from '../StepperWizard.types';
+
+export interface IStepSeparatorProps {
+    orientation: StepperWizardType;
+    isFinished?: boolean;
+    isAllCompletedSuccessfully: boolean;
+}
+
+export interface StepSeparatorStyleProps {
+    theme: IExtendedTheme;
+}
+export interface StepSeparatorStyles {
+    root: IStyle;
+
+    /**
+     * SubComponent styles.
+     */
+    subComponentStyles?: StepSeparatorSubComponentStyles;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface StepSeparatorSubComponentStyles {}

--- a/src/Apps/Legion/Components/StepperWizard/Internal/Stepper.tsx
+++ b/src/Apps/Legion/Components/StepperWizard/Internal/Stepper.tsx
@@ -1,0 +1,85 @@
+import React, { useMemo } from 'react';
+import { useWizardNavigationContext } from '../../../Models/Context/WizardNavigationContext/WizardNavigationContext';
+import { WizardNavigationContextActionType } from '../../../Models/Context/WizardNavigationContext/WizardNavigationContext.types';
+import { Step } from './Step';
+import { IStepProps } from './Step.types';
+import { IStepperProps } from './Stepper.types';
+import { StepSeparator } from './StepSeparator';
+
+export const Stepper: React.FC<IStepperProps> = ({
+    type,
+    steps,
+    isCurrentStepWithWarning,
+    isNavigationDisabled,
+    includeIcons,
+    isAllCompletedSuccessfully
+}) => {
+    // Context
+    const {
+        wizardNavigationContextState,
+        wizardNavigationContextDispatch
+    } = useWizardNavigationContext();
+
+    const stepperMapProps = useMemo(
+        () =>
+            steps.map(
+                (step, index) =>
+                    ({
+                        label: step.label,
+                        onClick: () => {
+                            wizardNavigationContextDispatch({
+                                type:
+                                    WizardNavigationContextActionType.NAVIGATE_TO,
+                                payload: { stepNumber: index }
+                            });
+                            if (step.onClick) {
+                                step.onClick();
+                            }
+                        }
+                    } as IStepProps)
+            ),
+        [steps, wizardNavigationContextDispatch]
+    );
+
+    return (
+        <>
+            {stepperMapProps.map(({ label, onClick }, index) => (
+                <div
+                    className={`cb-stepper-wizard-stepper cb-stepper-${type}`}
+                    key={index}
+                >
+                    <Step
+                        type={type}
+                        isFinished={
+                            wizardNavigationContextState.currentStep > index ||
+                            isAllCompletedSuccessfully
+                        }
+                        isSelected={
+                            wizardNavigationContextState.currentStep === index
+                        }
+                        label={label}
+                        onClick={onClick}
+                        isNavigationDisabled={isNavigationDisabled}
+                        includeIcons={includeIcons}
+                        isAllCompletedSuccessfully={isAllCompletedSuccessfully}
+                        hasWarning={
+                            wizardNavigationContextState.currentStep ===
+                                index && isCurrentStepWithWarning
+                        }
+                    />
+                    {index !== steps.length - 1 && (
+                        <StepSeparator
+                            orientation={type}
+                            isFinished={
+                                wizardNavigationContextState.currentStep > index
+                            }
+                            isAllCompletedSuccessfully={
+                                isAllCompletedSuccessfully
+                            }
+                        />
+                    )}
+                </div>
+            ))}
+        </>
+    );
+};

--- a/src/Apps/Legion/Components/StepperWizard/Internal/Stepper.types.ts
+++ b/src/Apps/Legion/Components/StepperWizard/Internal/Stepper.types.ts
@@ -1,0 +1,27 @@
+import { IStepperWizardStep, StepperWizardType } from '../StepperWizard.types';
+import { IExtendedTheme } from '../../../../../Theming/Theme.types';
+import { IStyle } from '@fluentui/react';
+
+export interface IStepperProps {
+    type: StepperWizardType;
+    steps: Array<IStepperWizardStep>;
+    isCurrentStepWithWarning: boolean;
+    isNavigationDisabled: boolean;
+    includeIcons: boolean;
+    isAllCompletedSuccessfully: boolean;
+}
+
+export interface StepperStyleProps {
+    theme: IExtendedTheme;
+}
+export interface StepperStyles {
+    root: IStyle;
+
+    /**
+     * SubComponent styles.
+     */
+    subComponentStyles?: StepperSubComponentStyles;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface StepperSubComponentStyles {}

--- a/src/Apps/Legion/Components/StepperWizard/StepperWizard.scss
+++ b/src/Apps/Legion/Components/StepperWizard/StepperWizard.scss
@@ -1,0 +1,118 @@
+@import '../../../../Resources/Styles/BaseStyles.scss';
+
+.cb-stepper-wizard {
+    display: flex;
+    font-size: 14px;
+    justify-content: center;
+
+    &.cb-stepper-vertical {
+        flex-direction: column;
+    }
+
+    &.cb-stepper-horizontal {
+        flex-direction: row;
+    }
+
+    .cb-stepper-wizard-step {
+        align-items: center;
+        cursor: pointer;
+        display: inline-flex;
+        flex-wrap: wrap;
+        gap: 12px;
+        padding: 2px;
+
+        &.cb-stepper-vertical {
+            flex-direction: row;
+        }
+
+        &.cb-stepper-horizontal {
+            flex-direction: column;
+        }
+
+        &.cb-step-is-selected {
+            font-weight: 600;
+        }
+
+        &.cb-step-is-disabled {
+            pointer-events: none;
+        }
+    }
+
+    .cb-stepper-wizard-stepper {
+        display: flex;
+
+        &.cb-stepper-vertical {
+            flex-direction: column;
+        }
+
+        &.cb-stepper-horizontal {
+            flex-direction: row;
+        }
+    }
+
+    .cb-stepper-wizard-step-circle {
+        align-items: center;
+        background: transparent;
+        border: 2px solid var(--cb-color-natural-light);
+        border-radius: 16px;
+        display: flex;
+        height: 16px;
+        justify-content: center;
+        width: 16px;
+
+        &.cb-step-is-finished,
+        &.cb-step-is-selected {
+            background: var(--cb-color-theme-primary);
+            border-color: var(--cb-color-theme-primary);
+        }
+
+        &.cb-green-line {
+            background: var(--cb-color-success);
+            border-color: var(--cb-color-success);
+        }
+    }
+
+    .cb-stepper-wizard-step-circle-icon {
+        font-size: 10px !important;
+    }
+
+    .cb-stepper-wizard-step-label {
+        overflow: hidden;
+        text-align: center;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        width: 60px;
+    }
+
+    .cb-stepper-wizard-stepper-separator {
+        &.cb-stepper-vertical {
+            padding: 9px;
+        }
+
+        &.cb-stepper-horizontal {
+            padding-top: 9px;
+        }
+    }
+
+    .cb-stepper-wizard-stepper-separator-line {
+        background: var(--cb-color-natural-light);
+
+        &.cb-stepper-vertical {
+            height: 20px;
+            width: 2px;
+        }
+
+        &.cb-stepper-horizontal {
+            height: 2px;
+            width: 20px;
+        }
+
+        &.cb-step-is-finished {
+            background: var(--cb-color-theme-primary);
+        }
+
+        &.cb-green-line {
+            background: var(--cb-color-success);
+        }
+    }
+}

--- a/src/Apps/Legion/Components/StepperWizard/StepperWizard.stories.tsx
+++ b/src/Apps/Legion/Components/StepperWizard/StepperWizard.stories.tsx
@@ -7,11 +7,12 @@ import {
     StepperWizardType
 } from './StepperWizard.types';
 import { getDefaultStoryDecorator } from '../../../../Models/Services/StoryUtilities';
+import { WizardNavigationContextProvider } from '../../Models/Context/WizardNavigationContext/WizardNavigationContext';
 
 const wrapperStyle = { width: 'fit-content', height: 'auto' };
 
 export default {
-    title: 'Components/StepperWizard',
+    title: 'Components/Apps/Legion/StepperWizard',
     component: StepperWizard,
     decorators: [getDefaultStoryDecorator(wrapperStyle)]
 };
@@ -39,7 +40,14 @@ const steps: Array<IStepperWizardStep> = [
 
 type TemplateStory = ComponentStory<typeof StepperWizard>;
 const Template: TemplateStory = (args: IStepperWizardProps) => (
-    <StepperWizard {...args} />
+    <WizardNavigationContextProvider
+        initialState={{
+            steps: steps,
+            currentStep: 0
+        }}
+    >
+        <StepperWizard {...args} />
+    </WizardNavigationContextProvider>
 );
 
 const horizontalProps: IStepperWizardProps = {

--- a/src/Apps/Legion/Components/StepperWizard/StepperWizard.stories.tsx
+++ b/src/Apps/Legion/Components/StepperWizard/StepperWizard.stories.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { ComponentStory } from '@storybook/react';
+import StepperWizard from './StepperWizard';
+import {
+    IStepperWizardProps,
+    IStepperWizardStep,
+    StepperWizardType
+} from './StepperWizard.types';
+import { getDefaultStoryDecorator } from '../../../../Models/Services/StoryUtilities';
+
+const wrapperStyle = { width: 'fit-content', height: 'auto' };
+
+export default {
+    title: 'Components/StepperWizard',
+    component: StepperWizard,
+    decorators: [getDefaultStoryDecorator(wrapperStyle)]
+};
+
+const steps: Array<IStepperWizardStep> = [
+    {
+        label: 'Step-1',
+        onClick: () => {
+            console.log('Step-1 clicked!');
+        }
+    },
+    {
+        label: 'Step-2',
+        onClick: () => {
+            console.log('Step-2 clicked!');
+        }
+    },
+    {
+        label: 'Step-3',
+        onClick: () => {
+            console.log('Step-3 clicked!');
+        }
+    }
+];
+
+type TemplateStory = ComponentStory<typeof StepperWizard>;
+const Template: TemplateStory = (args: IStepperWizardProps) => (
+    <StepperWizard {...args} />
+);
+
+const horizontalProps: IStepperWizardProps = {
+    type: StepperWizardType.Horizontal,
+    steps: steps,
+    currentStepIndex: 0
+};
+export const HorizontalStepperWizard = Template.bind({}) as TemplateStory;
+HorizontalStepperWizard.args = horizontalProps;
+
+const verticalProps: IStepperWizardProps = {
+    type: StepperWizardType.Vertical,
+    steps: steps,
+    currentStepIndex: 1,
+    includeIcons: true
+};
+export const VerticalStepperWizardWithIcons = Template.bind(
+    {}
+) as TemplateStory;
+VerticalStepperWizardWithIcons.args = verticalProps;
+
+const allFinishedProps: IStepperWizardProps = {
+    type: StepperWizardType.Vertical,
+    steps: steps,
+    currentStepIndex: 2,
+    includeIcons: true,
+    isAllCompletedSuccessfully: true,
+    isNavigationDisabled: true
+};
+export const VerticalAllFinishedSuccessfully = Template.bind(
+    {}
+) as TemplateStory;
+VerticalAllFinishedSuccessfully.args = allFinishedProps;
+
+const currentStepWarningProps: IStepperWizardProps = {
+    type: StepperWizardType.Horizontal,
+    steps: steps,
+    currentStepIndex: 1,
+    includeIcons: true,
+    isNavigationDisabled: true,
+    isCurrentStepWithWarning: true
+};
+export const HorizontalCurrentStepWarning = Template.bind({}) as TemplateStory;
+HorizontalCurrentStepWarning.args = currentStepWarningProps;

--- a/src/Apps/Legion/Components/StepperWizard/StepperWizard.tsx
+++ b/src/Apps/Legion/Components/StepperWizard/StepperWizard.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import './StepperWizard.scss';
+import { Stepper } from './Internal/Stepper';
+import { IStepperWizardProps } from './StepperWizard.types';
+
+const StepperWizard = ({
+    type,
+    steps,
+    isCurrentStepWithWarning = false,
+    isNavigationDisabled = false,
+    includeIcons = false,
+    isAllCompletedSuccessfully = false
+}: IStepperWizardProps) => {
+    return (
+        <div className={`cb-stepper-wizard cb-stepper-${type}`}>
+            <Stepper
+                type={type}
+                steps={steps}
+                isCurrentStepWithWarning={isCurrentStepWithWarning}
+                isNavigationDisabled={isNavigationDisabled}
+                includeIcons={includeIcons}
+                isAllCompletedSuccessfully={isAllCompletedSuccessfully}
+            />
+        </div>
+    );
+};
+
+export default StepperWizard;

--- a/src/Apps/Legion/Components/StepperWizard/StepperWizard.types.ts
+++ b/src/Apps/Legion/Components/StepperWizard/StepperWizard.types.ts
@@ -1,0 +1,19 @@
+export enum StepperWizardType {
+    Vertical = 'vertical',
+    Horizontal = 'horizontal'
+}
+
+export interface IStepperWizardStep {
+    label: string;
+    onClick?: () => void;
+}
+
+export interface IStepperWizardProps {
+    type: StepperWizardType;
+    steps: Array<IStepperWizardStep>;
+    currentStepIndex?: number;
+    isCurrentStepWithWarning?: boolean;
+    isNavigationDisabled?: boolean;
+    includeIcons?: boolean;
+    isAllCompletedSuccessfully?: boolean; // to color the steps green
+}

--- a/src/Apps/Legion/Components/WizardShell/Internal/DataSourceStep/DataSourceStep.stories.tsx
+++ b/src/Apps/Legion/Components/WizardShell/Internal/DataSourceStep/DataSourceStep.stories.tsx
@@ -7,7 +7,7 @@ import { getDefaultStoryDecorator } from '../../../../../../Models/Services/Stor
 const wrapperStyle = { width: '100%', height: '600px', padding: 8 };
 
 export default {
-    title: 'Components/DataSourceStep',
+    title: 'Components/Apps/Legion/DataSourceStep',
     component: DataSourceStep,
     decorators: [getDefaultStoryDecorator<IDataSourceStepProps>(wrapperStyle)]
 };

--- a/src/Apps/Legion/Components/WizardShell/Internal/DataSourceStep/DataSourceStep.stories.tsx
+++ b/src/Apps/Legion/Components/WizardShell/Internal/DataSourceStep/DataSourceStep.stories.tsx
@@ -7,7 +7,7 @@ import { getDefaultStoryDecorator } from '../../../../../../Models/Services/Stor
 const wrapperStyle = { width: '100%', height: '600px', padding: 8 };
 
 export default {
-    title: 'Components/Apps/Legion/DataSourceStep',
+    title: 'Components/Apps/Legion/WizardShell/DataSourceStep',
     component: DataSourceStep,
     decorators: [getDefaultStoryDecorator<IDataSourceStepProps>(wrapperStyle)]
 };

--- a/src/Apps/Legion/Components/WizardShell/Internal/DataSourceStep/DataSourceStep.stories.tsx
+++ b/src/Apps/Legion/Components/WizardShell/Internal/DataSourceStep/DataSourceStep.stories.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { ComponentStory } from '@storybook/react';
+import DataSourceStep from './DataSourceStep';
+import { IDataSourceStepProps } from './DataSourceStep.types';
+import { getDefaultStoryDecorator } from '../../../../../../Models/Services/StoryUtilities';
+
+const wrapperStyle = { width: '100%', height: '600px', padding: 8 };
+
+export default {
+    title: 'Components/DataSourceStep',
+    component: DataSourceStep,
+    decorators: [getDefaultStoryDecorator<IDataSourceStepProps>(wrapperStyle)]
+};
+
+type DataSourceStepStory = ComponentStory<typeof DataSourceStep>;
+
+const Template: DataSourceStepStory = (args) => {
+    return <DataSourceStep {...args} />;
+};
+
+export const Base = Template.bind({}) as DataSourceStepStory;
+Base.args = {} as IDataSourceStepProps;

--- a/src/Apps/Legion/Components/WizardShell/Internal/DataSourceStep/DataSourceStep.styles.ts
+++ b/src/Apps/Legion/Components/WizardShell/Internal/DataSourceStep/DataSourceStep.styles.ts
@@ -1,0 +1,20 @@
+import {
+    IDataSourceStepStyleProps,
+    IDataSourceStepStyles
+} from './DataSourceStep.types';
+import { CardboardClassNamePrefix } from '../../../../../../Models/Constants';
+
+const classPrefix = `${CardboardClassNamePrefix}-datasourcestep`;
+const classNames = {
+    root: `${classPrefix}-root`
+};
+
+// export const DATASOURCESTEP_CLASS_NAMES = classNames;
+export const getStyles = (
+    _props: IDataSourceStepStyleProps
+): IDataSourceStepStyles => {
+    return {
+        root: [classNames.root],
+        subComponentStyles: {}
+    };
+};

--- a/src/Apps/Legion/Components/WizardShell/Internal/DataSourceStep/DataSourceStep.tsx
+++ b/src/Apps/Legion/Components/WizardShell/Internal/DataSourceStep/DataSourceStep.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import {
+    IDataSourceStepProps,
+    IDataSourceStepStyleProps,
+    IDataSourceStepStyles
+} from './DataSourceStep.types';
+import { getStyles } from './DataSourceStep.styles';
+import { classNamesFunction, styled } from '@fluentui/react';
+import { getDebugLogger } from '../../../../../../Models/Services/Utils';
+import { useExtendedTheme } from '../../../../../../Models/Hooks/useExtendedTheme';
+
+const debugLogging = false;
+const logDebugConsole = getDebugLogger('DataSourceStep', debugLogging);
+
+const getClassNames = classNamesFunction<
+    IDataSourceStepStyleProps,
+    IDataSourceStepStyles
+>();
+
+const DataSourceStep: React.FC<IDataSourceStepProps> = (props) => {
+    const { styles } = props;
+
+    // contexts
+
+    // state
+
+    // hooks
+
+    // callbacks
+
+    // side effects
+
+    // styles
+    const classNames = getClassNames(styles, {
+        theme: useExtendedTheme()
+    });
+
+    logDebugConsole('debug', 'Render');
+
+    return <div className={classNames.root}>Hello DataSourceStep!</div>;
+};
+
+export default styled<
+    IDataSourceStepProps,
+    IDataSourceStepStyleProps,
+    IDataSourceStepStyles
+>(DataSourceStep, getStyles);

--- a/src/Apps/Legion/Components/WizardShell/Internal/DataSourceStep/DataSourceStep.types.ts
+++ b/src/Apps/Legion/Components/WizardShell/Internal/DataSourceStep/DataSourceStep.types.ts
@@ -1,0 +1,27 @@
+import { IStyle, IStyleFunctionOrObject } from '@fluentui/react';
+import { IExtendedTheme } from '../../../../../../Theming/Theme.types';
+
+export interface IDataSourceStepProps {
+    /**
+     * Call to provide customized styling that will layer on top of the variant rules.
+     */
+    styles?: IStyleFunctionOrObject<
+        IDataSourceStepStyleProps,
+        IDataSourceStepStyles
+    >;
+}
+
+export interface IDataSourceStepStyleProps {
+    theme: IExtendedTheme;
+}
+export interface IDataSourceStepStyles {
+    root: IStyle;
+
+    /**
+     * SubComponent styles.
+     */
+    subComponentStyles?: IDataSourceStepSubComponentStyles;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface IDataSourceStepSubComponentStyles {}

--- a/src/Apps/Legion/Components/WizardShell/Internal/RelationshipBuilderStep/RelationshipBuilderStep.stories.tsx
+++ b/src/Apps/Legion/Components/WizardShell/Internal/RelationshipBuilderStep/RelationshipBuilderStep.stories.tsx
@@ -7,7 +7,7 @@ import { getDefaultStoryDecorator } from '../../../../../../Models/Services/Stor
 const wrapperStyle = { width: '100%', height: '600px', padding: 8 };
 
 export default {
-    title: 'Components/RelationshipBuilderStep',
+    title: 'Components/Apps/Legion/RelationshipBuilderStep',
     component: RelationshipBuilderStep,
     decorators: [
         getDefaultStoryDecorator<IRelationshipBuilderStepProps>(wrapperStyle)

--- a/src/Apps/Legion/Components/WizardShell/Internal/RelationshipBuilderStep/RelationshipBuilderStep.stories.tsx
+++ b/src/Apps/Legion/Components/WizardShell/Internal/RelationshipBuilderStep/RelationshipBuilderStep.stories.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { ComponentStory } from '@storybook/react';
+import RelationshipBuilderStep from './RelationshipBuilderStep';
+import { IRelationshipBuilderStepProps } from './RelationshipBuilderStep.types';
+import { getDefaultStoryDecorator } from '../../../../../../Models/Services/StoryUtilities';
+
+const wrapperStyle = { width: '100%', height: '600px', padding: 8 };
+
+export default {
+    title: 'Components/RelationshipBuilderStep',
+    component: RelationshipBuilderStep,
+    decorators: [
+        getDefaultStoryDecorator<IRelationshipBuilderStepProps>(wrapperStyle)
+    ]
+};
+
+type RelationshipBuilderStepStory = ComponentStory<
+    typeof RelationshipBuilderStep
+>;
+
+const Template: RelationshipBuilderStepStory = (args) => {
+    return <RelationshipBuilderStep {...args} />;
+};
+
+export const Base = Template.bind({}) as RelationshipBuilderStepStory;
+Base.args = {} as IRelationshipBuilderStepProps;

--- a/src/Apps/Legion/Components/WizardShell/Internal/RelationshipBuilderStep/RelationshipBuilderStep.stories.tsx
+++ b/src/Apps/Legion/Components/WizardShell/Internal/RelationshipBuilderStep/RelationshipBuilderStep.stories.tsx
@@ -7,7 +7,7 @@ import { getDefaultStoryDecorator } from '../../../../../../Models/Services/Stor
 const wrapperStyle = { width: '100%', height: '600px', padding: 8 };
 
 export default {
-    title: 'Components/Apps/Legion/RelationshipBuilderStep',
+    title: 'Components/Apps/Legion/WizardShell/RelationshipBuilderStep',
     component: RelationshipBuilderStep,
     decorators: [
         getDefaultStoryDecorator<IRelationshipBuilderStepProps>(wrapperStyle)

--- a/src/Apps/Legion/Components/WizardShell/Internal/RelationshipBuilderStep/RelationshipBuilderStep.styles.ts
+++ b/src/Apps/Legion/Components/WizardShell/Internal/RelationshipBuilderStep/RelationshipBuilderStep.styles.ts
@@ -1,0 +1,20 @@
+import {
+    IRelationshipBuilderStepStyleProps,
+    IRelationshipBuilderStepStyles
+} from './RelationshipBuilderStep.types';
+import { CardboardClassNamePrefix } from '../../../../../../Models/Constants';
+
+const classPrefix = `${CardboardClassNamePrefix}-relationshipbuilderstep`;
+const classNames = {
+    root: `${classPrefix}-root`
+};
+
+// export const RELATIONSHIPBUILDERSTEP_CLASS_NAMES = classNames;
+export const getStyles = (
+    _props: IRelationshipBuilderStepStyleProps
+): IRelationshipBuilderStepStyles => {
+    return {
+        root: [classNames.root],
+        subComponentStyles: {}
+    };
+};

--- a/src/Apps/Legion/Components/WizardShell/Internal/RelationshipBuilderStep/RelationshipBuilderStep.tsx
+++ b/src/Apps/Legion/Components/WizardShell/Internal/RelationshipBuilderStep/RelationshipBuilderStep.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import {
+    IRelationshipBuilderStepProps,
+    IRelationshipBuilderStepStyleProps,
+    IRelationshipBuilderStepStyles
+} from './RelationshipBuilderStep.types';
+import { getStyles } from './RelationshipBuilderStep.styles';
+import { classNamesFunction, styled } from '@fluentui/react';
+import { getDebugLogger } from '../../../../../../Models/Services/Utils';
+import { useExtendedTheme } from '../../../../../../Models/Hooks/useExtendedTheme';
+
+const debugLogging = false;
+const logDebugConsole = getDebugLogger('RelationshipBuilderStep', debugLogging);
+
+const getClassNames = classNamesFunction<
+    IRelationshipBuilderStepStyleProps,
+    IRelationshipBuilderStepStyles
+>();
+
+const RelationshipBuilderStep: React.FC<IRelationshipBuilderStepProps> = (
+    props
+) => {
+    const { styles } = props;
+
+    // contexts
+
+    // state
+
+    // hooks
+
+    // callbacks
+
+    // side effects
+
+    // styles
+    const classNames = getClassNames(styles, {
+        theme: useExtendedTheme()
+    });
+
+    logDebugConsole('debug', 'Render');
+
+    return (
+        <div className={classNames.root}>Hello RelationshipBuilderStep!</div>
+    );
+};
+
+export default styled<
+    IRelationshipBuilderStepProps,
+    IRelationshipBuilderStepStyleProps,
+    IRelationshipBuilderStepStyles
+>(RelationshipBuilderStep, getStyles);

--- a/src/Apps/Legion/Components/WizardShell/Internal/RelationshipBuilderStep/RelationshipBuilderStep.types.ts
+++ b/src/Apps/Legion/Components/WizardShell/Internal/RelationshipBuilderStep/RelationshipBuilderStep.types.ts
@@ -1,0 +1,27 @@
+import { IStyle, IStyleFunctionOrObject } from '@fluentui/react';
+import { IExtendedTheme } from '../../../../../../Theming/Theme.types';
+
+export interface IRelationshipBuilderStepProps {
+    /**
+     * Call to provide customized styling that will layer on top of the variant rules.
+     */
+    styles?: IStyleFunctionOrObject<
+        IRelationshipBuilderStepStyleProps,
+        IRelationshipBuilderStepStyles
+    >;
+}
+
+export interface IRelationshipBuilderStepStyleProps {
+    theme: IExtendedTheme;
+}
+export interface IRelationshipBuilderStepStyles {
+    root: IStyle;
+
+    /**
+     * SubComponent styles.
+     */
+    subComponentStyles?: IRelationshipBuilderStepSubComponentStyles;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface IRelationshipBuilderStepSubComponentStyles {}

--- a/src/Apps/Legion/Components/WizardShell/Internal/SaveStep/SaveStep.stories.tsx
+++ b/src/Apps/Legion/Components/WizardShell/Internal/SaveStep/SaveStep.stories.tsx
@@ -7,7 +7,7 @@ import { getDefaultStoryDecorator } from '../../../../../../Models/Services/Stor
 const wrapperStyle = { width: '100%', height: '600px', padding: 8 };
 
 export default {
-    title: 'Components/Apps/Legion/SaveStep',
+    title: 'Components/Apps/Legion/WizardShell/SaveStep',
     component: SaveStep,
     decorators: [getDefaultStoryDecorator<ISaveStepProps>(wrapperStyle)]
 };

--- a/src/Apps/Legion/Components/WizardShell/Internal/SaveStep/SaveStep.stories.tsx
+++ b/src/Apps/Legion/Components/WizardShell/Internal/SaveStep/SaveStep.stories.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { ComponentStory } from '@storybook/react';
+import SaveStep from './SaveStep';
+import { ISaveStepProps } from './SaveStep.types';
+import { getDefaultStoryDecorator } from '../../../../../../Models/Services/StoryUtilities';
+
+const wrapperStyle = { width: '100%', height: '600px', padding: 8 };
+
+export default {
+    title: 'Components/SaveStep',
+    component: SaveStep,
+    decorators: [getDefaultStoryDecorator<ISaveStepProps>(wrapperStyle)]
+};
+
+type SaveStepStory = ComponentStory<typeof SaveStep>;
+
+const Template: SaveStepStory = (args) => {
+    return <SaveStep {...args} />;
+};
+
+export const Base = Template.bind({}) as SaveStepStory;
+Base.args = {} as ISaveStepProps;

--- a/src/Apps/Legion/Components/WizardShell/Internal/SaveStep/SaveStep.stories.tsx
+++ b/src/Apps/Legion/Components/WizardShell/Internal/SaveStep/SaveStep.stories.tsx
@@ -7,7 +7,7 @@ import { getDefaultStoryDecorator } from '../../../../../../Models/Services/Stor
 const wrapperStyle = { width: '100%', height: '600px', padding: 8 };
 
 export default {
-    title: 'Components/SaveStep',
+    title: 'Components/Apps/Legion/SaveStep',
     component: SaveStep,
     decorators: [getDefaultStoryDecorator<ISaveStepProps>(wrapperStyle)]
 };

--- a/src/Apps/Legion/Components/WizardShell/Internal/SaveStep/SaveStep.styles.ts
+++ b/src/Apps/Legion/Components/WizardShell/Internal/SaveStep/SaveStep.styles.ts
@@ -1,0 +1,15 @@
+import { ISaveStepStyleProps, ISaveStepStyles } from './SaveStep.types';
+import { CardboardClassNamePrefix } from '../../../../../../Models/Constants';
+
+const classPrefix = `${CardboardClassNamePrefix}-savestep`;
+const classNames = {
+    root: `${classPrefix}-root`
+};
+
+// export const SAVESTEP_CLASS_NAMES = classNames;
+export const getStyles = (_props: ISaveStepStyleProps): ISaveStepStyles => {
+    return {
+        root: [classNames.root],
+        subComponentStyles: {}
+    };
+};

--- a/src/Apps/Legion/Components/WizardShell/Internal/SaveStep/SaveStep.tsx
+++ b/src/Apps/Legion/Components/WizardShell/Internal/SaveStep/SaveStep.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import {
+    ISaveStepProps,
+    ISaveStepStyleProps,
+    ISaveStepStyles
+} from './SaveStep.types';
+import { getStyles } from './SaveStep.styles';
+import { classNamesFunction, styled } from '@fluentui/react';
+import { getDebugLogger } from '../../../../../../Models/Services/Utils';
+import { useExtendedTheme } from '../../../../../../Models/Hooks/useExtendedTheme';
+
+const debugLogging = false;
+const logDebugConsole = getDebugLogger('SaveStep', debugLogging);
+
+const getClassNames = classNamesFunction<
+    ISaveStepStyleProps,
+    ISaveStepStyles
+>();
+
+const SaveStep: React.FC<ISaveStepProps> = (props) => {
+    const { styles } = props;
+
+    // contexts
+
+    // state
+
+    // hooks
+
+    // callbacks
+
+    // side effects
+
+    // styles
+    const classNames = getClassNames(styles, {
+        theme: useExtendedTheme()
+    });
+
+    logDebugConsole('debug', 'Render');
+
+    return <div className={classNames.root}>Hello SaveStep!</div>;
+};
+
+export default styled<ISaveStepProps, ISaveStepStyleProps, ISaveStepStyles>(
+    SaveStep,
+    getStyles
+);

--- a/src/Apps/Legion/Components/WizardShell/Internal/SaveStep/SaveStep.types.ts
+++ b/src/Apps/Legion/Components/WizardShell/Internal/SaveStep/SaveStep.types.ts
@@ -1,0 +1,24 @@
+import { IStyle, IStyleFunctionOrObject } from '@fluentui/react';
+import { IExtendedTheme } from '../../../../../../Theming/Theme.types';
+
+export interface ISaveStepProps {
+    /**
+     * Call to provide customized styling that will layer on top of the variant rules.
+     */
+    styles?: IStyleFunctionOrObject<ISaveStepStyleProps, ISaveStepStyles>;
+}
+
+export interface ISaveStepStyleProps {
+    theme: IExtendedTheme;
+}
+export interface ISaveStepStyles {
+    root: IStyle;
+
+    /**
+     * SubComponent styles.
+     */
+    subComponentStyles?: ISaveStepSubComponentStyles;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface ISaveStepSubComponentStyles {}

--- a/src/Apps/Legion/Components/WizardShell/Internal/TwinVerificationStep/TwinVerificationStep.stories.tsx
+++ b/src/Apps/Legion/Components/WizardShell/Internal/TwinVerificationStep/TwinVerificationStep.stories.tsx
@@ -7,7 +7,7 @@ import { getDefaultStoryDecorator } from '../../../../../../Models/Services/Stor
 const wrapperStyle = { width: '100%', height: '600px', padding: 8 };
 
 export default {
-    title: 'Components/TwinVerificationStep',
+    title: 'Components/Apps/Legion/TwinVerificationStep',
     component: TwinVerificationStep,
     decorators: [
         getDefaultStoryDecorator<ITwinVerificationStepProps>(wrapperStyle)

--- a/src/Apps/Legion/Components/WizardShell/Internal/TwinVerificationStep/TwinVerificationStep.stories.tsx
+++ b/src/Apps/Legion/Components/WizardShell/Internal/TwinVerificationStep/TwinVerificationStep.stories.tsx
@@ -7,7 +7,7 @@ import { getDefaultStoryDecorator } from '../../../../../../Models/Services/Stor
 const wrapperStyle = { width: '100%', height: '600px', padding: 8 };
 
 export default {
-    title: 'Components/Apps/Legion/TwinVerificationStep',
+    title: 'Components/Apps/Legion/WizardShell/TwinVerificationStep',
     component: TwinVerificationStep,
     decorators: [
         getDefaultStoryDecorator<ITwinVerificationStepProps>(wrapperStyle)

--- a/src/Apps/Legion/Components/WizardShell/Internal/TwinVerificationStep/TwinVerificationStep.stories.tsx
+++ b/src/Apps/Legion/Components/WizardShell/Internal/TwinVerificationStep/TwinVerificationStep.stories.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { ComponentStory } from '@storybook/react';
+import TwinVerificationStep from './TwinVerificationStep';
+import { ITwinVerificationStepProps } from './TwinVerificationStep.types';
+import { getDefaultStoryDecorator } from '../../../../../../Models/Services/StoryUtilities';
+
+const wrapperStyle = { width: '100%', height: '600px', padding: 8 };
+
+export default {
+    title: 'Components/TwinVerificationStep',
+    component: TwinVerificationStep,
+    decorators: [
+        getDefaultStoryDecorator<ITwinVerificationStepProps>(wrapperStyle)
+    ]
+};
+
+type TwinVerificationStepStory = ComponentStory<typeof TwinVerificationStep>;
+
+const Template: TwinVerificationStepStory = (args) => {
+    return <TwinVerificationStep {...args} />;
+};
+
+export const Base = Template.bind({}) as TwinVerificationStepStory;
+Base.args = {} as ITwinVerificationStepProps;

--- a/src/Apps/Legion/Components/WizardShell/Internal/TwinVerificationStep/TwinVerificationStep.styles.ts
+++ b/src/Apps/Legion/Components/WizardShell/Internal/TwinVerificationStep/TwinVerificationStep.styles.ts
@@ -1,0 +1,20 @@
+import {
+    ITwinVerificationStepStyleProps,
+    ITwinVerificationStepStyles
+} from './TwinVerificationStep.types';
+import { CardboardClassNamePrefix } from '../../../../../../Models/Constants';
+
+const classPrefix = `${CardboardClassNamePrefix}-twinverificationstep`;
+const classNames = {
+    root: `${classPrefix}-root`
+};
+
+// export const TWINVERIFICATIONSTEP_CLASS_NAMES = classNames;
+export const getStyles = (
+    _props: ITwinVerificationStepStyleProps
+): ITwinVerificationStepStyles => {
+    return {
+        root: [classNames.root],
+        subComponentStyles: {}
+    };
+};

--- a/src/Apps/Legion/Components/WizardShell/Internal/TwinVerificationStep/TwinVerificationStep.tsx
+++ b/src/Apps/Legion/Components/WizardShell/Internal/TwinVerificationStep/TwinVerificationStep.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import {
+    ITwinVerificationStepProps,
+    ITwinVerificationStepStyleProps,
+    ITwinVerificationStepStyles
+} from './TwinVerificationStep.types';
+import { getStyles } from './TwinVerificationStep.styles';
+import { classNamesFunction, styled } from '@fluentui/react';
+import { getDebugLogger } from '../../../../../../Models/Services/Utils';
+import { useExtendedTheme } from '../../../../../../Models/Hooks/useExtendedTheme';
+
+const debugLogging = false;
+const logDebugConsole = getDebugLogger('TwinVerificationStep', debugLogging);
+
+const getClassNames = classNamesFunction<
+    ITwinVerificationStepStyleProps,
+    ITwinVerificationStepStyles
+>();
+
+const TwinVerificationStep: React.FC<ITwinVerificationStepProps> = (props) => {
+    const { styles } = props;
+
+    // contexts
+
+    // state
+
+    // hooks
+
+    // callbacks
+
+    // side effects
+
+    // styles
+    const classNames = getClassNames(styles, {
+        theme: useExtendedTheme()
+    });
+
+    logDebugConsole('debug', 'Render');
+
+    return <div className={classNames.root}>Hello TwinVerificationStep!</div>;
+};
+
+export default styled<
+    ITwinVerificationStepProps,
+    ITwinVerificationStepStyleProps,
+    ITwinVerificationStepStyles
+>(TwinVerificationStep, getStyles);

--- a/src/Apps/Legion/Components/WizardShell/Internal/TwinVerificationStep/TwinVerificationStep.types.ts
+++ b/src/Apps/Legion/Components/WizardShell/Internal/TwinVerificationStep/TwinVerificationStep.types.ts
@@ -1,0 +1,27 @@
+import { IStyle, IStyleFunctionOrObject } from '@fluentui/react';
+import { IExtendedTheme } from '../../../../../../Theming/Theme.types';
+
+export interface ITwinVerificationStepProps {
+    /**
+     * Call to provide customized styling that will layer on top of the variant rules.
+     */
+    styles?: IStyleFunctionOrObject<
+        ITwinVerificationStepStyleProps,
+        ITwinVerificationStepStyles
+    >;
+}
+
+export interface ITwinVerificationStepStyleProps {
+    theme: IExtendedTheme;
+}
+export interface ITwinVerificationStepStyles {
+    root: IStyle;
+
+    /**
+     * SubComponent styles.
+     */
+    subComponentStyles?: ITwinVerificationStepSubComponentStyles;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface ITwinVerificationStepSubComponentStyles {}

--- a/src/Apps/Legion/Components/WizardShell/WizardShell.stories.tsx
+++ b/src/Apps/Legion/Components/WizardShell/WizardShell.stories.tsx
@@ -3,6 +3,8 @@ import { ComponentStory } from '@storybook/react';
 import WizardShell from './WizardShell';
 import { IWizardShellProps } from './WizardShell.types';
 import { getDefaultStoryDecorator } from '../../../../Models/Services/StoryUtilities';
+import { IStepperWizardStep } from '../StepperWizard/StepperWizard.types';
+import { WizardNavigationContextProvider } from '../../Models/Context/WizardNavigationContext/WizardNavigationContext';
 
 const wrapperStyle = { width: '100%', height: '600px', padding: 8 };
 
@@ -15,7 +17,31 @@ export default {
 type WizardShellStory = ComponentStory<typeof WizardShell>;
 
 const Template: WizardShellStory = (args) => {
-    return <WizardShell {...args} />;
+    const steps: IStepperWizardStep[] = [
+        {
+            label: 'Connect'
+        },
+        {
+            label: 'Verify'
+        },
+        {
+            label: 'Build'
+        },
+        {
+            label: 'Finish'
+        }
+    ];
+
+    return (
+        <WizardNavigationContextProvider
+            initialState={{
+                steps: steps,
+                currentStep: 0
+            }}
+        >
+            <WizardShell {...args} />
+        </WizardNavigationContextProvider>
+    );
 };
 
 export const Base = Template.bind({}) as WizardShellStory;

--- a/src/Apps/Legion/Components/WizardShell/WizardShell.stories.tsx
+++ b/src/Apps/Legion/Components/WizardShell/WizardShell.stories.tsx
@@ -9,7 +9,7 @@ import { WizardNavigationContextProvider } from '../../Models/Context/WizardNavi
 const wrapperStyle = { width: '100%', height: '600px', padding: 8 };
 
 export default {
-    title: 'Components/WizardShell',
+    title: 'Components/Apps/Legion/WizardShell',
     component: WizardShell,
     decorators: [getDefaultStoryDecorator<IWizardShellProps>(wrapperStyle)]
 };

--- a/src/Apps/Legion/Components/WizardShell/WizardShell.tsx
+++ b/src/Apps/Legion/Components/WizardShell/WizardShell.tsx
@@ -1,13 +1,20 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import {
     IWizardShellProps,
     IWizardShellStyleProps,
     IWizardShellStyles
 } from './WizardShell.types';
 import { getStyles } from './WizardShell.styles';
-import { classNamesFunction, styled } from '@fluentui/react';
+import { classNamesFunction, Stack, styled } from '@fluentui/react';
 import { useExtendedTheme } from '../../../../Models/Hooks/useExtendedTheme';
 import { getDebugLogger } from '../../../../Models/Services/Utils';
+import { useWizardNavigationContext } from '../../Models/Context/WizardNavigationContext/WizardNavigationContext';
+import StepperWizard from '../StepperWizard/StepperWizard';
+import { StepperWizardType } from '../StepperWizard/StepperWizard.types';
+import DataSourceStep from './Internal/DataSourceStep/DataSourceStep';
+import TwinVerificationStep from './Internal/TwinVerificationStep/TwinVerificationStep';
+import RelationshipBuilderStep from './Internal/RelationshipBuilderStep/RelationshipBuilderStep';
+import SaveStep from './Internal/SaveStep/SaveStep';
 
 const debugLogging = false;
 const logDebugConsole = getDebugLogger('WizardShell', debugLogging);
@@ -21,6 +28,7 @@ const WizardShell: React.FC<IWizardShellProps> = (props) => {
     const { styles } = props;
 
     // contexts
+    const { wizardNavigationContextState } = useWizardNavigationContext();
 
     // state
 
@@ -35,9 +43,35 @@ const WizardShell: React.FC<IWizardShellProps> = (props) => {
         theme: useExtendedTheme()
     });
 
+    // Memo
+    const currentPage = useMemo(() => {
+        switch (wizardNavigationContextState.currentStep) {
+            // Create pages here
+            case 0:
+                return <DataSourceStep />;
+            case 1:
+                return <TwinVerificationStep />;
+            case 2:
+                return <RelationshipBuilderStep />;
+            case 3:
+                return <SaveStep />;
+        }
+    }, [wizardNavigationContextState.currentStep]);
+
     logDebugConsole('debug', 'Render');
 
-    return <div className={classNames.root}>Hello WizardShell!</div>;
+    return (
+        <div className={classNames.root}>
+            <Stack horizontal={true} tokens={{ childrenGap: 8 }}>
+                <StepperWizard
+                    steps={wizardNavigationContextState.steps}
+                    type={StepperWizardType.Vertical}
+                    currentStepIndex={wizardNavigationContextState.currentStep}
+                />
+                {currentPage}
+            </Stack>
+        </div>
+    );
 };
 
 export default styled<

--- a/src/Apps/Legion/Models/Context/WizardNavigationContext/WizardNavigationContext.tsx
+++ b/src/Apps/Legion/Models/Context/WizardNavigationContext/WizardNavigationContext.tsx
@@ -1,0 +1,83 @@
+import produce from 'immer';
+import React, { useContext, useReducer } from 'react';
+import { getDebugLogger } from '../../../../../Models/Services/Utils';
+import {
+    IWizardNavigationContext,
+    IWizardNavigationContextProviderProps,
+    IWizardNavigationContextState,
+    WizardNavigationContextAction,
+    WizardNavigationContextActionType
+} from './WizardNavigationContext.types';
+
+export const WizardNavigationContext = React.createContext<IWizardNavigationContext>(
+    null
+);
+export const useWizardNavigationContext = () =>
+    useContext(WizardNavigationContext);
+
+const debugLogging = false;
+const logDebugConsole = getDebugLogger('NavigationContext', debugLogging);
+
+export const NavigationContextReducer: (
+    draft: IWizardNavigationContextState,
+    action: WizardNavigationContextAction
+) => any = produce((draft, action) => {
+    logDebugConsole(
+        'info',
+        `Updating Navigation context ${action.type} with payload: `,
+        action.payload
+    );
+    switch (action.type) {
+        case WizardNavigationContextActionType.SET_STEPS:
+            draft.steps = action.payload.steps;
+            break;
+        case WizardNavigationContextActionType.NAVIGATE_TO:
+            draft.currentStep = action.payload.stepNumber;
+            break;
+    }
+});
+
+export const WizardNavigationContextProvider: React.FC<IWizardNavigationContextProviderProps> = (
+    props
+) => {
+    const { children, initialState } = props;
+
+    const [
+        wizardNavigationContextState,
+        wizardNavigationContextDispatch
+    ] = useReducer(
+        NavigationContextReducer,
+        { ...emptyState, ...initialState },
+        getInitialState
+    );
+
+    return (
+        <WizardNavigationContext.Provider
+            value={{
+                wizardNavigationContextState: wizardNavigationContextState,
+                wizardNavigationContextDispatch: wizardNavigationContextDispatch
+            }}
+        >
+            {children}
+        </WizardNavigationContext.Provider>
+    );
+};
+
+const emptyState: IWizardNavigationContextState = {
+    steps: [],
+    currentStep: -1
+};
+
+export const getInitialState = (
+    initialState?: IWizardNavigationContextState
+) => {
+    const state: IWizardNavigationContextState = {
+        steps: [],
+        currentStep: -1,
+        ...initialState
+    };
+
+    logDebugConsole('debug', 'Initialized context state. {state}', state);
+
+    return state;
+};

--- a/src/Apps/Legion/Models/Context/WizardNavigationContext/WizardNavigationContext.types.ts
+++ b/src/Apps/Legion/Models/Context/WizardNavigationContext/WizardNavigationContext.types.ts
@@ -1,0 +1,37 @@
+import React from 'react';
+import { IStepperWizardStep } from '../../../../../Components/StepperWizard/StepperWizard.types';
+
+// Context types
+export interface IWizardNavigationContext {
+    wizardNavigationContextState: IWizardNavigationContextState;
+    wizardNavigationContextDispatch: React.Dispatch<WizardNavigationContextAction>;
+}
+
+export interface IWizardNavigationContextState {
+    steps: Array<IStepperWizardStep>;
+    currentStep: number;
+}
+
+export enum WizardNavigationContextActionType {
+    SET_STEPS = 'SET_STEPS',
+    NAVIGATE_TO = 'NAVIGATE_TO'
+}
+
+export type WizardNavigationContextAction =
+    | {
+          type: WizardNavigationContextActionType.NAVIGATE_TO;
+          payload: {
+              stepNumber: number;
+          };
+      }
+    | {
+          type: WizardNavigationContextActionType.SET_STEPS;
+          payload: {
+              steps: Array<IStepperWizardStep>;
+          };
+      };
+
+// Provider types
+export interface IWizardNavigationContextProviderProps {
+    initialState?: Partial<IWizardNavigationContextState>;
+}


### PR DESCRIPTION
### Summary of changes 🔍 
Added WizardShell component to allow users to navigate to all 4 screens planned:
- Data source connector
- Twin verification
- Relationship builder
- Save

*Also added the skeleton component for each one of those screens/steps.

Modified `StepperWizard` component to allow navigation to be controlled by context, added this component to the Legion folder because more changes are planned for it.

### Testing 🧪
Open Storybook and take a look at `WizardShell` stories to see how navigation with stepper component works.

### Checklist ✔️
- [ ] Linked associated issue (if present)
- [ ] Added relevant labels
- [ ] Requested developer reviews
- [ ] Request UI review from design / PM
- [ ] Verify all code checks are passing