### PR TITLE
feat: Bump Axios to 0.28.0 and es5-ext to 0.10.63

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@types/react-transition-group": "^4.4.2",
         "@web3-storage/parse-link-header": "^3.1.0",
         "ajv": "^8.10.0",
-        "axios": "^0.21.1",
+        "axios": "^0.28.0",
         "axios-retry": "^3.1.9",
         "azure-iot-dtdl-parser": "^0.0.1-beta.0",
         "constantinople": "^4.0.1",
@@ -2629,6 +2629,15 @@
       },
       "engines": {
         "node": ">=8.3.0"
+      }
+    },
+    "node_modules/@chromaui/localtunnel/node_modules/axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "dev": true,
+      "dependencies": {
+        "follow-redirects": "^1.14.0"
       }
     },
     "node_modules/@cnakazawa/watch": {
@@ -14501,7 +14510,6 @@
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/at-least-node": {
@@ -14625,11 +14633,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.28.1.tgz",
+      "integrity": "sha512-iUcGA5a7p0mVb4Gm/sy+FSECNkPFT4y7wt6OM/CDpO/OnNCvSs3PoMG8ibrC9jRoGYU0gUK5pXVC4NPXq6lHRQ==",
       "dependencies": {
-        "follow-redirects": "^1.14.0"
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axios-retry": {
@@ -14637,6 +14647,19 @@
       "license": "Apache-2.0",
       "dependencies": {
         "is-retry-allowed": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/azure-iot-dtdl-parser": {
@@ -16172,21 +16195,6 @@
         "node": ">=0.10"
       }
     },
-    "node_modules/cli-color/node_modules/es5-ext": {
-      "version": "0.10.53",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
-      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
-      "dependencies": {
-        "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.3",
-        "next-tick": "~1.0.0"
-      }
-    },
-    "node_modules/cli-color/node_modules/next-tick": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-      "integrity": "sha512-mc/caHeUcdjnC/boPWJefDr4KUIWQNv+tlnFnJd38QMou86QtxQzBJfxgGRzvx8jazYRqrVlaHarfO72uNxPOg=="
-    },
     "node_modules/cli-cursor": {
       "version": "2.1.0",
       "dev": true,
@@ -16443,7 +16451,6 @@
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -17377,21 +17384,6 @@
         "type": "^1.0.1"
       }
     },
-    "node_modules/d/node_modules/es5-ext": {
-      "version": "0.10.53",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
-      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
-      "dependencies": {
-        "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.3",
-        "next-tick": "~1.0.0"
-      }
-    },
-    "node_modules/d/node_modules/next-tick": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-      "integrity": "sha512-mc/caHeUcdjnC/boPWJefDr4KUIWQNv+tlnFnJd38QMou86QtxQzBJfxgGRzvx8jazYRqrVlaHarfO72uNxPOg=="
-    },
     "node_modules/d3": {
       "version": "5.16.0",
       "resolved": "https://registry.npmjs.org/d3/-/d3-5.16.0.tgz",
@@ -17991,7 +17983,6 @@
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -18681,6 +18672,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es5-ext": {
+      "version": "0.10.63",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.63.tgz",
+      "integrity": "sha512-hUCZd2Byj/mNKjfP9jXrdVZ62B8KuA/VoK7X8nUh5qT+AxDmcbvZz041oDVZdbIN1qW6XY9VDNwzkvKnZvK2TQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.3",
+        "esniff": "^2.0.1",
+        "next-tick": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/es6-iterator": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
@@ -18690,21 +18696,6 @@
         "es5-ext": "^0.10.35",
         "es6-symbol": "^3.1.1"
       }
-    },
-    "node_modules/es6-iterator/node_modules/es5-ext": {
-      "version": "0.10.53",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
-      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
-      "dependencies": {
-        "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.3",
-        "next-tick": "~1.0.0"
-      }
-    },
-    "node_modules/es6-iterator/node_modules/next-tick": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-      "integrity": "sha512-mc/caHeUcdjnC/boPWJefDr4KUIWQNv+tlnFnJd38QMou86QtxQzBJfxgGRzvx8jazYRqrVlaHarfO72uNxPOg=="
     },
     "node_modules/es6-promise": {
       "version": "3.3.1",
@@ -18730,21 +18721,6 @@
         "es6-iterator": "^2.0.3",
         "es6-symbol": "^3.1.1"
       }
