### PR TITLE
[SceneViewer - Globe]: Public resources link fix

### DIFF
--- a/src/Models/Constants/Constants.ts
+++ b/src/Models/Constants/Constants.ts
@@ -371,7 +371,7 @@ export const intellisenseMultilineBreakpoint = 40;
 export const CardboardClassNamePrefix = 'cb';
 
 export const globeUrl =
-    'https://cardboardresources.blob.core.windows.net/public/Globe.glb';
+    'https://iotcardboardjsresources.blob.core.windows.net/public/Globe.glb';
 
 export const DTDLPropertyIconographyMap = {
     boolean: {


### PR DESCRIPTION
### Summary of changes 🔍 
- Fixed the link to the right public cardboard resources storage which was causing a CORS error for a customer with the old link which does not support the prod domain


### Testing 🧪
Select the "Globe View" in any 3d scene page
<img width="899" alt="image" src="https://github.com/microsoft/iot-cardboard-js/assets/45217314/4cc259e7-d892-41e1-b79d-a46cc671053a">


### Checklist ✔️
- [ ] Linked associated issue (if present)
- [x] Added relevant labels
- [x] Requested developer reviews
- [ ] Request UI review from design / PM
- [x] Verify all code checks are passing