### PR TITLE
Create wrapper on react-select with some defaults

### DIFF
--- a/src/Apps/Legion/Components/CarboardCreatableSelect/CarboardCreatableSelect.stories.tsx
+++ b/src/Apps/Legion/Components/CarboardCreatableSelect/CarboardCreatableSelect.stories.tsx
@@ -1,0 +1,92 @@
+/* eslint-disable no-console */
+import React from 'react';
+import { ComponentStory } from '@storybook/react';
+import { getDefaultStoryDecorator } from '../../../../Models/Services/StoryUtilities';
+import CarboardCreatableSelect from './CarboardCreatableSelect';
+import { ICarboardCreatableSelectProps } from './CarboardCreatableSelect.types';
+import { IReactSelectOption } from '../../Models';
+
+const wrapperStyle = { width: '500px', height: '600px', padding: 8 };
+
+export default {
+    title: 'Components/CarboardCreatableSelect',
+    component: CarboardCreatableSelect,
+    decorators: [
+        getDefaultStoryDecorator<ICarboardCreatableSelectProps<IListItem>>(
+            wrapperStyle
+        )
+    ]
+};
+
+type IListItem = IReactSelectOption;
+
+type CarboardCreatableSelectStory = ComponentStory<
+    typeof CarboardCreatableSelect
+>;
+
+const Template: CarboardCreatableSelectStory = (args) => {
+    return <CarboardCreatableSelect {...args} />;
+};
+
+const defaultProps: Partial<ICarboardCreatableSelectProps<IListItem>> = {
+    label: 'My picker',
+    onSelectionChange: (item, isNew) => {
+        console.log('Selection made. {item, isNew}', item, isNew);
+    },
+    options: [
+        {
+            label: 'option 1',
+            value: '1',
+            __isNew__: false
+        },
+        {
+            label: 'option 2',
+            value: '2',
+            __isNew__: false
+        },
+        {
+            label: 'option 3',
+            value: '3',
+            __isNew__: false
+        }
+    ],
+    placeholder: 'Select a value',
+    selectedItem: undefined,
+    required: true
+};
+
+export const Base = Template.bind({}) as CarboardCreatableSelectStory;
+Base.args = {
+    ...defaultProps
+} as ICarboardCreatableSelectProps<IListItem>;
+
+export const WithSelection = Template.bind({}) as CarboardCreatableSelectStory;
+WithSelection.args = {
+    ...defaultProps,
+    selectedItem: defaultProps.options[1]
+} as ICarboardCreatableSelectProps<IListItem>;
+
+export const WithTooltip = Template.bind({}) as CarboardCreatableSelectStory;
+WithTooltip.args = {
+    ...defaultProps,
+    tooltip: {
+        content: {
+            calloutContent: 'message blurb goes here'
+        }
+    }
+} as ICarboardCreatableSelectProps<IListItem>;
+
+export const Description = Template.bind({}) as CarboardCreatableSelectStory;
+Description.args = {
+    ...defaultProps,
+    description: 'Message here'
+} as ICarboardCreatableSelectProps<IListItem>;
+
+export const DescriptionError = Template.bind(
+    {}
+) as CarboardCreatableSelectStory;
+DescriptionError.args = {
+    ...defaultProps,
+    description: 'Error message here',
+    descriptionIsError: true
+} as ICarboardCreatableSelectProps<IListItem>;