-    },
-    "node_modules/es6-weak-map/node_modules/es5-ext": {
-      "version": "0.10.53",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
-      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
-      "dependencies": {
-        "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.3",
-        "next-tick": "~1.0.0"
-      }
-    },
-    "node_modules/es6-weak-map/node_modules/next-tick": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-      "integrity": "sha512-mc/caHeUcdjnC/boPWJefDr4KUIWQNv+tlnFnJd38QMou86QtxQzBJfxgGRzvx8jazYRqrVlaHarfO72uNxPOg=="
     },
     "node_modules/esbuild": {
       "version": "0.18.20",
@@ -19619,6 +19595,25 @@
         "node": ">=6"
       }
     },
+    "node_modules/esniff": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
+      "integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
+      "dependencies": {
+        "d": "^1.0.1",
+        "es5-ext": "^0.10.62",
+        "event-emitter": "^0.3.5",
+        "type": "^2.7.2"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esniff/node_modules/type": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/type/-/type-2.7.3.tgz",
+      "integrity": "sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ=="
+    },
     "node_modules/espree": {
       "version": "9.4.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
@@ -19741,21 +19736,6 @@
         "d": "1",
         "es5-ext": "~0.10.14"
       }
-    },
-    "node_modules/event-emitter/node_modules/es5-ext": {
-      "version": "0.10.53",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
-      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
-      "dependencies": {
-        "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.3",
-        "next-tick": "~1.0.0"
-      }
-    },
-    "node_modules/event-emitter/node_modules/next-tick": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-      "integrity": "sha512-mc/caHeUcdjnC/boPWJefDr4KUIWQNv+tlnFnJd38QMou86QtxQzBJfxgGRzvx8jazYRqrVlaHarfO72uNxPOg=="
     },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
@@ -25982,21 +25962,6 @@
         "es5-ext": "~0.10.2"
       }
     },
-    "node_modules/lru-queue/node_modules/es5-ext": {
-      "version": "0.10.53",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
-      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
-      "dependencies": {
-        "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.3",
-        "next-tick": "~1.0.0"
-      }
-    },
-    "node_modules/lru-queue/node_modules/next-tick": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-      "integrity": "sha512-mc/caHeUcdjnC/boPWJefDr4KUIWQNv+tlnFnJd38QMou86QtxQzBJfxgGRzvx8jazYRqrVlaHarfO72uNxPOg=="
-    },
     "node_modules/lz-string": {
       "version": "1.4.4",
       "dev": true,
@@ -26307,21 +26272,6 @@
         "timers-ext": "^0.1.7"
       }
     },
-    "node_modules/memoizee/node_modules/es5-ext": {
-      "version": "0.10.53",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
-      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
-      "dependencies": {
-        "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.3",
-        "next-tick": "~1.0.0"
-      }
-    },
-    "node_modules/memoizee/node_modules/es5-ext/node_modules/next-tick": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-      "integrity": "sha512-mc/caHeUcdjnC/boPWJefDr4KUIWQNv+tlnFnJd38QMou86QtxQzBJfxgGRzvx8jazYRqrVlaHarfO72uNxPOg=="
-    },
     "node_modules/memoizerific": {
       "version": "1.11.3",
       "dev": true,
@@ -26448,7 +26398,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -26457,7 +26406,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -29397,8 +29345,7 @@
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/psl": {
       "version": "1.8.0",
@@ -33870,16 +33817,6 @@
         "next-tick": "1"
       }
     },
-    "node_modules/timers-ext/node_modules/es5-ext": {
-      "version": "0.10.53",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
-      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
-      "dependencies": {
-        "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.3",
-        "next-tick": "~1.0.0"
-      }
-    },
     "node_modules/timers-ext/node_modules/next-tick": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
@@ -37337,6 +37274,17 @@
         "debug": "4.3.1",
         "openurl": "1.1.1",
         "yargs": "16.2.0"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.21.4",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+          "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+          "dev": true,
+          "requires": {
+            "follow-redirects": "1.15.6"
+          }
+        }
       }
     },
     "@cnakazawa/watch": {
@@ -45677,8 +45625,7 @@
       }
     },
     "asynckit": {
-      "version": "0.4.0",
-      "dev": true
+      "version": "0.4.0"
     },
     "at-least-node": {
       "version": "1.0.0",
@@ -45750,11 +45697,25 @@
       "dev": true
     },
     "axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.28.1.tgz",
