### PR TITLE
feat: Bump fast-xml-parser from 4.4.0 to 4.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "eslint-plugin-iot-cardboard-js": "^1.0.8",
         "eslint-plugin-react-hooks": "^4.5.0",
         "fast-json-patch": "^3.0.0-1",
-        "fast-xml-parser": "^4.0.4",
+        "fast-xml-parser": "^4.4.1",
         "highcharts": "^10.2.1",
         "highcharts-react-official": "^3.1.0",
         "i18next": "^19.8.7",
@@ -20251,17 +20251,17 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
-      "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
       "funding": [
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/naturalintelligence"
-        },
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
         }
       ],
       "dependencies": {
@@ -49698,9 +49698,9 @@
       "dev": true
     },
     "fast-xml-parser": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
-      "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
       "requires": {
         "strnum": "^1.0.5"
       }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
         "eslint-plugin-iot-cardboard-js": "^1.0.8",
         "eslint-plugin-react-hooks": "^4.5.0",
         "fast-json-patch": "^3.0.0-1",
-        "fast-xml-parser": "^4.0.4",
+        "fast-xml-parser": "^4.4.1",
         "highcharts": "^10.2.1",
         "highcharts-react-official": "^3.1.0",
         "i18next": "^19.8.7",


### PR DESCRIPTION
### Summary of changes 🔍 
Upgrade fast-xml-parser from 4.4.0 to 4.4.1 to fix the vulnerability.

With Node Version: 18.*

### Testing 🧪
- I ran the build locally and in the pipelines to make sure those worked with upgraded fast-xml-parser.
Hitting the localhost consuming local cardboard changes;

Build: 
![image](https://github.com/user-attachments/assets/1448b46d-99fa-4668-bf86-ad3e041c0aa6)

Running PublicFork with https://explorer.digitaltwins.azure.net/
![image](https://github.com/user-attachments/assets/ff63d5f0-e4a8-43e0-9e20-883be565f7fc)

Build App (3D Scenes):
![image](https://github.com/user-attachments/assets/862c0960-468c-4cd4-969a-df03c0dce8f2)

Running App:
![image](https://github.com/user-attachments/assets/1bc6ecfd-9a82-4f5d-bd8e-87b4a6ee9182)


### Checklist ✔️
- [x] Linked associated issue (if present)
- [x] Added relevant labels
- [x] Requested developer reviews
- [x] Request UI review from design / PM
- [x] Verify all code checks are passing