--- a/src/Apps/Legion/Components/CarboardCreatableSelect/CarboardCreatableSelect.stories.tsx
+++ b/src/Apps/Legion/Components/CarboardCreatableSelect/CarboardCreatableSelect.stories.tsx
@@ -9,7 +9,7 @@ import { IReactSelectOption } from '../../Models';
 const wrapperStyle = { width: '500px', height: '600px', padding: 8 };
 
 export default {
-    title: 'Components/CarboardCreatableSelect',
+    title: 'Apps/Legion/Components/CarboardCreatableSelect',
     component: CarboardCreatableSelect,
     decorators: [
         getDefaultStoryDecorator<ICarboardCreatableSelectProps<IListItem>>(

--- a/src/Apps/Legion/Components/CarboardCreatableSelect/CarboardCreatableSelect.styles.ts
+++ b/src/Apps/Legion/Components/CarboardCreatableSelect/CarboardCreatableSelect.styles.ts
@@ -9,9 +9,13 @@ export const getStyles = memoizeFunction(
                 marginLeft: 4
             },
             description: [
-                isDescriptionError && {
-                    color: theme.semanticColors.errorText
-                },
+                isDescriptionError
+                    ? {
+                          color: theme.semanticColors.errorText
+                      }
+                    : {
+                          color: theme.semanticColors.inputBorder
+                      },
                 {
                     marginTop: '5px !important', // 5 is what Fluent has so going with it
                     marginLeft: 4

--- a/src/Apps/Legion/Components/CarboardCreatableSelect/CarboardCreatableSelect.styles.ts
+++ b/src/Apps/Legion/Components/CarboardCreatableSelect/CarboardCreatableSelect.styles.ts
@@ -1,0 +1,22 @@
+import { ICarboardCreatableSelectStyleProps } from './CarboardCreatableSelect.types';
+import { IStyle, memoizeFunction, mergeStyleSets } from '@fluentui/react';
+
+export const getStyles = memoizeFunction(
+    (props: ICarboardCreatableSelectStyleProps) => {
+        const { isDescriptionError, theme } = props;
+        return mergeStyleSets({
+            label: {
+                marginLeft: 4
+            },
+            description: [
+                isDescriptionError && {
+                    color: theme.semanticColors.errorText
+                },
+                {
+                    marginTop: '5px !important', // 5 is what Fluent has so going with it
+                    marginLeft: 4
+                }
+            ] as IStyle[]
+        });
+    }
+);

--- a/src/Apps/Legion/Components/CarboardCreatableSelect/CarboardCreatableSelect.tsx
+++ b/src/Apps/Legion/Components/CarboardCreatableSelect/CarboardCreatableSelect.tsx
@@ -1,0 +1,109 @@
+import React, {
+    ReactNode,
+    useCallback,
+    useEffect,
+    useMemo,
+    useState
+} from 'react';
+import { Label, Stack, Text } from '@fluentui/react';
+import { useId } from '@fluentui/react-hooks';
+import CreatableSelect from 'react-select/creatable';
+import { ActionMeta, MultiValue, SingleValue } from 'react-select';
+import { useExtendedTheme } from '../../../../Models/Hooks/useExtendedTheme';
+import { getDebugLogger } from '../../../../Models/Services/Utils';
+import { ICarboardCreatableSelectProps } from './CarboardCreatableSelect.types';
+import { IReactSelectOption } from '../../Models';
+import { getReactSelectStyles } from '../../../../Resources/Styles/ReactSelect.styles';
+import { getStyles } from './CarboardCreatableSelect.styles';
+import TooltipCallout from '../../../../Components/TooltipCallout/TooltipCallout';
+
+const debugLogging = false;
+const logDebugConsole = getDebugLogger('CarboardCreatableSelect', debugLogging);
+
+const CarboardCreatableSelect = <T extends IReactSelectOption>(
+    props: ICarboardCreatableSelectProps<T> & { children?: ReactNode }
+) => {
+    const {
+        description,
+        descriptionIsError = false,
+        label,
+        options: optionsProp,
+        onSelectionChange,
+        placeholder,
+        required,
+        selectedItem,
+        tooltip
+    } = props;
+
+    // contexts
+
+    // state
+    const [options, setOptions] = useState<T[]>(optionsProp);
+
+    // hooks
+    const id = useId('creatable-select');
+
+    // callbacks
+    const onChange = useCallback(
+        (
+            selection: MultiValue<T> | SingleValue<T>,
+            actionMeta: ActionMeta<T>
+        ) => {
+            // cast is safe here because `SingleValue` is just an alias to `T` which is what our options are
+            const localOption = selection as T;
+            const isCreate = actionMeta.action === 'create-option';
+            onSelectionChange(localOption, isCreate);
+            if (isCreate) {
+                setOptions((draft) => {
+                    draft.push(localOption);
+                    return draft;
+                });
+            }
+        },
+        [onSelectionChange]
+    );
+
+    // side effects
+    useEffect(() => {
+        setOptions(optionsProp);
+    }, [optionsProp]);
+
+    // styles
+    const theme = useExtendedTheme();
+    const classNames = getStyles({
+        theme,
+        isDescriptionError: descriptionIsError
+    });
+    const selectStyles = useMemo(() => getReactSelectStyles<T>(theme, {}), [
+        theme
+    ]);
+
+    logDebugConsole('debug', 'Render');
+
+    return (
+        <Stack>
+            <Stack horizontal verticalAlign={'center'}>
+                <Label id={id} required={required} className={classNames.label}>
+                    {label}
+                </Label>
+                {tooltip && <TooltipCallout {...tooltip} />}
+            </Stack>
+            <CreatableSelect
+                {...props}
+                aria-aria-labelledby={id}
+                onChange={onChange}
+                options={options}
+                placeholder={placeholder}
+                styles={selectStyles}
+                value={selectedItem}
+            />
+            {description && (
+                <Text variant={'small'} className={classNames.description}>
+                    {description}
+                </Text>
+            )}
+        </Stack>
+    );
+};
+
+export default CarboardCreatableSelect;

--- a/src/Apps/Legion/Components/CarboardCreatableSelect/CarboardCreatableSelect.types.ts
+++ b/src/Apps/Legion/Components/CarboardCreatableSelect/CarboardCreatableSelect.types.ts
@@ -1,0 +1,34 @@
+import { IExtendedTheme } from '../../../../Theming/Theme.types';
+import { CreatableProps } from 'react-select/creatable';
+import { GroupBase } from 'react-select';
+import { IReactSelectOption } from '../../Models';
+import { ITooltipCalloutProps } from '../../../../Components/TooltipCallout/TooltipCallout.types';
+
+export type CreatableInternalProps<T> = Omit<
+    CreatableProps<T, boolean, GroupBase<T>>,
+    'options' | 'styles'
+>;
+export interface ICarboardCreatableSelectProps<T extends IReactSelectOption>
+    extends CreatableInternalProps<T> {
+    /** text below the dropdown */
+    description?: string;
+    /** indicates that the text under the dropdown is an error so it shows as red */
+    descriptionIsError?: boolean;
+    /** text above the dropdown */
+    label: string;
+    /** callback when selection changes */
+    onSelectionChange: (item: T, isNew: boolean) => void;
+    options: T[];
+    /** placeholder text inside the control before a selection is made */
+    placeholder: string;
+    /** is the field required? Shows the red * in the label */
+    required?: boolean;
+    /** the item to use as the selected item */
+    selectedItem: T | undefined;
+    tooltip?: ITooltipCalloutProps;
+}
+
+export interface ICarboardCreatableSelectStyleProps {
+    theme: IExtendedTheme;
+    isDescriptionError: boolean;
+}

--- a/src/Apps/Legion/Contexts/WizardDataContext/WizardDataContext.tsx
+++ b/src/Apps/Legion/Contexts/WizardDataContext/WizardDataContext.tsx
@@ -122,9 +122,7 @@ export const WizardDataContextReducer: (
 );
 
 export const WizardDataContextProvider = React.memo(
-    <T extends object>(
-        props: IWizardDataContextProviderProps<T> & { children?: ReactNode }
-    ) => {
+    (props: IWizardDataContextProviderProps & { children?: ReactNode }) => {
         const { children, initialState } = props;
 
         const [state, dispatch] = useReducer(WizardDataContextReducer, {

--- a/src/Apps/Legion/Models/Types.ts
+++ b/src/Apps/Legion/Models/Types.ts
@@ -1,3 +1,10 @@
 import { IModelProperty } from './Interfaces';
 
 export type ICookProperty = Pick<IModelProperty, 'name' | 'dataType'>;
+
+/** type definition for an option provided to a React-select component */
+export interface IReactSelectOption {
+    value: string;
+    label: string;
+    __isNew__?: boolean;
+}

--- a/src/Resources/Styles/ReactSelect.styles.ts
+++ b/src/Resources/Styles/ReactSelect.styles.ts
@@ -1,7 +1,7 @@
 import { FontSizes, ITheme } from '@fluentui/react';
 import { StylesConfig } from 'react-select';
 
-const getBaseReactSelectStyles = (theme: ITheme): StylesConfig => {
+function getBaseReactSelectStyles<T>(theme: ITheme): StylesConfig<T> {
     return {
         container: (provided) => ({
             ...provided,
@@ -34,7 +34,7 @@ const getBaseReactSelectStyles = (theme: ITheme): StylesConfig => {
             color: theme.semanticColors.inputText
         })
     };
-};
+}
 
 export function getReactSelectStyles<T>(
     theme: ITheme,
@@ -56,7 +56,7 @@ export function getReactSelectStyles<T>(
     const menu = params?.menu;
     const menuList = params?.menuList;
     return {
-        ...getBaseReactSelectStyles(theme),
+        ...getBaseReactSelectStyles<T>(theme),
         control: (provided, state) => ({
             ...provided,
             backgroundColor: theme.semanticColors.inputBackground,

--- a/src/Resources/Styles/ReactSelect.styles.ts
+++ b/src/Resources/Styles/ReactSelect.styles.ts
@@ -36,7 +36,7 @@ const getBaseReactSelectStyles = (theme: ITheme): StylesConfig => {
     };
 };
 
-export const getReactSelectStyles = (
+export function getReactSelectStyles<T>(
     theme: ITheme,
     params?: {
         menu?: {
@@ -52,7 +52,7 @@ export const getReactSelectStyles = (
             listMaxWidthCompact: number;
         };
     }
-): StylesConfig => {
+): StylesConfig<T> {
     const menu = params?.menu;
     const menuList = params?.menuList;
     return {
@@ -130,7 +130,7 @@ export const getReactSelectStyles = (
             }
         })
     };
-};
+}
 
 export const getMultiSelectStyles = (theme: ITheme): StylesConfig => {
     return {


### PR DESCRIPTION
### Summary of changes 🔍 
We keep having to add labels and such to the React-Select component so I thought I would create a wrapper that exposes all the same props but does some of the boilerplate for us.

![image](https://user-images.githubusercontent.com/57726991/232926749-f330a396-0950-4f30-9ec7-b03561107d8d.png)

With tooltip
![image](https://user-images.githubusercontent.com/57726991/232926788-532f9f88-af47-49a3-a0d3-05c50ef9f2df.png)

With error message
![image](https://user-images.githubusercontent.com/57726991/232926810-76f33781-c15b-4e03-bbd0-c4526866aa99.png)


### Testing 🧪
?path=/story/apps-legion-components-carboardcreatableselect--base