+      "integrity": "sha512-iUcGA5a7p0mVb4Gm/sy+FSECNkPFT4y7wt6OM/CDpO/OnNCvSs3PoMG8ibrC9jRoGYU0gUK5pXVC4NPXq6lHRQ==",
       "requires": {
-        "follow-redirects": "1.15.6"
+        "follow-redirects": "1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
       }
     },
     "axios-retry": {
@@ -46835,27 +46796,10 @@
       "integrity": "sha512-eBbxZF6fqPUNnf7CLAFOersUnyYzv83tHFLSlts+OAHsNendaqv2tHCq+/MO+b3Y+9JeoUlIvobyxG/Z8GNeOg==",
       "requires": {
         "d": "^1.0.1",
-        "es5-ext": "0.10.53",
+        "es5-ext": "0.10.63",
         "es6-iterator": "^2.0.3",
         "memoizee": "^0.4.15",
         "timers-ext": "^0.1.7"
-      },
-      "dependencies": {
-        "es5-ext": {
-          "version": "0.10.53",
-          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
-          "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
-          "requires": {
-            "es6-iterator": "~2.0.3",
-            "es6-symbol": "~3.1.3",
-            "next-tick": "~1.0.0"
-          }
-        },
-        "next-tick": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-          "integrity": "sha512-mc/caHeUcdjnC/boPWJefDr4KUIWQNv+tlnFnJd38QMou86QtxQzBJfxgGRzvx8jazYRqrVlaHarfO72uNxPOg=="
-        }
       }
     },
     "cli-cursor": {
@@ -47031,7 +46975,6 @@
     },
     "combined-stream": {
       "version": "1.0.8",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -47683,25 +47626,8 @@
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
       "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
       "requires": {
-        "es5-ext": "0.10.53",
+        "es5-ext": "0.10.63",
         "type": "^1.0.1"
-      },
-      "dependencies": {
-        "es5-ext": {
-          "version": "0.10.53",
-          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
-          "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
-          "requires": {
-            "es6-iterator": "~2.0.3",
-            "es6-symbol": "~3.1.3",
-            "next-tick": "~1.0.0"
-          }
-        },
-        "next-tick": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-          "integrity": "sha512-mc/caHeUcdjnC/boPWJefDr4KUIWQNv+tlnFnJd38QMou86QtxQzBJfxgGRzvx8jazYRqrVlaHarfO72uNxPOg=="
-        }
       }
     },
     "d3": {
@@ -48190,8 +48116,7 @@
       }
     },
     "delayed-stream": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "depd": {
       "version": "2.0.0",
@@ -48696,31 +48621,25 @@
         "is-symbol": "^1.0.2"
       }
     },
+    "es5-ext": {
+      "version": "0.10.63",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.63.tgz",
+      "integrity": "sha512-hUCZd2Byj/mNKjfP9jXrdVZ62B8KuA/VoK7X8nUh5qT+AxDmcbvZz041oDVZdbIN1qW6XY9VDNwzkvKnZvK2TQ==",
+      "requires": {
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.3",
+        "esniff": "^2.0.1",
+        "next-tick": "^1.1.0"
+      }
+    },
     "es6-iterator": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "requires": {
         "d": "1",
-        "es5-ext": "0.10.53",
+        "es5-ext": "0.10.63",
         "es6-symbol": "^3.1.1"
-      },
-      "dependencies": {
-        "es5-ext": {
-          "version": "0.10.53",
-          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
-          "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
-          "requires": {
-            "es6-iterator": "~2.0.3",
-            "es6-symbol": "~3.1.3",
-            "next-tick": "~1.0.0"
-          }
-        },
-        "next-tick": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-          "integrity": "sha512-mc/caHeUcdjnC/boPWJefDr4KUIWQNv+tlnFnJd38QMou86QtxQzBJfxgGRzvx8jazYRqrVlaHarfO72uNxPOg=="
-        }
       }
     },
     "es6-promise": {
@@ -48743,26 +48662,9 @@
       "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
       "requires": {
         "d": "1",
-        "es5-ext": "0.10.53",
+        "es5-ext": "0.10.63",
         "es6-iterator": "^2.0.3",
         "es6-symbol": "^3.1.1"
-      },
-      "dependencies": {
-        "es5-ext": {
-          "version": "0.10.53",
-          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
-          "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
-          "requires": {
-            "es6-iterator": "~2.0.3",
-            "es6-symbol": "~3.1.3",
-            "next-tick": "~1.0.0"
-          }
-        },
-        "next-tick": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-          "integrity": "sha512-mc/caHeUcdjnC/boPWJefDr4KUIWQNv+tlnFnJd38QMou86QtxQzBJfxgGRzvx8jazYRqrVlaHarfO72uNxPOg=="
-        }
       }
     },
     "esbuild": {
@@ -49334,6 +49236,24 @@
       "version": "3.2.25",
       "dev": true
     },
