### PR TITLE
[Fix] Allow hypen inclusive Kusto table names

### DIFF
--- a/src/Models/Hooks/useTimeSeriesData.ts
+++ b/src/Models/Hooks/useTimeSeriesData.ts
@@ -170,7 +170,7 @@ const getBulkADXQueryFromTimeSeriesTwins = (
 
     try {
         twins?.forEach((twin, idx) => {
-            query += `${connection.kustoTableName} | where TimeStamp > ago(${agoTimeInMillis}ms)`;
+            query += `['${connection.kustoTableName}'] | where TimeStamp > ago(${agoTimeInMillis}ms)`;
             query += ` | where Id == '${twin.twinId}' and Key == '${twin.twinPropertyName}'`;
             query +=
                 queryOptions?.shouldCastToDouble ??


### PR DESCRIPTION
### Summary of changes 🔍 
Allows hyphen inclusive Kusto table names to be permitted. i.e. table-name will now be ['table-name'].


### Testing 🧪
N/A

### Checklist ✔️
- [x] Linked associated issue (if present)
- [x] Added relevant labels
- [x] Requested developer reviews
- [x] Request UI review from design / PM
- [x] Verify all code checks are passing