### PR TITLE
[Data History Widget]: Label fix in "View" mode

### DIFF
--- a/src/Components/BehaviorsModal/Internal/Widgets/DataHistoryWidget/DataHistoryWidget.tsx
+++ b/src/Components/BehaviorsModal/Internal/Widgets/DataHistoryWidget/DataHistoryWidget.tsx
@@ -25,7 +25,6 @@ import {
     TimeSeriesData
 } from '../../../../../Models/Constants';
 import { useTimeSeriesData } from '../../../../../Models/Hooks/useTimeSeriesData';
-import { createGUID } from '../../../../../Models/Services/Utils';
 import {
     getMockTimeSeriesDataArrayInLocalTime,
     getQuickTimeSpanKeyByValue,

--- a/src/Components/BehaviorsModal/Internal/Widgets/DataHistoryWidget/DataHistoryWidget.tsx
+++ b/src/Components/BehaviorsModal/Internal/Widgets/DataHistoryWidget/DataHistoryWidget.tsx
@@ -285,7 +285,7 @@ const getTwinIdPropertyMap = (
                   const [alias, ...propertyPath] = splittedArray;
                   if (twins && alias?.length && propertyPath?.length) {
                       return {
-                          seriesId: createGUID(),
+                          seriesId: ts.id,
                           label: ts.label,
                           twinId: twins[alias]?.$dtId,
                           twinPropertyName: propertyPath.join('.'),


### PR DESCRIPTION
### Summary of changes 🔍 
Fixed series id inconsistency with fetched data due to creating a new guid in component lifecycle. It was a bug reported by a customer by not seeing the label of time series correctly in a data history widget in view mode. As a fix, I set the `seriesId` of the time series to the id of the data history time series in the 3d config file for consistent id mapping:

<img width="559" alt="image" src="https://github.com/microsoft/iot-cardboard-js/assets/45217314/46a457f2-3ac7-46a6-b751-a7aad8efa6bf">

![image](https://github.com/microsoft/iot-cardboard-js/assets/45217314/a3f2d69a-483a-4a28-9ab1-b8fa1ffc74ac)

with fix:
<img width="428" alt="image" src="https://github.com/microsoft/iot-cardboard-js/assets/45217314/bbb400e3-9d0d-46fe-a549-b1f2cd152634">
![image](https://github.com/microsoft/iot-cardboard-js/assets/45217314/29335280-615e-4560-a976-20a8c6e8524d)

### Testing 🧪
You can test it by creating a data history widget with a time series with a label and see it in View mode using ADT3DScenePage story.

### Checklist ✔️
- [ ] Linked associated issue (if present)
- [x] Added relevant labels
- [x] Requested developer reviews
- [ ] Request UI review from design / PM
- [x] Verify all code checks are passing