+    "esniff": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
+      "integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
+      "requires": {
+        "d": "^1.0.1",
+        "es5-ext": "0.10.63",
+        "event-emitter": "^0.3.5",
+        "type": "^2.7.2"
+      },
+      "dependencies": {
+        "type": {
+          "version": "2.7.3",
+          "resolved": "https://registry.npmjs.org/type/-/type-2.7.3.tgz",
+          "integrity": "sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ=="
+        }
+      }
+    },
     "espree": {
       "version": "9.4.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
@@ -49408,24 +49328,7 @@
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "requires": {
         "d": "1",
-        "es5-ext": "0.10.53"
-      },
-      "dependencies": {
-        "es5-ext": {
-          "version": "0.10.53",
-          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
-          "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
-          "requires": {
-            "es6-iterator": "~2.0.3",
-            "es6-symbol": "~3.1.3",
-            "next-tick": "~1.0.0"
-          }
-        },
-        "next-tick": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-          "integrity": "sha512-mc/caHeUcdjnC/boPWJefDr4KUIWQNv+tlnFnJd38QMou86QtxQzBJfxgGRzvx8jazYRqrVlaHarfO72uNxPOg=="
-        }
+        "es5-ext": "0.10.63"
       }
     },
     "eventemitter3": {
@@ -53673,24 +53576,7 @@
       "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
       "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
       "requires": {
-        "es5-ext": "0.10.53"
-      },
-      "dependencies": {
-        "es5-ext": {
-          "version": "0.10.53",
-          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
-          "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
-          "requires": {
-            "es6-iterator": "~2.0.3",
-            "es6-symbol": "~3.1.3",
-            "next-tick": "~1.0.0"
-          }
-        },
-        "next-tick": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-          "integrity": "sha512-mc/caHeUcdjnC/boPWJefDr4KUIWQNv+tlnFnJd38QMou86QtxQzBJfxgGRzvx8jazYRqrVlaHarfO72uNxPOg=="
-        }
+        "es5-ext": "0.10.63"
       }
     },
     "lz-string": {
@@ -53886,32 +53772,13 @@
       "integrity": "sha512-UBWmJpLZd5STPm7PMUlOw/TSy972M+z8gcyQ5veOnSDRREz/0bmpyTfKt3/51DhEBqCZQn1udM/5flcSPYhkdQ==",
       "requires": {
         "d": "^1.0.1",
-        "es5-ext": "0.10.53",
+        "es5-ext": "0.10.63",
         "es6-weak-map": "^2.0.3",
         "event-emitter": "^0.3.5",
         "is-promise": "^2.2.2",
         "lru-queue": "^0.1.0",
         "next-tick": "^1.1.0",
         "timers-ext": "^0.1.7"
-      },
-      "dependencies": {
-        "es5-ext": {
-          "version": "0.10.53",
-          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
-          "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
-          "requires": {
-            "es6-iterator": "~2.0.3",
-            "es6-symbol": "~3.1.3",
-            "next-tick": "~1.0.0"
-          },
-          "dependencies": {
-            "next-tick": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-              "integrity": "sha512-mc/caHeUcdjnC/boPWJefDr4KUIWQNv+tlnFnJd38QMou86QtxQzBJfxgGRzvx8jazYRqrVlaHarfO72uNxPOg=="
-            }
-          }
-        }
       }
     },
     "memoizerific": {
@@ -53992,14 +53859,12 @@
     "mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
     },
     "mime-types": {
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "requires": {
         "mime-db": "1.52.0"
       }
@@ -55935,8 +55800,7 @@
     "proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "psl": {
       "version": "1.8.0",
@@ -59034,20 +58898,10 @@
       "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.7.tgz",
       "integrity": "sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==",
       "requires": {
-        "es5-ext": "0.10.53",
+        "es5-ext": "0.10.63",
         "next-tick": "1"
       },
       "dependencies": {
-        "es5-ext": {
-          "version": "0.10.53",
-          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
-          "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
-          "requires": {
-            "es6-iterator": "~2.0.3",
-            "es6-symbol": "~3.1.3",
-            "next-tick": "~1.0.0"
-          }
-        },
         "next-tick": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2631,15 +2631,6 @@
         "node": ">=8.3.0"
       }
     },
-    "node_modules/@chromaui/localtunnel/node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "dev": true,
-      "dependencies": {
-        "follow-redirects": "^1.14.0"
-      }
-    },
     "node_modules/@cnakazawa/watch": {
       "version": "1.0.4",
       "dev": true,
@@ -33817,11 +33808,6 @@
         "next-tick": "1"
       }
     },
-    "node_modules/timers-ext/node_modules/next-tick": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-      "integrity": "sha512-mc/caHeUcdjnC/boPWJefDr4KUIWQNv+tlnFnJd38QMou86QtxQzBJfxgGRzvx8jazYRqrVlaHarfO72uNxPOg=="
-    },
     "node_modules/timsort": {
       "version": "0.3.0",
       "dev": true,
@@ -37270,21 +37256,10 @@
       "version": "2.0.4",
       "dev": true,
       "requires": {
-        "axios": "0.21.4",
+        "axios": "^0.28.0",
         "debug": "4.3.1",
         "openurl": "1.1.1",
         "yargs": "16.2.0"
-      },
-      "dependencies": {
-        "axios": {
-          "version": "0.21.4",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-          "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-          "dev": true,
-          "requires": {
-            "follow-redirects": "1.15.6"
-          }
-        }
       }
     },
     "@cnakazawa/watch": {
@@ -58900,13 +58875,6 @@
       "requires": {
         "es5-ext": "0.10.63",
         "next-tick": "1"
-      },
-      "dependencies": {
-        "next-tick": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-          "integrity": "sha512-mc/caHeUcdjnC/boPWJefDr4KUIWQNv+tlnFnJd38QMou86QtxQzBJfxgGRzvx8jazYRqrVlaHarfO72uNxPOg=="
-        }
       }
     },
     "timsort": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
         "@types/react-transition-group": "^4.4.2",
         "@web3-storage/parse-link-header": "^3.1.0",
         "ajv": "^8.10.0",
-        "axios": "^0.21.1",
+        "axios": "^0.28.0",
         "axios-retry": "^3.1.9",
         "azure-iot-dtdl-parser": "^0.0.1-beta.0",
         "constantinople": "^4.0.1",
@@ -176,7 +176,7 @@
     "overrides": {
         "minimist@1.2.5": "1.2.6",
         "follow-redirects": "1.15.6",
-        "es5-ext": "0.10.53"
+        "es5-ext": "0.10.63"
     },
     "author": "",
     "license": "ISC"

--- a/package.json
+++ b/package.json
@@ -176,7 +176,8 @@
     "overrides": {
         "minimist@1.2.5": "1.2.6",
         "follow-redirects": "1.15.6",
-        "es5-ext": "0.10.63"
+        "es5-ext": "0.10.63",
+        "axios": "^0.28.0"
     },
     "author": "",
     "license": "ISC"

--- a/src/Adapters/ADTAdapter.ts
+++ b/src/Adapters/ADTAdapter.ts
@@ -583,7 +583,7 @@ export default class ADTAdapter implements IADTAdapter {
                     return null;
                 }
             });
-            return new ADTModelsData(axiosResult?.data);
+            return new ADTModelsData(axiosResult?.data as unknown as IADTModel[]);
         });
     }
 
@@ -815,7 +815,7 @@ export default class ADTAdapter implements IADTAdapter {
             const recursivelyAddToExpandedModels = async (modelId: string) => {
                 try {
                     // Add root model
-                    const rootModel = (await fetchFullModel(modelId)).data
+                    const rootModel = (await fetchFullModel(modelId)).data.data
                         .model;
                     expandedModels.push(rootModel);
 
@@ -867,7 +867,7 @@ export default class ADTAdapter implements IADTAdapter {
 
             const parallelFetchModel = async (modelId: string) => {
                 try {
-                    const model = (await fetchFullModel(modelId)).data.model;
+                    const model = (await fetchFullModel(modelId)).data.data.model;
                     expandedModels.push(model);
                 } catch (err) {
                     adapterMethodSandbox.pushError({
@@ -948,7 +948,7 @@ export default class ADTAdapter implements IADTAdapter {
                 }
             });
 
-            return new ADTRelationshipData(axiosResponse.data);
+            return new ADTRelationshipData(axiosResponse.data.data);
         });
     }
 

--- a/src/Adapters/ADTAdapter.ts
+++ b/src/Adapters/ADTAdapter.ts
@@ -583,7 +583,9 @@ export default class ADTAdapter implements IADTAdapter {
                     return null;
                 }
             });
-            return new ADTModelsData(axiosResult?.data as unknown as IADTModel[]);
+            return new ADTModelsData(
+                (axiosResult?.data as unknown) as IADTModel[]
+            );
         });
     }
 
@@ -867,7 +869,8 @@ export default class ADTAdapter implements IADTAdapter {
 
             const parallelFetchModel = async (modelId: string) => {
                 try {
-                    const model = (await fetchFullModel(modelId)).data.data.model;
+                    const model = (await fetchFullModel(modelId)).data.data
+                        .model;
                     expandedModels.push(model);
                 } catch (err) {
                     adapterMethodSandbox.pushError({

--- a/src/Adapters/ADXAdapter.ts
+++ b/src/Adapters/ADXAdapter.ts
@@ -84,7 +84,10 @@ export default class ADXAdapter implements IADXAdapter {
                 const adxDataHistoryResults = await getDataHistoryFromADX();
                 const resultTimeSeriesData: Array<ADXTimeSeries> = []; // considering there is going to be multiple series to fetch data for
 
-                if (adxDataHistoryResults.data && adxDataHistoryResults.data.data) {
+                if (
+                    adxDataHistoryResults.data &&
+                    adxDataHistoryResults.data.data
+                ) {
                     const primaryResultTables: Array<ADXTable> = adxDataHistoryResults.data.data.filter(
                         (frame) => frame.TableKind === 'PrimaryResult'
                     );

--- a/src/Adapters/ADXAdapter.ts
+++ b/src/Adapters/ADXAdapter.ts
@@ -85,7 +85,7 @@ export default class ADXAdapter implements IADXAdapter {
                 const resultTimeSeriesData: Array<ADXTimeSeries> = []; // considering there is going to be multiple series to fetch data for
 
                 if (adxDataHistoryResults.data) {
-                    const primaryResultTables: Array<ADXTable> = adxDataHistoryResults.data.filter(
+                    const primaryResultTables: Array<ADXTable> = adxDataHistoryResults.data.data.filter(
                         (frame) => frame.TableKind === 'PrimaryResult'
                     );
                     logDebugConsole(

--- a/src/Adapters/ADXAdapter.ts
+++ b/src/Adapters/ADXAdapter.ts
@@ -84,7 +84,7 @@ export default class ADXAdapter implements IADXAdapter {
                 const adxDataHistoryResults = await getDataHistoryFromADX();
                 const resultTimeSeriesData: Array<ADXTimeSeries> = []; // considering there is going to be multiple series to fetch data for
 
-                if (adxDataHistoryResults.data) {
+                if (adxDataHistoryResults.data && adxDataHistoryResults.data.data) {
                     const primaryResultTables: Array<ADXTable> = adxDataHistoryResults.data.data.filter(
                         (frame) => frame.TableKind === 'PrimaryResult'
                     );

--- a/src/Adapters/BlobAdapter.ts
+++ b/src/Adapters/BlobAdapter.ts
@@ -174,7 +174,7 @@ export default class BlobAdapter implements IBlobAdapter {
                         ),
                         headers: this.generateBlobHeaders(headers)
                     });
-                    if (scenesBlob.data) {
+                    if (scenesBlob.data && scenesBlob.data.data) {
                         config = validate3DConfigWithSchema(
                             scenesBlob.data.data
                         );

--- a/src/Adapters/BlobAdapter.ts
+++ b/src/Adapters/BlobAdapter.ts
@@ -175,7 +175,7 @@ export default class BlobAdapter implements IBlobAdapter {
                         headers: this.generateBlobHeaders(headers)
                     });
                     if (scenesBlob.data) {
-                        config = validate3DConfigWithSchema(scenesBlob.data);
+                        config = validate3DConfigWithSchema(scenesBlob.data.data);
                     } else {
                         throw new Error('Data not found');
                     }
@@ -254,50 +254,50 @@ export default class BlobAdapter implements IBlobAdapter {
      * and accepts an array of file types to be used to filter those files. It parses XML response into JSON and returns adapter data with array of blobs
      */
     async getContainerBlobs(fileTypes: Array<string>) {
-        const adapterMethodSandbox = new AdapterMethodSandbox(
-            this.blobAuthService
-        );
-
-        return await adapterMethodSandbox.safelyFetchData(async (token) => {
-            const headers = {
-                authorization: 'Bearer ' + token,
-                'Content-Type': 'application/json',
-                'x-ms-version': '2017-11-09'
-            };
-            try {
-                const filesData = await axios({
-                    method: 'GET',
-                    url: this.generateBlobUrl(`/${this.containerName}`),
-                    headers: this.generateBlobHeaders(headers),
-                    params: {
-                        restype: 'container',
-                        comp: 'list'
+            const adapterMethodSandbox = new AdapterMethodSandbox(
+                this.blobAuthService
+            );
+    
+            return await adapterMethodSandbox.safelyFetchData(async (token) => {
+                const headers = {
+                    authorization: 'Bearer ' + token,
+                    'Content-Type': 'application/json',
+                    'x-ms-version': '2017-11-09'
+                };
+                try {
+                    const filesData = await axios({
+                        method: 'GET',
+                        url: this.generateBlobUrl(`/${this.containerName}`),
+                        headers: this.generateBlobHeaders(headers),
+                        params: {
+                            restype: 'container',
+                            comp: 'list'
+                        }
+                    });
+                    const filesXML = filesData.data;
+                    const parser = new XMLParser();
+                    let files: Array<IStorageBlob> = parser.parse(filesXML.data)
+                        ?.EnumerationResults?.Blobs?.Blob;
+                    if (fileTypes) {
+                        files = files.filter((f) =>
+                            fileTypes.includes(f.Name?.split('.')?.[1])
+                        );
                     }
-                });
-                const filesXML = filesData.data;
-                const parser = new XMLParser();
-                let files: Array<IStorageBlob> = parser.parse(filesXML)
-                    ?.EnumerationResults?.Blobs?.Blob;
-                if (fileTypes) {
-                    files = files.filter((f) =>
-                        fileTypes.includes(f.Name?.split('.')?.[1])
+                    files.map(
+                        (f) =>
+                            (f.Path = `https://${this.storageAccountHostName}/${this.containerName}/${f.Name}`)
                     );
+    
+                    return new StorageBlobsData(files);
+                } catch (err) {
+                    adapterMethodSandbox.pushError({
+                        type: ComponentErrorType.DataFetchFailed,
+                        isCatastrophic: true,
+                        rawError: err
+                    });
                 }
-                files.map(
-                    (f) =>
-                        (f.Path = `https://${this.storageAccountHostName}/${this.containerName}/${f.Name}`)
-                );
-
-                return new StorageBlobsData(files);
-            } catch (err) {
-                adapterMethodSandbox.pushError({
-                    type: ComponentErrorType.DataFetchFailed,
-                    isCatastrophic: true,
-                    rawError: err
-                });
-            }
-        }, 'storage');
-    }
+            }, 'storage');
+        }
 
     // This method create/update existing blob in the container using Put Blob API (https://docs.microsoft.com/en-us/rest/api/storageservices/put-blob)
     putBlob(file: File) {


### PR DESCRIPTION
Summary of changes 🔍
Build with Axios upgrades with recent Node 18 Migration; to further addresses the Comp Gov with Upgrade axios from 0.21.4 to 0.28.0 to fix the vulnerability.

**Testing** 🧪

- I ran the build locally and in the pipelines to make sure those worked.
           Hitting the localhost consuming local cardboard changes;      
![image](https://github.com/user-attachments/assets/a1406dbe-6892-4014-9c95-55a86fc585f1)

- I ran storybook and it looks like all the styling stuff is still looking good.

**Checklist** ✔️

- [x]  Linked associated issue (if present)
- [x]  Added relevant labels
- [x]  Requested developer reviews
- [x]  Request UI review from design / PM
- [x]  Verify all code checks are passing